### PR TITLE
feat(subscription): tier helper + expiry cron (#5 phase A)

### DIFF
--- a/web-app/src/app/api/admin/users/[id]/route.ts
+++ b/web-app/src/app/api/admin/users/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getAdminFromToken } from '@/lib/jwt';
+import { invalidateUserTierCache } from '@/lib/subscription';
 
 export async function GET(
   request: NextRequest,
@@ -98,8 +99,13 @@ export async function PATCH(
     select: { id: true, email: true, role: true, subscriptionTier: true, name: true },
   });
 
-  // Record subscription change
+  // Record subscription change. Cancel any prior ACTIVE subscription so
+  // `User.subscriptionTier` and the active Subscription row stay in sync.
   if (subscriptionTier && subscriptionTier !== current.subscriptionTier) {
+    await prisma.subscription.updateMany({
+      where: { userId: id, status: 'ACTIVE' },
+      data: { status: 'CANCELLED', cancelledAt: new Date() },
+    });
     await prisma.subscription.create({
       data: {
         userId: id,
@@ -108,6 +114,7 @@ export async function PATCH(
         provider: 'manual',
       },
     });
+    await invalidateUserTierCache(id);
   }
 
   return NextResponse.json(updated);

--- a/web-app/src/app/api/cron/expire-subscriptions/route.test.ts
+++ b/web-app/src/app/api/cron/expire-subscriptions/route.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  subscriptionFindMany: vi.fn(),
+  subscriptionUpdateMany: vi.fn(async () => ({ count: 0 })),
+  subscriptionCount: vi.fn(),
+  userUpdate: vi.fn(async () => ({})),
+  invalidateUserTierCache: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    subscription: {
+      findMany: mocks.subscriptionFindMany,
+      updateMany: mocks.subscriptionUpdateMany,
+      count: mocks.subscriptionCount,
+    },
+    user: { update: mocks.userUpdate },
+  },
+}));
+
+vi.mock('@/lib/subscription', () => ({
+  invalidateUserTierCache: mocks.invalidateUserTierCache,
+}));
+
+import { POST } from './route';
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request('http://localhost/api/cron/expire-subscriptions', {
+    method: 'POST',
+    headers,
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/cron/expire-subscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = 'test-secret-xyz';
+  });
+
+  it('returns 503 when CRON_SECRET is not set', async () => {
+    delete process.env.CRON_SECRET;
+    const res = await POST(makeRequest({ 'x-cron-secret': 'anything' }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when secret header is missing or wrong', async () => {
+    const r1 = await POST(makeRequest({}));
+    expect(r1.status).toBe(401);
+
+    const r2 = await POST(makeRequest({ 'x-cron-secret': 'wrong' }));
+    expect(r2.status).toBe(401);
+  });
+
+  it('returns 200 with zero counts when nothing is expired', async () => {
+    mocks.subscriptionFindMany.mockResolvedValueOnce([]);
+    const res = await POST(makeRequest({ 'x-cron-secret': 'test-secret-xyz' }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.expired).toBe(0);
+    expect(data.downgraded).toBe(0);
+    expect(mocks.subscriptionUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('flips expired subs to EXPIRED and downgrades users with no other active sub', async () => {
+    mocks.subscriptionFindMany.mockResolvedValueOnce([
+      { id: 's-1', userId: 'u-1' },
+      { id: 's-2', userId: 'u-2' },
+    ]);
+    // Neither user has another active subscription
+    mocks.subscriptionCount.mockResolvedValue(0);
+
+    const res = await POST(makeRequest({ 'x-cron-secret': 'test-secret-xyz' }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.expired).toBe(2);
+    expect(data.downgraded).toBe(2);
+
+    expect(mocks.subscriptionUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ['s-1', 's-2'] } },
+        data: { status: 'EXPIRED' },
+      })
+    );
+    expect(mocks.userUpdate).toHaveBeenCalledTimes(2);
+    expect(mocks.userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'u-1' }, data: { subscriptionTier: 'FREE' } })
+    );
+    expect(mocks.invalidateUserTierCache).toHaveBeenCalledWith('u-1');
+    expect(mocks.invalidateUserTierCache).toHaveBeenCalledWith('u-2');
+  });
+
+  it('does NOT downgrade users who still have another active subscription', async () => {
+    mocks.subscriptionFindMany.mockResolvedValueOnce([{ id: 's-1', userId: 'u-1' }]);
+    mocks.subscriptionCount.mockResolvedValueOnce(1); // user still has one active
+
+    const res = await POST(makeRequest({ 'x-cron-secret': 'test-secret-xyz' }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.expired).toBe(1);
+    expect(data.downgraded).toBe(0);
+    expect(mocks.userUpdate).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates affected users when one user has multiple expired subs', async () => {
+    mocks.subscriptionFindMany.mockResolvedValueOnce([
+      { id: 's-1', userId: 'u-1' },
+      { id: 's-2', userId: 'u-1' },
+    ]);
+    mocks.subscriptionCount.mockResolvedValue(0);
+
+    await POST(makeRequest({ 'x-cron-secret': 'test-secret-xyz' }));
+
+    // userUpdate should be called only once even though two subs expired for u-1
+    expect(mocks.userUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web-app/src/app/api/cron/expire-subscriptions/route.ts
+++ b/web-app/src/app/api/cron/expire-subscriptions/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { invalidateUserTierCache } from '@/lib/subscription';
+
+/**
+ * POST /api/cron/expire-subscriptions
+ *
+ * Called by an external scheduler (cron-job.org / Netlify scheduled function).
+ * Auth: `x-cron-secret` header must equal `CRON_SECRET` env var. Header-only
+ * (no query string) to keep the secret out of access logs.
+ *
+ * Sweep:
+ *   1. Find ACTIVE subscriptions whose `currentPeriodEnd` is in the past.
+ *   2. Flip them to EXPIRED.
+ *   3. For each affected user, if they no longer have any active subscription,
+ *      downgrade `User.subscriptionTier` to FREE.
+ *   4. Invalidate the tier cache so the next request reflects the downgrade.
+ */
+export async function POST(request: NextRequest) {
+  const provided = request.headers.get('x-cron-secret');
+  const expected = process.env.CRON_SECRET;
+
+  if (!expected) {
+    logger.error('Cron disabled: CRON_SECRET is not set');
+    return NextResponse.json(
+      { error: 'Cron not configured' },
+      { status: 503 }
+    );
+  }
+
+  if (provided !== expected) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const now = new Date();
+
+    const expiredRows = await prisma.subscription.findMany({
+      where: {
+        status: 'ACTIVE',
+        currentPeriodEnd: { lt: now, not: null },
+      },
+      select: { id: true, userId: true },
+    });
+
+    let downgraded = 0;
+
+    if (expiredRows.length > 0) {
+      await prisma.subscription.updateMany({
+        where: { id: { in: expiredRows.map((s) => s.id) } },
+        data: { status: 'EXPIRED' },
+      });
+
+      const affectedUsers = Array.from(new Set(expiredRows.map((s) => s.userId)));
+      for (const userId of affectedUsers) {
+        const stillActive = await prisma.subscription.count({
+          where: {
+            userId,
+            status: 'ACTIVE',
+            OR: [{ currentPeriodEnd: null }, { currentPeriodEnd: { gt: now } }],
+          },
+        });
+        if (stillActive === 0) {
+          await prisma.user.update({
+            where: { id: userId },
+            data: { subscriptionTier: 'FREE' },
+          });
+          await invalidateUserTierCache(userId);
+          downgraded++;
+        }
+      }
+    }
+
+    return NextResponse.json({
+      message: 'Subscription expiry sweep complete',
+      expired: expiredRows.length,
+      downgraded,
+    });
+  } catch (error) {
+    logger.error('Subscription expiry cron error', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web-app/src/lib/subscription.test.ts
+++ b/web-app/src/lib/subscription.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const redisMocks = vi.hoisted(() => ({
+  get: vi.fn(async () => null),
+  setex: vi.fn(async () => 'OK'),
+  del: vi.fn(async () => 1),
+}));
+
+const prismaMocks = vi.hoisted(() => ({
+  subscriptionFindFirst: vi.fn(),
+  userFindUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({ redis: redisMocks }));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    subscription: { findFirst: prismaMocks.subscriptionFindFirst },
+    user: { findUnique: prismaMocks.userFindUnique },
+  },
+}));
+
+import {
+  isPaidTier,
+  tierAtLeast,
+  getUserTier,
+  invalidateUserTierCache,
+  userHasTier,
+} from './subscription';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  redisMocks.get.mockResolvedValue(null);
+  redisMocks.setex.mockResolvedValue('OK');
+});
+
+// ─── isPaidTier / tierAtLeast ────────────────────────────────────────────────
+
+describe('isPaidTier', () => {
+  it('PRO and TEAM are paid', () => {
+    expect(isPaidTier('PRO')).toBe(true);
+    expect(isPaidTier('TEAM')).toBe(true);
+  });
+  it('FREE / null / unknown are not paid', () => {
+    expect(isPaidTier('FREE')).toBe(false);
+    expect(isPaidTier(null)).toBe(false);
+    expect(isPaidTier('FOO')).toBe(false);
+  });
+});
+
+describe('tierAtLeast', () => {
+  it('orders FREE < PRO < TEAM', () => {
+    expect(tierAtLeast('TEAM', 'PRO')).toBe(true);
+    expect(tierAtLeast('PRO', 'PRO')).toBe(true);
+    expect(tierAtLeast('FREE', 'PRO')).toBe(false);
+    expect(tierAtLeast('PRO', 'TEAM')).toBe(false);
+    expect(tierAtLeast('FREE', 'FREE')).toBe(true);
+  });
+  it('treats unknown tiers as FREE', () => {
+    expect(tierAtLeast('UNKNOWN', 'FREE')).toBe(true);
+    expect(tierAtLeast('UNKNOWN', 'PRO')).toBe(false);
+  });
+});
+
+// ─── getUserTier ─────────────────────────────────────────────────────────────
+
+describe('getUserTier', () => {
+  it('returns cached tier without DB lookup when Redis hits', async () => {
+    redisMocks.get.mockResolvedValueOnce('PRO');
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('PRO');
+    expect(prismaMocks.subscriptionFindFirst).not.toHaveBeenCalled();
+    expect(prismaMocks.userFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('ignores garbage cache values and falls through to DB', async () => {
+    redisMocks.get.mockResolvedValueOnce('NOT_A_TIER');
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce(null);
+    prismaMocks.userFindUnique.mockResolvedValueOnce({ subscriptionTier: 'FREE' });
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('FREE');
+  });
+
+  it('uses an active Subscription row when one exists', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce({ tier: 'TEAM' });
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('TEAM');
+    expect(prismaMocks.userFindUnique).not.toHaveBeenCalled();
+    expect(redisMocks.setex).toHaveBeenCalledWith('tier:u-1', 300, 'TEAM');
+  });
+
+  it('falls back to User.subscriptionTier when no active Subscription exists (manual upgrade case)', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce(null);
+    prismaMocks.userFindUnique.mockResolvedValueOnce({ subscriptionTier: 'PRO' });
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('PRO');
+  });
+
+  it('defaults to FREE when neither Subscription nor User row exists', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce(null);
+    prismaMocks.userFindUnique.mockResolvedValueOnce(null);
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('FREE');
+  });
+
+  it('still resolves a tier when Redis read throws (degraded path)', async () => {
+    redisMocks.get.mockRejectedValueOnce(new Error('upstash down'));
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce({ tier: 'PRO' });
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('PRO');
+  });
+
+  it('still resolves a tier when Redis write throws (does not leak)', async () => {
+    redisMocks.get.mockResolvedValueOnce(null);
+    redisMocks.setex.mockRejectedValueOnce(new Error('upstash down'));
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce({ tier: 'TEAM' });
+    const tier = await getUserTier('u-1');
+    expect(tier).toBe('TEAM');
+  });
+});
+
+describe('invalidateUserTierCache', () => {
+  it('deletes the cached tier key', async () => {
+    await invalidateUserTierCache('u-9');
+    expect(redisMocks.del).toHaveBeenCalledWith('tier:u-9');
+  });
+
+  it('swallows Redis errors so write paths stay resilient', async () => {
+    redisMocks.del.mockRejectedValueOnce(new Error('upstash down'));
+    await expect(invalidateUserTierCache('u-9')).resolves.toBeUndefined();
+  });
+});
+
+describe('userHasTier', () => {
+  it('grants TEAM access when user is TEAM', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce({ tier: 'TEAM' });
+    expect(await userHasTier('u-1', 'TEAM')).toBe(true);
+  });
+
+  it('grants PRO access when user is TEAM', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce({ tier: 'TEAM' });
+    expect(await userHasTier('u-1', 'PRO')).toBe(true);
+  });
+
+  it('denies PRO access for FREE user', async () => {
+    prismaMocks.subscriptionFindFirst.mockResolvedValueOnce(null);
+    prismaMocks.userFindUnique.mockResolvedValueOnce({ subscriptionTier: 'FREE' });
+    expect(await userHasTier('u-1', 'PRO')).toBe(false);
+  });
+});

