### PR TITLE
fix(auth): password reset + email-verified login gate

### DIFF
--- a/desktop-app/Interfaces/IApiClient.cs
+++ b/desktop-app/Interfaces/IApiClient.cs
@@ -31,5 +31,14 @@ public interface IApiClient
     Task<bool> RegisterDeviceAsync();
     void Logout();
 
+    /// <summary>
+    /// API error code from the most recent failed <see cref="LoginAsync"/>.
+    /// E.g. "EMAIL_NOT_VERIFIED". Null on success.
+    /// </summary>
+    string? LastLoginErrorCode { get; }
+
+    /// <summary>Human-readable message from the most recent failed login.</summary>
+    string? LastLoginErrorMessage { get; }
+
     event EventHandler? SessionExpired;
 }

--- a/desktop-app/Services/ApiClient.cs
+++ b/desktop-app/Services/ApiClient.cs
@@ -20,6 +20,16 @@ namespace FlowShield.Desktop.Services
         public event EventHandler? SessionExpired;
         private string? _authToken;
 
+        /// <summary>
+        /// Reason the most recent <see cref="LoginAsync"/> call failed, when
+        /// the API returned a structured error. Null on success or transport
+        /// failures. Useful values: "EMAIL_NOT_VERIFIED", "INVALID_CREDENTIALS".
+        /// </summary>
+        public string? LastLoginErrorCode { get; private set; }
+
+        /// <summary>Human-readable message from the most recent failed login.</summary>
+        public string? LastLoginErrorMessage { get; private set; }
+
         public ApiClient(IDatabaseService dbService, string? baseUrl = null)
         {
             _dbService = dbService;
@@ -54,6 +64,9 @@ namespace FlowShield.Desktop.Services
 
         public async Task<bool> LoginAsync(string email, string password, bool rememberMe)
         {
+            LastLoginErrorCode = null;
+            LastLoginErrorMessage = null;
+
             try
             {
                 var loginData = new { email, password, rememberMe };
@@ -75,12 +88,26 @@ namespace FlowShield.Desktop.Services
                         // Save credentials
                         _dbService.SaveSetting("AuthToken", _authToken);
                         _dbService.SaveSetting("UserId", result.UserId ?? string.Empty);
-                        
+
                         // Save email for pre-filling next time
                         _dbService.SaveSetting("UserEmail", email);
 
                         return true;
                     }
+                }
+
+                // Parse structured error so callers can show specific copy
+                // (e.g. "Please verify your email") instead of generic "Login failed".
+                try
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync();
+                    var err = JsonConvert.DeserializeObject<LoginErrorResponse>(errorBody);
+                    LastLoginErrorCode = err?.Code;
+                    LastLoginErrorMessage = err?.Error;
+                }
+                catch
+                {
+                    // ignore parse failures — caller falls back to generic error
                 }
 
                 return false;
@@ -89,6 +116,12 @@ namespace FlowShield.Desktop.Services
             {
                 return false;
             }
+        }
+
+        private class LoginErrorResponse
+        {
+            [JsonProperty("error")] public string? Error { get; set; }
+            [JsonProperty("code")] public string? Code { get; set; }
         }
 
         public async Task<bool> SyncActivitiesAsync()

--- a/mobile-app/src/lib/api.ts
+++ b/mobile-app/src/lib/api.ts
@@ -12,6 +12,19 @@ export interface User {
   name: string | null;
 }
 
+/**
+ * Auth-flow error that preserves the API's error `code` (e.g. EMAIL_NOT_VERIFIED)
+ * so screens can show specific copy / CTAs without parsing the message string.
+ */
+export class AuthError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = 'AuthError';
+    this.code = code;
+  }
+}
+
 export interface Session {
   id: string;
   startTime: string;
@@ -95,7 +108,9 @@ export const api = {
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || 'Login failed');
+      // Preserve API error code (e.g. EMAIL_NOT_VERIFIED) so callers can
+      // surface a specific CTA like "Resend verification email".
+      throw new AuthError(data.error || 'Login failed', data.code);
     }
     const data = await res.json();
     await setToken(data.token);

