### PR TITLE
fix(coach): durable FREE-tier quota + tier-aware cache invalidation

### DIFF
--- a/web-app/prisma/migrations/20260501000000_add_user_last_coach_call_at/migration.sql
+++ b/web-app/prisma/migrations/20260501000000_add_user_last_coach_call_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "lastCoachCallAt" TIMESTAMP(3);

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   verificationTokenExpires DateTime?
   role              UserRole         @default(USER)
   subscriptionTier  SubscriptionTier @default(FREE)
+  lastCoachCallAt   DateTime?
   subscriptions     Subscription[]
   categoryRules     CategoryRule[]
 

--- a/web-app/src/app/(app)/coach/page.tsx
+++ b/web-app/src/app/(app)/coach/page.tsx
@@ -7,12 +7,20 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 
+type Tier = 'FREE' | 'PRO' | 'TEAM';
+
+function formatResetDate(d: Date): string {
+  return d.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
 export default function CoachPage() {
   const router = useRouter();
   const [advice, setAdvice] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [tier, setTier] = useState<Tier | null>(null);
+  const [nextResetAt, setNextResetAt] = useState<Date | null>(null);
   const adviceRef = useRef('');
 
   useEffect(() => {
@@ -44,6 +52,18 @@ export default function CoachPage() {
         return;
       }
 
+      // 429 = FREE tier already used their monthly call. Show next-reset copy.
+      if (res.status === 429) {
+        const data = await res.json().catch(() => ({}));
+        if (data.tier) setTier(data.tier as Tier);
+        if (data.nextResetAt) setNextResetAt(new Date(data.nextResetAt));
+        const reset = data.nextResetAt ? formatResetDate(new Date(data.nextResetAt)) : 'next month';
+        setError(`You've used your AI Coach call for this month. Next refresh on ${reset}.`);
+        setIsLoading(false);
+        setHasLoaded(true);
+        return;
+      }
+
       if (!res.ok || !res.body) {
         setError('Failed to get advice. Please try again.');
         setIsLoading(false);
@@ -55,6 +75,8 @@ export default function CoachPage() {
       // JSON response — cached advice, zero-activity empty state, or probe hit.
       if (contentType.includes('application/json')) {
         const data = await res.json();
+        if (data.tier) setTier(data.tier as Tier);
+        if (data.nextResetAt) setNextResetAt(new Date(data.nextResetAt));
         if (data.error) {
           setError(data.error);
         } else if (typeof data.advice === 'string') {
@@ -119,8 +141,8 @@ export default function CoachPage() {
   // On mount, probe the cache only. If cached or zero-activity, render instantly.
   // Otherwise the user clicks "Generate advice" to burn a Claude call explicitly.
   useEffect(() => {
-    fetchAdvice(true); // eslint-disable-line react-hooks/set-state-in-effect
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchAdvice(true);
   }, []);
 
   return (
@@ -173,13 +195,28 @@ export default function CoachPage() {
           )}
         </Card>
 
-        {hasLoaded && advice && (
-          <div className="mt-4 flex justify-end">
-            <Button variant="secondary" size="sm" onClick={() => fetchAdvice(false)}>
-              Refresh Advice
-            </Button>
-          </div>
-        )}
+        {hasLoaded && advice && (() => {
+          const freeUsedUp = tier === 'FREE';
+          const resetCopy = nextResetAt ? formatResetDate(nextResetAt) : null;
+          return (
+            <div className="mt-4 flex items-center justify-end gap-3">
+              {freeUsedUp && resetCopy && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  Free plan: next refresh on {resetCopy}
+                </span>
+              )}
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={freeUsedUp}
+                onClick={() => fetchAdvice(false)}
+                title={freeUsedUp ? 'You get one call per calendar month on the Free plan.' : undefined}
+              >
+                Refresh Advice
+              </Button>
+            </div>
+          );
+        })()}
 
         {/* Teams Section */}
         <TeamsSection />

--- a/web-app/src/app/api/activity/recategorize/route.ts
+++ b/web-app/src/app/api/activity/recategorize/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { normalizeCategory, CATEGORIES } from '@/app/api/categories/route';
+import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 
 /**
  * POST /api/activity/recategorize
@@ -59,6 +60,9 @@ export async function POST(request: NextRequest) {
         data: { category: newCategory },
       });
 
+      // Recategorization changes coach context; bust paid-tier cache.
+      await bustCoachCacheIfPaid(userId);
+
       return NextResponse.json({
         message: 'Category corrected',
         updatedCount: updated.count + 1,
@@ -85,6 +89,8 @@ export async function POST(request: NextRequest) {
         },
         data: { category: newCategory },
       });
+
+      await bustCoachCacheIfPaid(userId);
 
       return NextResponse.json({
         message: 'Category corrected for application',
@@ -134,6 +140,8 @@ export async function POST(request: NextRequest) {
           updatedCount++;
         }
       }
+
+      await bustCoachCacheIfPaid(userId);
 
       return NextResponse.json({
         message: 'Bulk recategorization complete',

--- a/web-app/src/app/api/coach/advice/route.ts
+++ b/web-app/src/app/api/coach/advice/route.ts
@@ -5,21 +5,12 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken, getJwtSecret } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { redis } from '@/lib/redis';
-
-const ADVICE_CACHE_TTL_DAILY_SECONDS = 24 * 60 * 60;        // 24h — paid tiers
-const ADVICE_CACHE_TTL_MONTHLY_SECONDS = 31 * 24 * 60 * 60; // 31d — FREE tier (1 gen/month)
-
-function coachCacheKey(userId: string, tier: string): string {
-  const iso = new Date().toISOString();
-  // FREE users key by calendar month (YYYY-MM) so the entry only rolls over
-  // on the 1st. Paid tiers key by day (YYYY-MM-DD) for the existing 24h cache.
-  const dateKey = tier === 'FREE' ? iso.slice(0, 7) : iso.slice(0, 10);
-  return `coach:${userId}:${dateKey}`;
-}
-
-function cacheTtlFor(tier: string): number {
-  return tier === 'FREE' ? ADVICE_CACHE_TTL_MONTHLY_SECONDS : ADVICE_CACHE_TTL_DAILY_SECONDS;
-}
+import {
+  coachCacheKey,
+  coachCacheTtl,
+  freeTierCanCall,
+  nextFreeTierResetAt,
+} from '@/lib/coach-quota';
 
 // EventSource cannot set Authorization headers, so the client can pass the JWT
 // as ?token=... on this SSE endpoint. Fall back to that when the header is absent.
@@ -36,8 +27,6 @@ function getUserIdFromRequestOrQuery(request: NextRequest): string | null {
   }
 }
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_API_KEY || '');
-
 async function readCache(userId: string, tier: string): Promise<string | null> {
   try {
     const cached = await redis.get<string>(coachCacheKey(userId, tier));
@@ -50,7 +39,7 @@ async function readCache(userId: string, tier: string): Promise<string | null> {
 
 async function writeCache(userId: string, tier: string, text: string): Promise<void> {
   try {
-    await redis.setex(coachCacheKey(userId, tier), cacheTtlFor(tier), text);
+    await redis.setex(coachCacheKey(userId, tier), coachCacheTtl(tier), text);
   } catch (err) {
     logger.warn('Coach cache write failed', err);
   }
@@ -60,15 +49,26 @@ async function writeCache(userId: string, tier: string, text: string): Promise<v
  * GET /api/coach/advice
  *   - `?cacheOnly=1` → fast JSON probe. Returns cached advice (200) or 204 on miss.
  *   - Zero activity in last 7 days → JSON empty-state message, no Gemini call.
- *   - Cache hit → JSON cached advice.
- *   - Otherwise → SSE stream from Gemini, cached to Redis on completion.
+ *   - Cache hit → JSON cached advice (does NOT consume FREE quota).
+ *   - FREE tier already used this month + cache miss → 429 with `nextResetAt`.
+ *   - Otherwise → SSE stream from Gemini, cached + lastCoachCallAt stamped on completion.
  *
- * Rate limiting via cache granularity:
- *   - FREE tier: cached for 31 days under month key (1 generation per calendar month)
- *   - PRO / TEAM: cached for 24h under day key (existing behavior)
+ * Quota for FREE tier is durable: enforced via `User.lastCoachCallAt` in the
+ * database, so a Redis outage cannot grant unlimited calls. Cache is purely a
+ * perf layer.
  */
 export async function GET(request: NextRequest) {
   try {
+    // Fail fast and visibly when the API key isn't configured rather than
+    // surfacing the failure as an error inside an opened SSE stream.
+    if (!process.env.GOOGLE_AI_API_KEY) {
+      logger.error('Coach disabled: GOOGLE_AI_API_KEY is not set');
+      return new Response(
+        JSON.stringify({ error: 'AI Coach is not configured' }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
     const userId = getUserIdFromRequestOrQuery(request);
 
     if (!userId) {
@@ -81,10 +81,14 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const cacheOnly = url.searchParams.get('cacheOnly') === '1';
 
-    // Fetch user first — tier determines the cache key (monthly for FREE, daily for paid).
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: { name: true, subscriptionTier: true, preferences: true },
+      select: {
+        name: true,
+        subscriptionTier: true,
+        lastCoachCallAt: true,
+        preferences: true,
+      },
     });
 
     if (!user) {
@@ -95,15 +99,40 @@ export async function GET(request: NextRequest) {
     }
 
     const tier = user.subscriptionTier ?? 'FREE';
+    const isFree = tier === 'FREE';
+    const nextResetAt = nextFreeTierResetAt();
 
-    // Serve from cache when available (tier-aware key + TTL)
+    // Cache hit — serve immediately. For FREE this does NOT consume their
+    // monthly call (quota is already recorded by the original generation
+    // that populated the cache).
     const cached = await readCache(userId, tier);
     if (cached) {
-      return new Response(JSON.stringify({ advice: cached, cached: true, tier }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          advice: cached,
+          cached: true,
+          tier,
+          ...(isFree && { nextResetAt: nextResetAt.toISOString() }),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
     }
+
+    // Durable FREE-tier quota check (DB column). If they've already called this
+    // calendar month and the cache missed (e.g. Redis flush, cache eviction, or
+    // outage), refuse the call cleanly with the next reset time.
+    if (isFree && !freeTierCanCall(user.lastCoachCallAt)) {
+      return new Response(
+        JSON.stringify({
+          error: 'Monthly limit reached',
+          code: 'FREE_TIER_LIMIT',
+          tier,
+          nextResetAt: nextResetAt.toISOString(),
+        }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
     if (cacheOnly) {
       return new Response(null, { status: 204 });
     }
@@ -134,13 +163,19 @@ export async function GET(request: NextRequest) {
       .reduce((sum, s) => sum + (s.actualDuration || 0), 0);
     const completedSessions = sessions.filter(s => s.completed).length;
 
-    // Zero-activity short-circuit — no Gemini call, no cache write
+    // Zero-activity short-circuit — no Gemini call, no cache write, no quota consumed
     if (totalFocusMinutes === 0 && completedSessions === 0) {
       const advice = 'Start a focus session to unlock personalized advice. Flow gets smarter with every session you complete.';
-      return new Response(JSON.stringify({ advice, cached: false, empty: true, tier }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          advice,
+          cached: false,
+          empty: true,
+          tier,
+          ...(isFree && { nextResetAt: nextResetAt.toISOString() }),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     // Summarize activity by category
@@ -187,12 +222,17 @@ Keep your response to 150–250 words. Do not include a greeting like "Hi [name]
 
 Based on this data, give ${userName} 2–3 specific, actionable coaching tips to improve their productivity this week. Reference their actual numbers.`;
 
-    // Stream Gemini's response as SSE + accumulate for cache write
+    // Stream Gemini's response as SSE + accumulate for cache write.
+    // We persist to cache + stamp lastCoachCallAt ONLY on a clean stream
+    // completion, never on a mid-stream error — partial advice would burn
+    // the FREE user's monthly call without giving them usable text.
+    const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_API_KEY);
     const encoder = new TextEncoder();
     let fullText = '';
 
     const stream = new ReadableStream({
       async start(controller) {
+        let streamErrored = false;
         try {
           const model = genAI.getGenerativeModel({
             model: 'gemini-2.5-flash-lite',
@@ -213,19 +253,30 @@ Based on this data, give ${userName} 2–3 specific, actionable coaching tips to
               controller.enqueue(encoder.encode(`data: ${data}\n\n`));
             }
           }
-
-          if (fullText.length > 0) {
-            await writeCache(userId, tier, fullText);
-          }
-
-          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
-          controller.close();
         } catch (err) {
+          streamErrored = true;
           logger.error('Coach stream error:', err);
           const errData = JSON.stringify({ error: 'Stream failed' });
           controller.enqueue(encoder.encode(`data: ${errData}\n\n`));
           controller.close();
+          return;
         }
+
+        // Clean completion only: persist cache + stamp quota.
+        if (!streamErrored && fullText.length > 0) {
+          await writeCache(userId, tier, fullText);
+          try {
+            await prisma.user.update({
+              where: { id: userId },
+              data: { lastCoachCallAt: new Date() },
+            });
+          } catch (err) {
+            logger.warn('Failed to record coach call timestamp', err);
+          }
+        }
+
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
       },
     });
 

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   sessionFindUnique: vi.fn(),
   sessionUpdate: vi.fn(),
   dailyStatsUpsert: vi.fn(async () => ({})),
-  redisDel: vi.fn(async () => 1),
+  bustCoachCacheIfPaid: vi.fn(async () => undefined),
   triggerUserEvent: vi.fn(),
   sendSessionEndPush: vi.fn(async () => 1),
 }));
@@ -31,15 +31,15 @@ vi.mock('@/lib/pusher', () => ({
   triggerUserEvent: mocks.triggerUserEvent,
 }));
 
-vi.mock('@/lib/redis', () => ({
-  redis: { del: mocks.redisDel },
+vi.mock('@/lib/coach-quota', () => ({
+  bustCoachCacheIfPaid: mocks.bustCoachCacheIfPaid,
 }));
 
 vi.mock('@/lib/pushNotify', () => ({
   sendSessionEndPush: mocks.sendSessionEndPush,
 }));
 
-const { sessionFindUnique, sessionUpdate, triggerUserEvent, redisDel, sendSessionEndPush } = mocks;
+const { sessionFindUnique, sessionUpdate, triggerUserEvent, bustCoachCacheIfPaid, sendSessionEndPush } = mocks;
 
 import { POST } from './route';
 
@@ -113,7 +113,7 @@ describe('POST /api/sessions/[id]/auto-end', () => {
       })
     );
     expect(triggerUserEvent).toHaveBeenCalledWith('user-1', 'session-update');
-    expect(redisDel).toHaveBeenCalled();
+    expect(bustCoachCacheIfPaid).toHaveBeenCalledWith('user-1');
     expect(sendSessionEndPush).toHaveBeenCalledWith('user-1', 's-3', 25);
   });
 

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
-import { redis } from '@/lib/redis';
+import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 import { sendSessionEndPush } from '@/lib/pushNotify';
 import { classifySessionProject } from '@/lib/project-classifier';
 
@@ -100,13 +100,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     triggerUserEvent(userId, 'session-update');
 
-    // Bust coach cache so next /coach visit reflects the new completion
-    try {
-      const dateKey = new Date().toISOString().slice(0, 10);
-      await redis.del(`coach:${userId}:${dateKey}`);
-    } catch (err) {
-      logger.warn('Coach cache bust failed after auto-end', err);
-    }
+    // Bust coach cache for paid tiers; FREE quota is durable via DB column.
+    await bustCoachCacheIfPaid(userId);
 
     // Fire a push notification so a closed tab still gets notified
     sendSessionEndPush(userId, id, session.plannedDuration).catch((err) => {

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
-import { redis } from '@/lib/redis';
+import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 import { classifySessionProject } from '@/lib/project-classifier';
 
 type RouteContext = {
@@ -118,14 +118,11 @@ export async function PATCH(
 
     triggerUserEvent(userId, 'session-update');
 
-    // Bust the AI Coach cache so fresh advice reflects this session
+    // Bust the AI Coach cache for paid tiers so their next visit gets fresh
+    // advice that reflects this session. FREE users are intentionally NOT
+    // busted — their monthly quota is gated by `User.lastCoachCallAt`.
     if (completed) {
-      try {
-        const dateKey = new Date().toISOString().slice(0, 10);
-        await redis.del(`coach:${userId}:${dateKey}`);
-      } catch (err) {
-        logger.warn('Coach cache bust failed after session PATCH', err);
-      }
+      await bustCoachCacheIfPaid(userId);
     }
 
     return NextResponse.json({ session: updatedSession });

--- a/web-app/src/app/api/user/preferences/route.ts
+++ b/web-app/src/app/api/user/preferences/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { UpdatePreferencesSchema } from '@/lib/schemas';
+import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 
 export async function GET(request: NextRequest) {
   try {
@@ -61,6 +62,10 @@ export async function PATCH(request: NextRequest) {
       update: updates,
       create: { userId, ...updates },
     });
+
+    // Preference changes (e.g. preferredDuration) feed into coach prompts;
+    // bust paid-tier cache so next visit reflects the new preferences.
+    await bustCoachCacheIfPaid(userId);
 
     return NextResponse.json({
       message: 'Preferences updated successfully',

--- a/web-app/src/lib/coach-quota.test.ts
+++ b/web-app/src/lib/coach-quota.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPaidTier,
+  isSameCalendarMonthUTC,
+  freeTierCanCall,
+  nextFreeTierResetAt,
+  coachCacheKey,
+  coachCacheTtl,
+} from './coach-quota';
+
+// ─── isPaidTier ──────────────────────────────────────────────────────────────
+
+describe('isPaidTier', () => {
+  it('treats PRO and TEAM as paid', () => {
+    expect(isPaidTier('PRO')).toBe(true);
+    expect(isPaidTier('TEAM')).toBe(true);
+  });
+
+  it('treats FREE, null, undefined, and unknown strings as not paid', () => {
+    expect(isPaidTier('FREE')).toBe(false);
+    expect(isPaidTier(null)).toBe(false);
+    expect(isPaidTier(undefined)).toBe(false);
+    expect(isPaidTier('UNKNOWN')).toBe(false);
+  });
+});
+
+// ─── isSameCalendarMonthUTC ──────────────────────────────────────────────────
+
+describe('isSameCalendarMonthUTC', () => {
+  it('is true for two dates in the same UTC month', () => {
+    expect(
+      isSameCalendarMonthUTC(new Date('2026-05-01T00:00:00Z'), new Date('2026-05-31T23:59:59Z'))
+    ).toBe(true);
+  });
+
+  it('is false across a month boundary', () => {
+    expect(
+      isSameCalendarMonthUTC(new Date('2026-05-31T23:59:59Z'), new Date('2026-06-01T00:00:00Z'))
+    ).toBe(false);
+  });
+
+  it('is false across a year boundary', () => {
+    expect(
+      isSameCalendarMonthUTC(new Date('2026-12-31T23:59:59Z'), new Date('2027-01-01T00:00:00Z'))
+    ).toBe(false);
+  });
+});
+
+// ─── freeTierCanCall ─────────────────────────────────────────────────────────
+
+describe('freeTierCanCall', () => {
+  it('allows the call when there is no prior call recorded', () => {
+    expect(freeTierCanCall(null)).toBe(true);
+    expect(freeTierCanCall(undefined)).toBe(true);
+  });
+
+  it('blocks when a call was made earlier this calendar month', () => {
+    const now = new Date('2026-05-15T10:00:00Z');
+    const earlierThisMonth = new Date('2026-05-01T00:00:00Z');
+    expect(freeTierCanCall(earlierThisMonth, now)).toBe(false);
+  });
+
+  it('blocks even on the same instant', () => {
+    const t = new Date('2026-05-10T12:00:00Z');
+    expect(freeTierCanCall(t, t)).toBe(false);
+  });
+
+  it('allows when last call was last month', () => {
+    const now = new Date('2026-05-01T00:00:00Z');
+    const lastMonth = new Date('2026-04-30T23:59:59Z');
+    expect(freeTierCanCall(lastMonth, now)).toBe(true);
+  });
+
+  it('allows across year rollover', () => {
+    const now = new Date('2027-01-01T00:00:00Z');
+    const lastYear = new Date('2026-12-31T23:00:00Z');
+    expect(freeTierCanCall(lastYear, now)).toBe(true);
+  });
+});
+
+// ─── nextFreeTierResetAt ─────────────────────────────────────────────────────
+
+describe('nextFreeTierResetAt', () => {
+  it('returns the first instant of next month, UTC', () => {
+    const now = new Date('2026-05-15T10:30:00Z');
+    const next = nextFreeTierResetAt(now);
+    expect(next.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('rolls year correctly in December', () => {
+    const now = new Date('2026-12-25T00:00:00Z');
+    const next = nextFreeTierResetAt(now);
+    expect(next.toISOString()).toBe('2027-01-01T00:00:00.000Z');
+  });
+});
+
+// ─── coachCacheKey ───────────────────────────────────────────────────────────
+
+describe('coachCacheKey', () => {
+  it('uses month granularity (YYYY-MM) for FREE tier', () => {
+    const now = new Date('2026-05-15T10:00:00Z');
+    expect(coachCacheKey('user-1', 'FREE', now)).toBe('coach:user-1:2026-05');
+  });
+
+  it('uses day granularity (YYYY-MM-DD) for paid tiers', () => {
+    const now = new Date('2026-05-15T10:00:00Z');
+    expect(coachCacheKey('user-1', 'PRO', now)).toBe('coach:user-1:2026-05-15');
+    expect(coachCacheKey('user-1', 'TEAM', now)).toBe('coach:user-1:2026-05-15');
+  });
+
+  it('rolls FREE key on the 1st of each month', () => {
+    const apr30 = new Date('2026-04-30T23:59:59Z');
+    const may1 = new Date('2026-05-01T00:00:00Z');
+    expect(coachCacheKey('u', 'FREE', apr30)).toBe('coach:u:2026-04');
+    expect(coachCacheKey('u', 'FREE', may1)).toBe('coach:u:2026-05');
+  });
+});
+
+// ─── coachCacheTtl ───────────────────────────────────────────────────────────
+
+describe('coachCacheTtl', () => {
+  it('FREE is 31 days', () => {
+    expect(coachCacheTtl('FREE')).toBe(31 * 24 * 60 * 60);
+  });
+
+  it('paid tiers are 24 hours', () => {
+    expect(coachCacheTtl('PRO')).toBe(24 * 60 * 60);
+    expect(coachCacheTtl('TEAM')).toBe(24 * 60 * 60);
+  });
+
+  it('unknown tier defaults to daily (paid) TTL', () => {
+    expect(coachCacheTtl('SOMETHING_NEW')).toBe(24 * 60 * 60);
+  });
+});

--- a/web-app/src/lib/coach-quota.ts
+++ b/web-app/src/lib/coach-quota.ts
@@ -1,0 +1,62 @@
+import { prisma } from '@/lib/prisma';
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
+
+const ADVICE_CACHE_TTL_DAILY_SECONDS = 24 * 60 * 60;
+const ADVICE_CACHE_TTL_MONTHLY_SECONDS = 31 * 24 * 60 * 60;
+
+export function isPaidTier(tier: string | null | undefined): boolean {
+  return tier === 'PRO' || tier === 'TEAM';
+}
+
+export function isSameCalendarMonthUTC(a: Date, b: Date): boolean {
+  return a.getUTCFullYear() === b.getUTCFullYear() && a.getUTCMonth() === b.getUTCMonth();
+}
+
+// FREE tier is allowed one Gemini coach call per calendar month. The DB column
+// `User.lastCoachCallAt` is the durable source of truth so the quota survives
+// Redis outages (cache is just a perf layer).
+export function freeTierCanCall(
+  lastCoachCallAt: Date | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!lastCoachCallAt) return true;
+  return !isSameCalendarMonthUTC(lastCoachCallAt, now);
+}
+
+// First moment of the next calendar month, UTC. Shown to FREE users so they
+// know exactly when their next call unlocks.
+export function nextFreeTierResetAt(now: Date = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+}
+
+export function coachCacheKey(userId: string, tier: string, now: Date = new Date()): string {
+  const iso = now.toISOString();
+  // FREE: monthly key (YYYY-MM) — rolls on the 1st alongside the DB quota.
+  // Paid: daily key (YYYY-MM-DD) — busts whenever activity changes.
+  const dateKey = tier === 'FREE' ? iso.slice(0, 7) : iso.slice(0, 10);
+  return `coach:${userId}:${dateKey}`;
+}
+
+export function coachCacheTtl(tier: string): number {
+  return tier === 'FREE' ? ADVICE_CACHE_TTL_MONTHLY_SECONDS : ADVICE_CACHE_TTL_DAILY_SECONDS;
+}
+
+// Invalidate the coach cache for paid users so fresh advice reflects their
+// latest activity. FREE users are intentionally NOT busted: their monthly
+// cache key carries the quota signal alongside the durable lastCoachCallAt
+// column, and we don't want their own activity to "use up" their advice early.
+export async function bustCoachCacheIfPaid(userId: string): Promise<void> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { subscriptionTier: true },
+    });
+    if (!user) return;
+    const tier = user.subscriptionTier ?? 'FREE';
+    if (!isPaidTier(tier)) return;
+    await redis.del(coachCacheKey(userId, tier));
+  } catch (err) {
+    logger.warn('Coach cache bust failed', err);
+  }
+}


### PR DESCRIPTION
Closes #4

## Summary
Commit 8fc8710 introduced a FREE-tier "1 coach call per calendar month" limit, but it was enforced only via Redis cache TTL (fail-open if Redis down) and the monthly cache key was never invalidated by user activity, leading to stale advice all month. UI gave no signal of the limit. This PR fixes all three issues.

## Backend changes
- **`User.lastCoachCallAt`** (new column, nullable) — DB is now the durable source of truth for FREE quota; quota survives Redis outages.
- **`/api/coach/advice`**:
  - Returns 503 immediately if `GOOGLE_AI_API_KEY` is missing, instead of surfacing it as an error inside an opened SSE stream
  - Checks the durable quota and returns **429 + `{ nextResetAt }`** for FREE-tier overages
  - Stamps `lastCoachCallAt` only on clean stream completion — no partial advice gets persisted (which would burn the FREE call without giving the user usable text)
  - Returns `tier` + `nextResetAt` in JSON responses
- **`bustCoachCacheIfPaid(userId)`** new helper — used by sessions PATCH, auto-end, activity recategorize, and user preferences PATCH. FREE keys are intentionally NOT busted: quota lives in DB, and we don't want a user's own activity to "use up" their advice early.
- Activity recategorize and preferences PATCH now also invalidate paid-tier coach cache (previously only session writes did).

## UI changes
- Coach page reads `tier` and `nextResetAt` from API responses (and from 429s).
- FREE users with cached advice: **Refresh Advice button disabled** with copy "Free plan: next refresh on <date>".
- 429 path shows clean "You've used your AI Coach call for this month. Next refresh on <date>." instead of generic "Failed to get advice".

## Tests
- 18 new unit tests in `src/lib/coach-quota.test.ts` covering calendar-month rollover, key formats, TTLs, paid-tier detection, year boundaries.
- Updated `auto-end/route.test.ts` to mock `bustCoachCacheIfPaid` instead of `redis.del` directly.
- All 186 Vitest tests pass; lint clean (0 errors); `npm run build` succeeds.

## Migration
Adds nullable `lastCoachCallAt` column to `users`. Safe — no backfill needed; existing users are treated as "never called" until they make their first call.

> Note: `web-app/.gitignore` has `prisma/migrations` listed, but other migrations have been force-added historically. Used `git add -f` here too. Worth fixing the gitignore in a follow-up.

## Test plan
- [ ] FREE user generates advice → cache populated, `lastCoachCallAt` set
- [ ] FREE user revisits same day → cache hit, button disabled, "next refresh" copy shown
- [ ] FREE user with cleared Redis revisits → 429 with `nextResetAt` (durable quota holds)
- [ ] FREE user on the 1st of next month → can call again
- [ ] PRO user completes session → cache busted; revisit gets fresh advice
- [ ] FREE user completes session → cache **not** busted (their monthly window stays intact)
- [ ] Missing `GOOGLE_AI_API_KEY` → 503 with clean error, not SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)