--- a/web-app/src/lib/subscription.test.ts
+++ b/web-app/src/lib/subscription.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Explicit return type so `get` resolves to `string | null` (matches the real
+// Redis surface). Without this, vi.fn infers Promise<null> from the initial
+// value and `mockResolvedValueOnce('PRO')` fails strict typecheck.
 const redisMocks = vi.hoisted(() => ({
-  get: vi.fn(async () => null),
+  get: vi.fn<() => Promise<string | null>>(async () => null),
   setex: vi.fn(async () => 'OK'),
   del: vi.fn(async () => 1),
 }));

--- a/web-app/src/lib/subscription.ts
+++ b/web-app/src/lib/subscription.ts
@@ -1,0 +1,94 @@
+import { prisma } from '@/lib/prisma';
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
+import type { SubscriptionTier } from '@prisma/client';
+
+const TIER_CACHE_TTL_SECONDS = 5 * 60;
+
+const TIER_RANK: Record<string, number> = { FREE: 0, PRO: 1, TEAM: 2 };
+
+export function isPaidTier(tier: string | null | undefined): boolean {
+  return tier === 'PRO' || tier === 'TEAM';
+}
+
+/**
+ * Returns true when `tier` is at least as privileged as `minTier`.
+ * Ordering: FREE < PRO < TEAM. Unknown tiers are treated as FREE.
+ */
+export function tierAtLeast(tier: string, minTier: string): boolean {
+  return (TIER_RANK[tier] ?? 0) >= (TIER_RANK[minTier] ?? 0);
+}
+
+function tierCacheKey(userId: string): string {
+  return `tier:${userId}`;
+}
+
+/**
+ * Resolve the user's effective subscription tier.
+ *
+ * Resolution order (first match wins):
+ *   1. Most-privileged ACTIVE Subscription whose `currentPeriodEnd` is in the
+ *      future (or null = perpetual).
+ *   2. `User.subscriptionTier` — covers manual admin upgrades that didn't
+ *      create a Subscription row.
+ *   3. 'FREE' — default.
+ *
+ * Result is cached in Redis for 5 minutes to keep gating cheap. Use
+ * `invalidateUserTierCache(userId)` after any tier-changing write so callers
+ * see the new tier immediately.
+ */
+export async function getUserTier(userId: string): Promise<SubscriptionTier> {
+  try {
+    const cached = await redis.get<string>(tierCacheKey(userId));
+    if (cached === 'FREE' || cached === 'PRO' || cached === 'TEAM') {
+      return cached as SubscriptionTier;
+    }
+  } catch (err) {
+    logger.warn('Tier cache read failed', err);
+  }
+
+  const now = new Date();
+  const sub = await prisma.subscription.findFirst({
+    where: {
+      userId,
+      status: 'ACTIVE',
+      OR: [{ currentPeriodEnd: null }, { currentPeriodEnd: { gt: now } }],
+    },
+    orderBy: [{ tier: 'desc' }, { currentPeriodStart: 'desc' }],
+    select: { tier: true },
+  });
+
+  let tier: SubscriptionTier = 'FREE';
+  if (sub) {
+    tier = sub.tier;
+  } else {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { subscriptionTier: true },
+    });
+    tier = user?.subscriptionTier ?? 'FREE';
+  }
+
+  try {
+    await redis.setex(tierCacheKey(userId), TIER_CACHE_TTL_SECONDS, tier);
+  } catch (err) {
+    logger.warn('Tier cache write failed', err);
+  }
+
+  return tier;
+}
+
+/** Drop the cached tier for a user. Call after any tier-changing write. */
+export async function invalidateUserTierCache(userId: string): Promise<void> {
+  try {
+    await redis.del(tierCacheKey(userId));
+  } catch (err) {
+    logger.warn('Tier cache invalidation failed', err);
+  }
+}
+
+/** Convenience gate. Returns true when the user is at least `minTier`. */
+export async function userHasTier(userId: string, minTier: SubscriptionTier): Promise<boolean> {
+  const tier = await getUserTier(userId);
+  return tierAtLeast(tier, minTier);
+}