--- a/web-app/prisma/migrations/20260501010000_add_password_reset_fields/migration.sql
+++ b/web-app/prisma/migrations/20260501010000_add_password_reset_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "passwordResetToken" TEXT,
+ADD COLUMN "passwordResetExpires" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_passwordResetToken_key" ON "users"("passwordResetToken");

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -26,6 +26,8 @@ model User {
   emailVerified     DateTime?
   verificationToken String?          @unique
   verificationTokenExpires DateTime?
+  passwordResetToken   String?       @unique
+  passwordResetExpires DateTime?
   role              UserRole         @default(USER)
   subscriptionTier  SubscriptionTier @default(FREE)
   lastCoachCallAt   DateTime?

--- a/web-app/src/app/api/auth/forgot-password/route.test.ts
+++ b/web-app/src/app/api/auth/forgot-password/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  update: vi.fn(async () => ({})),
+  sendEmail: vi.fn(async () => true),
+  rateLimit: vi.fn(() => ({ allowed: true, resetInMs: 0 })),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { findUnique: mocks.findUnique, update: mocks.update } },
+}));
+
+vi.mock('@/lib/email', () => ({ sendEmail: mocks.sendEmail }));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: mocks.rateLimit,
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/auth/forgot-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/auth/forgot-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimit.mockReturnValue({ allowed: true, resetInMs: 0 });
+  });
+
+  it('returns 200 with generic message even when email does not exist', async () => {
+    mocks.findUnique.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ email: 'nobody@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('generates a token and sends the reset email when user exists with a password', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'u-1',
+      email: 'user@example.com',
+      hashedPassword: 'bcrypt-hash',
+      name: 'Asif',
+    });
+    const res = await POST(makeRequest({ email: 'user@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u-1' },
+        data: expect.objectContaining({
+          passwordResetToken: expect.any(String),
+          passwordResetExpires: expect.any(Date),
+        }),
+      })
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        subject: expect.stringContaining('Reset'),
+      })
+    );
+  });
+
+  it('does NOT send email for Google-only users (empty hashedPassword)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'u-2',
+      email: 'google@example.com',
+      hashedPassword: '',
+      name: null,
+    });
+    const res = await POST(makeRequest({ email: 'google@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed email payload', async () => {
+    const res = await POST(makeRequest({ email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    mocks.rateLimit.mockReturnValueOnce({ allowed: false, resetInMs: 5000 });
+    const res = await POST(makeRequest({ email: 'user@example.com' }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/web-app/src/app/api/auth/forgot-password/route.ts
+++ b/web-app/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { rateLimit, getClientIp } from '@/lib/rate-limit';
+import { ForgotPasswordSchema } from '@/lib/schemas';
+import { sendEmail } from '@/lib/email';
+
+const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * POST /api/auth/forgot-password
+ *
+ * Always returns 200 with a generic message — do not reveal whether the email
+ * exists. The reset email is only actually sent for accounts that exist and
+ * have a password (i.e. were not Google-only).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const ip = getClientIp(request);
+    const rl = rateLimit(`forgot-password:${ip}`, 3, 60 * 60 * 1000);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many password-reset requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(rl.resetInMs / 1000)) } }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parsed = ForgotPasswordSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+    const { email } = parsed.data;
+
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, hashedPassword: true, name: true },
+    });
+
+    // Only generate + send a reset link for accounts that have a password.
+    // Empty hashedPassword => Google-only user; reset would not unlock anything.
+    if (user && user.hashedPassword) {
+      const passwordResetToken = crypto.randomBytes(32).toString('hex');
+      const passwordResetExpires = new Date(Date.now() + RESET_TOKEN_TTL_MS);
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { passwordResetToken, passwordResetExpires },
+      });
+
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const resetUrl = `${appUrl}/auth/reset-password?token=${passwordResetToken}`;
+      const greeting = user.name ? user.name.split(' ')[0] : 'there';
+
+      await sendEmail({
+        to: user.email,
+        subject: 'Reset your FlowShield password',
+        html: `
+          <p>Hi ${greeting},</p>
+          <p>Someone (hopefully you) requested a password reset for your FlowShield account. Click the link below to set a new password:</p>
+          <p><a href="${resetUrl}">${resetUrl}</a></p>
+          <p>This link will expire in 1 hour. If you didn't request this, you can safely ignore the email — your password won't change.</p>
+        `,
+      });
+    }
+
+    // Same response for both branches — don't leak whether the email is registered.
+    return NextResponse.json({
+      message: 'If an account exists for that email, a reset link has been sent.',
+    });
+  } catch (error) {
+    logger.error('Forgot-password error', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web-app/src/app/api/auth/login/route.test.ts
+++ b/web-app/src/app/api/auth/login/route.test.ts
@@ -3,8 +3,21 @@ import { decode } from 'jsonwebtoken';
 
 process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
 
+// Explicit return type so emailVerified is `Date | null` (allowing tests to
+// override with `null` for the unverified-user gate); without this, TS infers
+// the narrow `Date` from the initial value and `mockResolvedValueOnce({...,
+// emailVerified: null})` fails strict typecheck.
+type MockUser = {
+  id: string;
+  email: string;
+  role: string;
+  hashedPassword: string;
+  emailVerified: Date | null;
+  preferences: { workStyle?: string } | null;
+};
+
 const mocks = vi.hoisted(() => ({
-  findUnique: vi.fn(async () => ({
+  findUnique: vi.fn<() => Promise<MockUser>>(async () => ({
     id: 'user-1',
     email: 'user@example.com',
     role: 'USER',

--- a/web-app/src/app/api/auth/login/route.test.ts
+++ b/web-app/src/app/api/auth/login/route.test.ts
@@ -3,17 +3,20 @@ import { decode } from 'jsonwebtoken';
 
 process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
 
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(async () => ({
+    id: 'user-1',
+    email: 'user@example.com',
+    role: 'USER',
+    hashedPassword: 'hashed',
+    emailVerified: new Date(),
+    preferences: null,
+  })),
+}));
+
 vi.mock('@/lib/prisma', () => ({
   prisma: {
-    user: {
-      findUnique: vi.fn(async () => ({
-        id: 'user-1',
-        email: 'user@example.com',
-        role: 'USER',
-        hashedPassword: 'hashed',
-        preferences: null,
-      })),
-    },
+    user: { findUnique: mocks.findUnique },
   },
 }));
 
@@ -39,6 +42,14 @@ function makeRequest(body: Record<string, unknown>) {
 describe('POST /api/auth/login — JWT expiry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'USER',
+      hashedPassword: 'hashed',
+      emailVerified: new Date(),
+      preferences: null,
+    });
   });
 
   it('issues a 7-day token when rememberMe is false', async () => {
@@ -55,5 +66,55 @@ describe('POST /api/auth/login — JWT expiry', () => {
     const data = await res.json();
     const decoded = decode(data.token) as { iat: number; exp: number };
     expect(decoded.exp - decoded.iat).toBe(30 * 24 * 60 * 60);
+  });
+});
+
+describe('POST /api/auth/login — email-verified gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.REQUIRE_EMAIL_VERIFICATION;
+  });
+
+  it('allows unverified users when REQUIRE_EMAIL_VERIFICATION is unset (default off)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'USER',
+      hashedPassword: 'hashed',
+      emailVerified: null,
+      preferences: null,
+    });
+    const res = await POST(makeRequest({ email: 'user@example.com', password: 'password123' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 EMAIL_NOT_VERIFIED for unverified users when flag is on', async () => {
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'true';
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'USER',
+      hashedPassword: 'hashed',
+      emailVerified: null,
+      preferences: null,
+    });
+    const res = await POST(makeRequest({ email: 'user@example.com', password: 'password123' }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.code).toBe('EMAIL_NOT_VERIFIED');
+  });
+
+  it('still allows verified users when flag is on', async () => {
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'true';
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'USER',
+      hashedPassword: 'hashed',
+      emailVerified: new Date(),
+      preferences: null,
+    });
+    const res = await POST(makeRequest({ email: 'user@example.com', password: 'password123' }));
+    expect(res.status).toBe(200);
   });
 });

