### PR TITLE
fix(auth): change-password + GDPR UI + OAuth URL fix + profile validation

### DIFF
--- a/web-app/src/app/(app)/profile/page.tsx
+++ b/web-app/src/app/(app)/profile/page.tsx
@@ -754,6 +754,203 @@ export default function ProfilePage() {
             </Button>
           </div>
         </form>
+
+        <AccountAndPrivacyCard onMessage={setMessage} />
+    </div>
+  );
+}
+
+function AccountAndPrivacyCard({
+  onMessage,
+}: {
+  onMessage: (m: { type: 'success' | 'error'; text: string } | null) => void;
+}) {
+  const router = useRouter();
+  const [pwCurrent, setPwCurrent] = useState('');
+  const [pwNew, setPwNew] = useState('');
+  const [pwConfirm, setPwConfirm] = useState('');
+  const [pwSaving, setPwSaving] = useState(false);
+
+  const [delPassword, setDelPassword] = useState('');
+  const [delConfirm, setDelConfirm] = useState(false);
+  const [delSaving, setDelSaving] = useState(false);
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    onMessage(null);
+    if (pwNew !== pwConfirm) {
+      onMessage({ type: 'error', text: 'New passwords do not match.' });
+      return;
+    }
+    const token = getToken();
+    if (!token) return;
+    setPwSaving(true);
+    try {
+      const res = await fetch('/api/user/password', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ currentPassword: pwCurrent, newPassword: pwNew }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        onMessage({ type: 'error', text: data.error || 'Failed to change password.' });
+        return;
+      }
+      onMessage({ type: 'success', text: 'Password updated successfully.' });
+      setPwCurrent('');
+      setPwNew('');
+      setPwConfirm('');
+    } finally {
+      setPwSaving(false);
+    }
+  };
+
+  const handleExport = async () => {
+    onMessage(null);
+    const token = getToken();
+    if (!token) return;
+    try {
+      const res = await fetch('/api/export', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        onMessage({ type: 'error', text: 'Failed to export your data.' });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `flowshield-data-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      onMessage({ type: 'success', text: 'Your data has been downloaded.' });
+    } catch {
+      onMessage({ type: 'error', text: 'Failed to export your data.' });
+    }
+  };
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    onMessage(null);
+    if (!delConfirm) {
+      onMessage({ type: 'error', text: 'Please confirm you understand this is permanent.' });
+      return;
+    }
+    const token = getToken();
+    if (!token) return;
+    setDelSaving(true);
+    try {
+      const res = await fetch('/api/user/delete', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ password: delPassword }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        onMessage({ type: 'error', text: data.error || 'Failed to delete account.' });
+        return;
+      }
+      removeToken();
+      router.push('/auth/signup?deleted=true');
+    } finally {
+      setDelSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-8 space-y-6">
+      <Card>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+          Change Password
+        </h3>
+        <form onSubmit={handleChangePassword} className="space-y-4 max-w-md">
+          <Input
+            label="Current password"
+            type="password"
+            required
+            value={pwCurrent}
+            onChange={(e) => setPwCurrent(e.target.value)}
+          />
+          <Input
+            label="New password"
+            type="password"
+            required
+            minLength={8}
+            value={pwNew}
+            onChange={(e) => setPwNew(e.target.value)}
+            placeholder="At least 8 characters"
+          />
+          <Input
+            label="Confirm new password"
+            type="password"
+            required
+            minLength={8}
+            value={pwConfirm}
+            onChange={(e) => setPwConfirm(e.target.value)}
+          />
+          <Button type="submit" variant="primary" size="sm" disabled={pwSaving}>
+            {pwSaving ? 'Updating…' : 'Update password'}
+          </Button>
+        </form>
+      </Card>
+
+      <Card>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">
+          Your data (GDPR)
+        </h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Download a copy of all your FlowShield data at any time.
+        </p>
+        <Button type="button" variant="secondary" size="sm" onClick={handleExport}>
+          Download my data
+        </Button>
+      </Card>
+
+      <Card className="border-2 border-red-200 dark:border-red-500/20">
+        <h3 className="text-sm font-semibold text-red-700 dark:text-red-400 mb-2">
+          Danger zone — Delete account
+        </h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          This permanently deletes your account, sessions, activity logs, goals,
+          devices, and projects. This cannot be undone.
+        </p>
+        <form onSubmit={handleDelete} className="space-y-4 max-w-md">
+          <Input
+            label="Confirm with your password"
+            type="password"
+            required
+            value={delPassword}
+            onChange={(e) => setDelPassword(e.target.value)}
+          />
+          <label className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={delConfirm}
+              onChange={(e) => setDelConfirm(e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-gray-300 dark:border-white/20 text-red-500 focus:ring-red-500"
+            />
+            <span>I understand this is permanent and cannot be reversed.</span>
+          </label>
+          <Button
+            type="submit"
+            variant="secondary"
+            size="sm"
+            disabled={delSaving || !delConfirm || !delPassword}
+            className="!bg-red-600 hover:!bg-red-700 !text-white !border-red-600"
+          >
+            {delSaving ? 'Deleting…' : 'Delete my account'}
+          </Button>
+        </form>
+      </Card>
     </div>
   );
 }

--- a/web-app/src/app/api/auth/callback-exchange/route.test.ts
+++ b/web-app/src/app/api/auth/callback-exchange/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  del: vi.fn(async () => 1),
+}));
+
+vi.mock('@/lib/redis', () => ({ redis: mocks }));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/auth/callback-exchange', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+const VALID_SESSION = 'a'.repeat(64);
+
+describe('POST /api/auth/callback-exchange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects requests with no session id', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects too-short session ids', async () => {
+    const res = await POST(makeRequest({ session: 'short' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 410 when the session is missing or already used', async () => {
+    mocks.get.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ session: VALID_SESSION }));
+    expect(res.status).toBe(410);
+  });
+
+  it('returns 503 when Redis read fails', async () => {
+    mocks.get.mockRejectedValueOnce(new Error('upstash down'));
+    const res = await POST(makeRequest({ session: VALID_SESSION }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns the stored payload and deletes the key on success', async () => {
+    const payload = {
+      token: 'jwt-here',
+      user: { id: 'u-1', email: 'u@example.com' },
+      redirect: '/dashboard',
+    };
+    mocks.get.mockResolvedValueOnce(payload); // Upstash returns deserialized
+    const res = await POST(makeRequest({ session: VALID_SESSION }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual(payload);
+    expect(mocks.del).toHaveBeenCalledWith(`auth-callback:${VALID_SESSION}`);
+  });
+
+  it('parses string-serialized payloads', async () => {
+    const payload = { token: 'jwt', user: { id: 'u-1' }, redirect: '/x' };
+    mocks.get.mockResolvedValueOnce(JSON.stringify(payload));
+    const res = await POST(makeRequest({ session: VALID_SESSION }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual(payload);
+  });
+});

--- a/web-app/src/app/api/auth/callback-exchange/route.ts
+++ b/web-app/src/app/api/auth/callback-exchange/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/auth/callback-exchange
+ *
+ * Single-use exchange for the OAuth callback page. The Google callback
+ * stores the issued JWT + user payload in Redis under a UUID, then
+ * redirects the browser to `/auth/callback?session=<uuid>`. The page
+ * POSTs that UUID here and gets back the token without ever putting
+ * it in URL/history/referrer/proxy logs.
+ *
+ * Body: { session: string }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const session = typeof body?.session === 'string' ? body.session : '';
+    if (!session || session.length < 16 || session.length > 128) {
+      return NextResponse.json(
+        { error: 'Invalid session id' },
+        { status: 400 }
+      );
+    }
+
+    const key = `auth-callback:${session}`;
+    let payload: unknown = null;
+    try {
+      payload = await redis.get(key);
+    } catch (err) {
+      logger.error('Auth callback Redis read failed', err);
+      return NextResponse.json(
+        { error: 'Auth service unavailable' },
+        { status: 503 }
+      );
+    }
+
+    if (!payload) {
+      return NextResponse.json(
+        { error: 'Session expired or already used' },
+        { status: 410 }
+      );
+    }
+
+    // Single-use: delete on success so a leaked URL ID can't be replayed.
+    try {
+      await redis.del(key);
+    } catch (err) {
+      logger.warn('Auth callback Redis delete failed', err);
+    }
+
+    // Upstash already deserializes JSON values, so payload may be an object.
+    const data = typeof payload === 'string' ? JSON.parse(payload) : payload;
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error('Auth callback exchange error', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web-app/src/app/api/auth/google/callback/route.ts
+++ b/web-app/src/app/api/auth/google/callback/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
 import { prisma } from '@/lib/prisma';
 import { sign } from 'jsonwebtoken';
 import { getJwtSecret } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { redis } from '@/lib/redis';
+
+const CALLBACK_SESSION_TTL_SECONDS = 120; // 2-minute window for the page to exchange
 
 export async function GET(request: NextRequest) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
@@ -97,16 +101,42 @@ export async function GET(request: NextRequest) {
     const jwtToken = sign(
       { userId: user.id, email: user.email, role: user.role },
       getJwtSecret(),
-      { expiresIn: '1h' }
+      { expiresIn: '7d' }
     );
 
     const isNewUser = !user.preferences?.workStyle;
     const dest = isNewUser ? '/onboarding' : '/dashboard';
 
-    // Pass token to client via URL fragment (picked up by the login page)
-    return NextResponse.redirect(
-      `${appUrl}/auth/callback?token=${encodeURIComponent(jwtToken)}&user=${encodeURIComponent(JSON.stringify({ id: user.id, email: user.email, name: user.name, preferences: user.preferences }))}&redirect=${encodeURIComponent(dest)}`
-    );
+    // Don't put the JWT or user payload in the URL — it ends up in browser
+    // history, referrer headers, and proxy/CDN access logs. Instead, stash
+    // it in Redis under a single-use UUID and redirect the browser with
+    // only that ID. The /auth/callback page POSTs the ID to
+    // /api/auth/callback-exchange to retrieve the token, then drops the
+    // entry. TTL is short so a leaked URL is useless after 2 minutes.
+    const sessionId = crypto.randomBytes(32).toString('hex');
+    const payload = {
+      token: jwtToken,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        preferences: user.preferences,
+      },
+      redirect: dest,
+    };
+
+    try {
+      await redis.setex(
+        `auth-callback:${sessionId}`,
+        CALLBACK_SESSION_TTL_SECONDS,
+        JSON.stringify(payload)
+      );
+    } catch (err) {
+      logger.error('Failed to write auth callback session to Redis', err);
+      return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_failed`);
+    }
+
+    return NextResponse.redirect(`${appUrl}/auth/callback?session=${sessionId}`);
   } catch (err) {
     logger.error('Google OAuth callback error', err);
     return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_failed`);

--- a/web-app/src/app/api/user/delete/route.test.ts
+++ b/web-app/src/app/api/user/delete/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  delete: vi.fn(async () => ({})),
+  verifyPassword: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { findUnique: mocks.findUnique, delete: mocks.delete } },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  verifyPassword: mocks.verifyPassword,
+}));
+
+vi.mock('@/lib/jwt', () => ({
+  getUserIdFromToken: vi.fn(() => 'user-1'),
+}));
+
+import { DELETE } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/user/delete', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fake' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('DELETE /api/user/delete — password confirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects when password is missing', async () => {
+    const res = await DELETE(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('rejects when password is wrong', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: 'hash' });
+    mocks.verifyPassword.mockResolvedValueOnce(false);
+    const res = await DELETE(makeRequest({ password: 'wrong' }));
+    expect(res.status).toBe(401);
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('rejects Google-only users with NO_PASSWORD_SET', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: '' });
+    const res = await DELETE(makeRequest({ password: 'anything' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.code).toBe('NO_PASSWORD_SET');
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the user when password is correct', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: 'hash' });
+    mocks.verifyPassword.mockResolvedValueOnce(true);
+    const res = await DELETE(makeRequest({ password: 'correct' }));
+    expect(res.status).toBe(200);
+    expect(mocks.delete).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+  });
+});

--- a/web-app/src/app/api/user/delete/route.ts
+++ b/web-app/src/app/api/user/delete/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { verifyPassword } from '@/lib/auth';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { DeleteAccountSchema } from '@/lib/schemas';
 
 /**
  * DELETE /api/user/delete
  * Permanently deletes the authenticated user and all their data.
+ * Requires password re-entry to prevent accidental + token-replay deletion.
  * All related records cascade via Prisma schema (onDelete: Cascade).
+ *
+ * Body: { password: string }
  */
 export async function DELETE(request: NextRequest) {
   try {
@@ -15,10 +20,43 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Confirm the user exists before deleting
-    const user = await prisma.user.findUnique({ where: { id: userId } });
+    const body = await request.json().catch(() => ({}));
+    const parsed = DeleteAccountSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+    const { password } = parsed.data;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, hashedPassword: true },
+    });
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // Google-only users (empty hashedPassword) cannot confirm via password.
+    // They must re-authenticate via Google before deleting — for now, refuse
+    // and tell them to set a password first via the reset-password flow.
+    if (!user.hashedPassword) {
+      return NextResponse.json(
+        {
+          error: 'Set a password first via the password-reset flow to confirm deletion.',
+          code: 'NO_PASSWORD_SET',
+        },
+        { status: 400 }
+      );
+    }
+
+    const ok = await verifyPassword(password, user.hashedPassword);
+    if (!ok) {
+      return NextResponse.json(
+        { error: 'Password is incorrect' },
+        { status: 401 }
+      );
     }
 
     // Delete user — all related data cascades automatically:

--- a/web-app/src/app/api/user/password/route.test.ts
+++ b/web-app/src/app/api/user/password/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  update: vi.fn(async () => ({})),
+  verifyPassword: vi.fn(),
+  hashPassword: vi.fn(async (p: string) => `hashed:${p}`),
+  rateLimit: vi.fn(() => ({ allowed: true, resetInMs: 0 })),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { findUnique: mocks.findUnique, update: mocks.update } },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  verifyPassword: mocks.verifyPassword,
+  hashPassword: mocks.hashPassword,
+}));
+
+vi.mock('@/lib/jwt', () => ({
+  getUserIdFromToken: vi.fn(() => 'user-1'),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: mocks.rateLimit,
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/user/password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fake' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+const VALID_NEW = 'NewPass123';
+
+describe('POST /api/user/password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimit.mockReturnValue({ allowed: true, resetInMs: 0 });
+  });
+
+  it('rejects weak new password', async () => {
+    const res = await POST(makeRequest({ currentPassword: 'old', newPassword: 'weak' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when current password is wrong', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: 'hash' });
+    mocks.verifyPassword.mockResolvedValueOnce(false);
+    const res = await POST(makeRequest({ currentPassword: 'wrong', newPassword: VALID_NEW }));
+    expect(res.status).toBe(401);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects Google-only users (no current password to verify)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: '' });
+    const res = await POST(makeRequest({ currentPassword: 'anything', newPassword: VALID_NEW }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.code).toBe('NO_PASSWORD_SET');
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('hashes and stores new password on success', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'user-1', hashedPassword: 'old-hash' });
+    mocks.verifyPassword.mockResolvedValueOnce(true);
+    const res = await POST(makeRequest({ currentPassword: 'old', newPassword: VALID_NEW }));
+    expect(res.status).toBe(200);
+    expect(mocks.hashPassword).toHaveBeenCalledWith(VALID_NEW);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'user-1' },
+        data: { hashedPassword: `hashed:${VALID_NEW}` },
+      })
+    );
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    mocks.rateLimit.mockReturnValueOnce({ allowed: false, resetInMs: 5000 });
+    const res = await POST(makeRequest({ currentPassword: 'old', newPassword: VALID_NEW }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/web-app/src/app/api/user/password/route.ts
+++ b/web-app/src/app/api/user/password/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { hashPassword, verifyPassword } from '@/lib/auth';
+import { getUserIdFromToken } from '@/lib/jwt';
+import { logger } from '@/lib/logger';
+import { rateLimit } from '@/lib/rate-limit';
+import { ChangePasswordSchema } from '@/lib/schemas';
+
+/**
+ * POST /api/user/password
+ *
+ * Authenticated change-password. Verifies the user's current password before
+ * accepting the new one. Rate-limited 10/h per user to slow brute-force on
+ * the current-password check.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = getUserIdFromToken(request);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const rl = rateLimit(`change-password:${userId}`, 10, 60 * 60 * 1000);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many password-change attempts. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(rl.resetInMs / 1000)) } }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parsed = ChangePasswordSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+    const { currentPassword, newPassword } = parsed.data;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, hashedPassword: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    if (!user.hashedPassword) {
+      // Google-only users have an empty hashedPassword and have no current
+      // password to verify. They should use forgot-password to set one.
+      return NextResponse.json(
+        {
+          error: 'This account was created via Google. Use the password-reset flow to set a password.',
+          code: 'NO_PASSWORD_SET',
+        },
+        { status: 400 }
+      );
+    }
+
+    const ok = await verifyPassword(currentPassword, user.hashedPassword);
+    if (!ok) {
+      return NextResponse.json(
+        { error: 'Current password is incorrect' },
+        { status: 401 }
+      );
+    }
+
+    const hashed = await hashPassword(newPassword);
+    await prisma.user.update({
+      where: { id: userId },
+      data: { hashedPassword: hashed },
+    });
+
+    return NextResponse.json({ message: 'Password updated successfully' });
+  } catch (error) {
+    logger.error('Change-password error', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web-app/src/app/api/user/profile/route.ts
+++ b/web-app/src/app/api/user/profile/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { UpdateProfileSchema } from '@/lib/schemas';
 
 export async function GET(request: NextRequest) {
   try {
@@ -49,14 +50,21 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { name, timezone, preferences } = body;
+    const body = await request.json().catch(() => ({}));
+    const parsed = UpdateProfileSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+    const { name, timezone, preferences } = parsed.data;
 
     const updatedUser = await prisma.user.update({
       where: { id: userId },
       data: {
-        ...(name && { name }),
-        ...(timezone && { timezone }),
+        ...(name !== undefined && { name }),
+        ...(timezone !== undefined && { timezone }),
         ...(preferences && {
           preferences: {
             update: preferences,

--- a/web-app/src/app/auth/callback/page.tsx
+++ b/web-app/src/app/auth/callback/page.tsx
@@ -1,24 +1,58 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { setToken, setUserData } from '@/lib/auth-token';
 
-export default function AuthCallbackPage() {
+function AuthCallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    const token = searchParams.get('token');
-    const userParam = searchParams.get('user');
-    const redirect = searchParams.get('redirect') || '/dashboard';
+    const session = searchParams.get('session');
 
-    if (token && userParam) {
+    // Legacy compatibility: if a token is still in the URL (e.g. an old
+    // OAuth redirect from before the exchange flow), accept it once. New
+    // redirects use the session-exchange path above.
+    const legacyToken = searchParams.get('token');
+    const legacyUser = searchParams.get('user');
+    const legacyRedirect = searchParams.get('redirect') || '/dashboard';
+
+    if (session) {
+      let cancelled = false;
+      (async () => {
+        try {
+          const res = await fetch('/api/auth/callback-exchange', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session }),
+          });
+          if (!res.ok) {
+            router.replace('/auth/login?error=oauth_failed');
+            return;
+          }
+          const data = await res.json();
+          if (cancelled) return;
+          if (!data?.token || !data?.user) {
+            router.replace('/auth/login?error=oauth_failed');
+            return;
+          }
+          setToken(data.token, true);
+          setUserData(data.user, true);
+          router.replace(data.redirect || '/dashboard');
+        } catch {
+          if (!cancelled) router.replace('/auth/login?error=oauth_failed');
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    } else if (legacyToken && legacyUser) {
       try {
-        const user = JSON.parse(userParam);
-        setToken(token, true);
+        const user = JSON.parse(legacyUser);
+        setToken(legacyToken, true);
         setUserData(user, true);
-        router.replace(redirect);
+        router.replace(legacyRedirect);
       } catch {
         router.replace('/auth/login?error=oauth_failed');
       }
@@ -34,5 +68,13 @@ export default function AuthCallbackPage() {
         <p className="text-gray-600 dark:text-gray-400">Completing sign in...</p>
       </div>
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthCallbackInner />
+    </Suspense>
   );
 }

--- a/web-app/src/lib/schemas.ts
+++ b/web-app/src/lib/schemas.ts
@@ -63,3 +63,36 @@ export const PushSendSchema = z.object({
   body: z.string().min(1).max(500),
   userId: z.string().uuid(),
 });
+
+const PasswordStrength = z
+  .string()
+  .min(8, 'Password must be at least 8 characters')
+  .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+  .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+  .regex(/[0-9]/, 'Password must contain at least one number');
+
+export const ChangePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: PasswordStrength,
+});
+
+export const DeleteAccountSchema = z.object({
+  password: z.string().min(1, 'Password is required to confirm deletion'),
+});
+
+export const UpdateProfileSchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  timezone: z.string().min(1).max(64).optional(),
+  preferences: z
+    .object({
+      workStyle: z.string().max(50).optional(),
+      preferredDuration: z.number().int().min(5).max(240).optional(),
+      primaryDistractions: z.array(z.string().max(100)).max(50).optional(),
+      workEnvironment: z.string().max(50).optional(),
+      breakReminders: z.boolean().optional(),
+      soundEnabled: z.boolean().optional(),
+      darkMode: z.boolean().optional(),
+    })
+    .strict()
+    .optional(),
+});


### PR DESCRIPTION
Bundle PR closing **#6, #7, #8, #9, #10** — five small auth/user-management fixes that share the same files.

## #6 — Authenticated change-password
- New endpoint `POST /api/user/password` with `{ currentPassword, newPassword }` body.
- Verifies current via bcrypt; rate-limited 10/h per user.
- Google-only users (empty `hashedPassword`) get **NO_PASSWORD_SET** — they should use the password-reset flow first.
- New "Change Password" section in profile page.

## #7 — OAuth callback no longer leaks JWT in URL
The token used to be passed via `?token=…&user=…` query params on the redirect from `/api/auth/google/callback`. That ended up in browser history, referrer headers, and proxy logs.

**New flow:**
1. Google callback stashes `{ token, user, redirect }` in Redis under a fresh 32-byte hex UUID with **120 s TTL**.
2. Redirects the browser to `/auth/callback?session=<uuid>` — no token, no user data in the URL.
3. The page POSTs that UUID to a new `/api/auth/callback-exchange` endpoint.
4. The exchange returns the payload and deletes the key (**single-use** — a leaked URL is useless after exchange or 2 minutes, whichever comes first).

The `/auth/callback` page is rewritten with `Suspense` wrapping (Next.js 16 pattern) and includes a one-release fallback for the legacy `?token=&user=` path so users mid-flow don't get stranded.

## #8 — Google OAuth JWT lifetime aligned
Bumped from `1h` → `7d` to match the password-login default. Admins stop getting logged out hourly when they sign in via Google. (`rememberMe`-style 30d path is unchanged — it's currently login-only.)

## #9 — GDPR Export + Delete UI + password confirmation
- New "Your data (GDPR)" card with **Download my data** button — fetches `/api/export` and triggers a JSON download.
- New "Danger zone — Delete account" card with password confirmation field + checkbox to confirm permanence.
- `DELETE /api/user/delete` now **requires `{ password }`** in the body and verifies via bcrypt before deletion. Google-only users get `NO_PASSWORD_SET` and are pointed at the reset-password flow.

## #10 — Zod validation on PUT /api/user/profile
- New `UpdateProfileSchema` in `lib/schemas.ts` validating `name`, `timezone`, and a `strict()` `preferences` shape (rejects unknown keys).
- PUT returns 400 with friendly Zod messages on bad input.
- Empty-string inputs no longer silently overwrite real values (changed `&& name` → `name !== undefined && { name }`).

## Tests
- 15 new unit tests: password (5) + delete (4) + callback-exchange (6).
- 183 total Vitest tests pass; `npm run lint` clean (0 errors); `npm run build` succeeds.
- Pre-existing 2 lint warnings on `coach/page.tsx` are unrelated and addressed by PR #27 (#4 epic).

## Test plan
- [ ] Change-password: correct current → 200; wrong current → 401; weak new → 400; Google-only → NO_PASSWORD_SET
- [ ] OAuth flow: login via Google → URL contains only `?session=…`, no token; check browser history shows only the session ID
- [ ] OAuth replay: paste an old `?session=…` URL after first use → "Session expired or already used"
- [ ] OAuth Redis outage: Redis down during callback → user redirected to `/auth/login?error=oauth_failed`
- [ ] Account delete: requires password; wrong password → 401; Google-only → NO_PASSWORD_SET
- [ ] Data export: button downloads `flowshield-data-YYYY-MM-DD.json`
- [ ] Profile update: invalid `timezone` (e.g. 100-char string) → 400; unknown preferences key → 400 (strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)