### PR DESCRIPTION
First slice of #5. Internal-only foundation that future webhook handlers, gating logic, and UI paywalls can build on without needing any payment-provider account.

## What's in
**Tier helper — `web-app/src/lib/subscription.ts`**
- `getUserTier(userId)` — resolves the effective tier with this precedence:
  1. Most-privileged ACTIVE `Subscription` whose `currentPeriodEnd` is in the future (or null = perpetual)
  2. `User.subscriptionTier` — covers manual admin upgrades
  3. `FREE` default
- 5-min Redis cache so gating is cheap.
- `tierAtLeast` / `userHasTier` — gate helpers (FREE < PRO < TEAM ordering).
- `invalidateUserTierCache(userId)` — call from any tier-changing write.

**Expiry cron — `POST /api/cron/expire-subscriptions`**
- Header-only `x-cron-secret` auth (no query string in logs).
- Flips ACTIVE subs whose `currentPeriodEnd` is past to `EXPIRED` (uses the previously dead `SubscriptionStatus.EXPIRED` enum).
- Downgrades affected users to FREE only when they have no other active subscription.
- Invalidates tier cache so the change is immediate.

**Admin upgrade reconciliation**
- `/api/admin/users/[id]` PATCH now cancels any prior ACTIVE subscription before creating the new one, so `User.subscriptionTier` and the active `Subscription` row never drift again (closes the audit's "dual writes can drift" finding).
- Invalidates tier cache after the change.

## What's NOT in (phase B/C/D)
- **Payment webhooks** — need real Lemon Squeezy / bKash credentials + signing secrets. Separate PR once provider accounts exist.
- **Server-side gates** on leaderboard / teams creation / push send — need product decision on which features paywall. Separate PR.
- **Pricing / paywall UI + tier badge** — needs design + copy. Separate PR.

## Tests
- 22 new unit tests: `subscription.test.ts` (cache hit / fall-through / Redis-fail / tier ordering) + `expire-subscriptions/route.test.ts` (auth / no-op / batch flip / per-user dedupe / no-downgrade-when-other-active).
- 190 total Vitest tests pass; `npm run lint` clean; `npm run build` succeeds.

## Cron setup (deploy step)
After merge, schedule a daily call:
```
curl -X POST https://flowshield.app/api/cron/expire-subscriptions \
  -H "x-cron-secret: $CRON_SECRET"
```
Same pattern as the existing weekly-digest cron (cron-job.org).

## Test plan
- [ ] Apply migration (no schema changes — pure code)
- [ ] Manually flip a user's `currentPeriodEnd` to the past, hit the cron → user downgrades to FREE, EXPIRED row created
- [ ] User with another ACTIVE sub: cron does NOT downgrade them
- [ ] Admin upgrade: prior subs become CANCELLED, new ACTIVE created, tier cache flushed
- [ ] Cron without secret → 401; without env var configured → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)