--- a/web-app/src/app/api/auth/login/route.ts
+++ b/web-app/src/app/api/auth/login/route.ts
@@ -54,6 +54,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Email-verified gate (off by default until mobile + desktop clients
+    // ship error-code handling). Set REQUIRE_EMAIL_VERIFICATION=true to enable.
+    if (process.env.REQUIRE_EMAIL_VERIFICATION === 'true' && !user.emailVerified) {
+      return NextResponse.json(
+        {
+          error: 'Please verify your email before signing in.',
+          code: 'EMAIL_NOT_VERIFIED',
+        },
+        { status: 403 }
+      );
+    }
+
     // Create JWT token
     const token = sign(
       { userId: user.id, email: user.email, role: user.role },

--- a/web-app/src/app/api/auth/reset-password/route.test.ts
+++ b/web-app/src/app/api/auth/reset-password/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  update: vi.fn(async () => ({})),
+  hashPassword: vi.fn(async (p: string) => `hashed:${p}`),
+  rateLimit: vi.fn(() => ({ allowed: true, resetInMs: 0 })),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { findUnique: mocks.findUnique, update: mocks.update } },
+}));
+
+vi.mock('@/lib/auth', () => ({ hashPassword: mocks.hashPassword }));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: mocks.rateLimit,
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+const VALID_TOKEN = 'a'.repeat(64);
+const VALID_PASSWORD = 'NewPass123';
+
+describe('POST /api/auth/reset-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimit.mockReturnValue({ allowed: true, resetInMs: 0 });
+  });
+
+  it('rejects when token is missing or too short', async () => {
+    const res = await POST(makeRequest({ token: 'short', newPassword: VALID_PASSWORD }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects weak passwords (no uppercase)', async () => {
+    const res = await POST(makeRequest({ token: VALID_TOKEN, newPassword: 'lowercase1' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when token does not match any user', async () => {
+    mocks.findUnique.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ token: VALID_TOKEN, newPassword: VALID_PASSWORD }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when token is expired and clears the stale token', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'u-1',
+      passwordResetExpires: new Date(Date.now() - 10_000),
+    });
+    const res = await POST(makeRequest({ token: VALID_TOKEN, newPassword: VALID_PASSWORD }));
+    expect(res.status).toBe(400);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u-1' },
+        data: { passwordResetToken: null, passwordResetExpires: null },
+      })
+    );
+    expect(mocks.hashPassword).not.toHaveBeenCalled();
+  });
+
+  it('hashes new password and clears reset token on success', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'u-1',
+      passwordResetExpires: new Date(Date.now() + 10 * 60 * 1000),
+    });
+    const res = await POST(makeRequest({ token: VALID_TOKEN, newPassword: VALID_PASSWORD }));
+    expect(res.status).toBe(200);
+    expect(mocks.hashPassword).toHaveBeenCalledWith(VALID_PASSWORD);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u-1' },
+        data: expect.objectContaining({
+          hashedPassword: `hashed:${VALID_PASSWORD}`,
+          passwordResetToken: null,
+          passwordResetExpires: null,
+        }),
+      })
+    );
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    mocks.rateLimit.mockReturnValueOnce({ allowed: false, resetInMs: 5000 });
+    const res = await POST(makeRequest({ token: VALID_TOKEN, newPassword: VALID_PASSWORD }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/web-app/src/app/api/auth/reset-password/route.ts
+++ b/web-app/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { hashPassword } from '@/lib/auth';
+import { logger } from '@/lib/logger';
+import { rateLimit, getClientIp } from '@/lib/rate-limit';
+import { ResetPasswordSchema } from '@/lib/schemas';
+
+/**
+ * POST /api/auth/reset-password
+ *
+ * Validates the password-reset token, hashes the new password, clears the
+ * token + expiry. The token is single-use.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const ip = getClientIp(request);
+    const rl = rateLimit(`reset-password:${ip}`, 10, 60 * 60 * 1000);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(rl.resetInMs / 1000)) } }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parsed = ResetPasswordSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+    const { token, newPassword } = parsed.data;
+
+    const user = await prisma.user.findUnique({
+      where: { passwordResetToken: token },
+      select: { id: true, passwordResetExpires: true },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Invalid or already-used reset token' },
+        { status: 400 }
+      );
+    }
+
+    if (!user.passwordResetExpires || user.passwordResetExpires < new Date()) {
+      // Token expired — clear it so a fresh request can be made.
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { passwordResetToken: null, passwordResetExpires: null },
+      });
+      return NextResponse.json(
+        { error: 'Reset token has expired. Please request a new one.' },
+        { status: 400 }
+      );
+    }
+
+    const hashed = await hashPassword(newPassword);
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        hashedPassword: hashed,
+        passwordResetToken: null,
+        passwordResetExpires: null,
+      },
+    });
+
+    return NextResponse.json({
+      message: 'Password reset successfully. You can now sign in with your new password.',
+    });
+  } catch (error) {
+    logger.error('Reset-password error', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web-app/src/app/auth/forgot-password/page.tsx
+++ b/web-app/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        setError(data.error || 'Something went wrong. Please try again.');
+        return;
+      }
+
+      setSubmitted(true);
+    } catch {
+      setError('Connection failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Flow<span className="text-primary-500">Shield</span>
+          </h1>
+          <h2 className="mt-4 text-xl font-semibold text-gray-900 dark:text-white">
+            Reset your password
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Enter your email and we&apos;ll send you a reset link.
+          </p>
+        </div>
+
+        {submitted ? (
+          <div className="space-y-4">
+            <div className="bg-success-50 dark:bg-success-500/10 border border-success-100 dark:border-success-500/20 text-success-700 dark:text-success-400 px-4 py-3 rounded-xl text-sm">
+              If an account exists for <strong>{email}</strong>, a password-reset
+              link has been sent. The link expires in 1 hour.
+            </div>
+            <Link
+              href="/auth/login"
+              className="block text-center text-sm font-medium text-primary-500 hover:text-primary-400"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        ) : (
+          <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+            {error && (
+              <div className="bg-danger-50 dark:bg-danger-500/10 border border-danger-200 dark:border-danger-500/20 text-danger-600 dark:text-danger-400 px-4 py-3 rounded-xl text-sm">
+                {error}
+              </div>
+            )}
+
+            <Input
+              label="Email address"
+              id="email"
+              name="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+            />
+
+            <Button type="submit" variant="primary" size="lg" loading={loading} className="w-full">
+              Send reset link
+            </Button>
+
+            <div className="text-center text-sm">
+              <Link
+                href="/auth/login"
+                className="font-medium text-primary-500 hover:text-primary-400"
+              >
+                Back to sign in
+              </Link>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/app/auth/login/page.tsx
+++ b/web-app/src/app/auth/login/page.tsx
@@ -46,7 +46,11 @@ export default function LoginPage() {
       const data = await response.json();
 
       if (!response.ok) {
-        setError(data.error || 'Login failed');
+        if (data.code === 'EMAIL_NOT_VERIFIED') {
+          setError('Please verify your email before signing in. Check your inbox for the verification link.');
+        } else {
+          setError(data.error || 'Login failed');
+        }
         return;
       }
 
@@ -117,15 +121,23 @@ export default function LoginPage() {
             />
           </div>
 
-          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={rememberMe}
-              onChange={(e) => setRememberMe(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300 dark:border-white/20 text-primary-500 focus:ring-primary-500"
-            />
-            Remember me
-          </label>
+          <div className="flex items-center justify-between">
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 dark:border-white/20 text-primary-500 focus:ring-primary-500"
+              />
+              Remember me
+            </label>
+            <Link
+              href="/auth/forgot-password"
+              className="text-sm font-medium text-primary-500 hover:text-primary-400"
+            >
+              Forgot password?
+            </Link>
+          </div>
 
           <Button type="submit" variant="primary" size="lg" loading={loading} className="w-full">
             Sign in

--- a/web-app/src/app/auth/reset-password/page.tsx
+++ b/web-app/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="bg-danger-50 dark:bg-danger-500/10 border border-danger-200 dark:border-danger-500/20 text-danger-600 dark:text-danger-400 px-4 py-3 rounded-xl text-sm">
+        Missing reset token. Open the link from your password-reset email.
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (newPassword !== confirm) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, newPassword }),
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        setError(data.error || 'Failed to reset password.');
+        return;
+      }
+
+      setSuccess(true);
+      setTimeout(() => router.push('/auth/login?reset=true'), 2500);
+    } catch {
+      setError('Connection failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-success-50 dark:bg-success-500/10 border border-success-100 dark:border-success-500/20 text-success-700 dark:text-success-400 px-4 py-3 rounded-xl text-sm">
+          Password reset! Redirecting to sign in…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+      {error && (
+        <div className="bg-danger-50 dark:bg-danger-500/10 border border-danger-200 dark:border-danger-500/20 text-danger-600 dark:text-danger-400 px-4 py-3 rounded-xl text-sm">
+          {error}
+        </div>
+      )}
+
+      <Input
+        label="New password"
+        id="newPassword"
+        name="newPassword"
+        type="password"
+        required
+        minLength={8}
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        placeholder="At least 8 characters"
+      />
+
+      <Input
+        label="Confirm new password"
+        id="confirm"
+        name="confirm"
+        type="password"
+        required
+        minLength={8}
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+      />
+
+      <Button type="submit" variant="primary" size="lg" loading={loading} className="w-full">
+        Reset password
+      </Button>
+
+      <div className="text-center text-sm">
+        <Link href="/auth/login" className="font-medium text-primary-500 hover:text-primary-400">
+          Back to sign in
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Flow<span className="text-primary-500">Shield</span>
+          </h1>
+          <h2 className="mt-4 text-xl font-semibold text-gray-900 dark:text-white">
+            Set a new password
+          </h2>
+        </div>
+
+        <Suspense fallback={<div className="text-sm text-gray-500">Loading…</div>}>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/lib/schemas.ts
+++ b/web-app/src/lib/schemas.ts
@@ -96,3 +96,12 @@ export const UpdateProfileSchema = z.object({
     .strict()
     .optional(),
 });
+
+export const ForgotPasswordSchema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+export const ResetPasswordSchema = z.object({
+  token: z.string().min(32, 'Invalid reset token'),
+  newPassword: PasswordStrength,
+});


### PR DESCRIPTION
Closes #3

## Summary
Two related auth gaps closed in one PR:
1. **Login did not gate on `emailVerified`** — users could sign in immediately after signup without clicking the verification email.
2. **Password reset did not exist** — no schema fields, endpoints, email template, or UI.

## Email-verified login gate
- `POST /api/auth/login` returns **403 `{ code: 'EMAIL_NOT_VERIFIED' }`** for unverified accounts, **behind env flag `REQUIRE_EMAIL_VERIFICATION`**.
- **Default off**. The flag stays off until mobile + desktop have shipped error-code handling. Once verified on staging, set `REQUIRE_EMAIL_VERIFICATION=true` in production env to flip.
- Web login page surfaces the new code inline.
- **Mobile** (`mobile-app/src/lib/api.ts`): typed `AuthError` carries the `code` so screens can show specific copy / a "Resend verification" CTA without parsing message strings.
- **Desktop** (`desktop-app/Services/ApiClient.cs` + `Interfaces/IApiClient.cs`): `LastLoginErrorCode` and `LastLoginErrorMessage` are now exposed so login forms can render specific UI on failure.

> **Google OAuth users are auto-verified** in the callback already, so they won't be locked out when the flag flips.

## Password reset
**Schema** — new columns on `User`:
- `passwordResetToken String? @unique`
- `passwordResetExpires DateTime?`

**Endpoints**:
- `POST /api/auth/forgot-password` — input `{ email }`. Always returns 200 (no info leak about whether the email is registered). Rate-limited 3/h per IP. Only sends mail when the account exists **and** has a password (Google-only users skipped silently).
- `POST /api/auth/reset-password` — input `{ token, newPassword }`. Token is single-use, 1h TTL, validated against schema. Rate-limited 10/h per IP. On expiry, the stale token is cleared so a fresh request works.

**UI**:
- `/auth/forgot-password` page (email form → success state).
- `/auth/reset-password?token=…` page (new + confirm password → redirects to login on success).
- "Forgot password?" link added to `/auth/login`.

## Coordination & rollout
1. Merge this PR → flag stays off → behaviour identical to today.
2. Cut a mobile build that uses `AuthError.code` for nicer copy (separate PR or same release).
3. Cut a desktop build that reads `LastLoginErrorCode` (separate PR / `desktop-release.yml` tag).
4. Set `REQUIRE_EMAIL_VERIFICATION=true` in Netlify env → gate is live.

## Tests
- 11 new tests: forgot-password (5) + reset-password (6).
- 3 new tests for the email-verified gate (default off / gate on + unverified / gate on + verified).
- All 182 Vitest tests pass; `npm run lint` clean (0 errors — pre-existing 2 warnings on `coach/page.tsx` unrelated and addressed by #4 PR); `npm run build` succeeds.

## Migration
`20260501010000_add_password_reset_fields` — additive (two nullable columns + unique index). No backfill needed. Force-added past `prisma/migrations` gitignore entry, same as previous migrations in the repo.

## Test plan
- [ ] Forgot-password with unknown email → 200 generic message, no email sent
- [ ] Forgot-password with known email → reset email arrives with link
- [ ] Forgot-password for Google-only user → no email sent (silent)
- [ ] Reset-password with valid token → password updated, token cleared
- [ ] Reset-password with expired token → 400, stale token cleared
- [ ] Reset-password reused token → 400 invalid
- [ ] With flag OFF: unverified user logs in successfully (no regression)
- [ ] With flag ON: unverified user gets 403 EMAIL_NOT_VERIFIED
- [ ] With flag ON: verified user logs in successfully
- [ ] Mobile login surface code (Expo build)
- [ ] Desktop login surfaces code (release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)