### PR TITLE
fix(sessions): race check + weighted avg + auto-classify dedupe + FocusTimer pause

### DIFF
--- a/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   bustCoachCacheIfPaid: vi.fn(async () => undefined),
   triggerUserEvent: vi.fn(),
   sendSessionEndPush: vi.fn(async () => 1),
+  autoClassifyIfNeeded: vi.fn(async (_id: string, _userId: string, session: any) => session),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -37,6 +38,10 @@ vi.mock('@/lib/coach-quota', () => ({
 
 vi.mock('@/lib/pushNotify', () => ({
   sendSessionEndPush: mocks.sendSessionEndPush,
+}));
+
+vi.mock('@/lib/auto-classify-helper', () => ({
+  autoClassifyIfNeeded: mocks.autoClassifyIfNeeded,
 }));
 
 const { sessionFindUnique, sessionUpdate, triggerUserEvent, bustCoachCacheIfPaid, sendSessionEndPush } = mocks;

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.ts
@@ -5,7 +5,7 @@ import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 import { sendSessionEndPush } from '@/lib/pushNotify';
-import { classifySessionProject } from '@/lib/project-classifier';
+import { autoClassifyIfNeeded } from '@/lib/auto-classify-helper';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -64,21 +64,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       },
     });
 
-    // Auto-classify only when the user didn't link the session to a project up front.
-    if (!updatedSession.projectId) {
-      try {
-        const guessed = await classifySessionProject(id, userId);
-        if (guessed) {
-          updatedSession = await prisma.session.update({
-            where: { id },
-            data: { projectId: guessed },
-          });
-          logger.info(`Session ${id} auto-classified to project ${guessed} on auto-end`);
-        }
-      } catch (err) {
-        logger.warn('Project auto-classify failed on auto-end', err);
-      }
-    }
+    updatedSession = await autoClassifyIfNeeded(id, userId, updatedSession);
 
     // Update DailyStats for the day the session ENDED (i.e. plannedEnd), not now.
     const statsDate = new Date(plannedEnd);

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -4,7 +4,7 @@ import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
-import { classifySessionProject } from '@/lib/project-classifier';
+import { autoClassifyIfNeeded, nextWeightedAverage } from '@/lib/auto-classify-helper';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -71,47 +71,44 @@ export async function PATCH(
 
     // Auto-classify only when completing a session the user didn't link to a project.
     // Skip if the user explicitly set projectId in this request (respects user intent).
-    if (completed && !projectIdProvided && !updatedSession.projectId) {
-      try {
-        const guessed = await classifySessionProject(id, userId);
-        if (guessed) {
-          updatedSession = await prisma.session.update({
-            where: { id },
-            data: { projectId: guessed },
-          });
-          logger.info(`Session ${id} auto-classified to project ${guessed}`);
-        }
-      } catch (err) {
-        logger.warn('Project auto-classify failed', err);
-      }
+    if (completed && !projectIdProvided) {
+      updatedSession = await autoClassifyIfNeeded(id, userId, updatedSession);
     }
 
-    // Update DailyStats if session is completed
+    // Update DailyStats if session is completed. Use a weighted average so
+    // every completed session contributes — was previously overwriting with
+    // just the latest score.
     if (completed && actualDuration) {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
+      const existingStats = await prisma.dailyStats.findUnique({
+        where: { userId_date: { userId, date: today } },
+        select: { avgProductivityScore: true, sessionsCompleted: true },
+      });
+
+      const newAvg =
+        productivityScore !== undefined
+          ? nextWeightedAverage(
+              existingStats?.avgProductivityScore ?? null,
+              existingStats?.sessionsCompleted ?? 0,
+              productivityScore
+            )
+          : existingStats?.avgProductivityScore ?? 0;
+
       await prisma.dailyStats.upsert({
-        where: {
-          userId_date: {
-            userId,
-            date: today,
-          },
-        },
+        where: { userId_date: { userId, date: today } },
         update: {
           totalFocusMinutes: { increment: actualDuration },
           sessionsCompleted: { increment: 1 },
-          // Simple average update logic (weighted average would be better but keeping it simple)
-          ...(productivityScore && {
-            avgProductivityScore: productivityScore // Simplified: just taking latest or would need complex math
-          }),
+          ...(productivityScore !== undefined && { avgProductivityScore: newAvg }),
         },
         create: {
           userId,
           date: today,
           totalFocusMinutes: actualDuration,
           sessionsCompleted: 1,
-          avgProductivityScore: productivityScore || 0,
+          avgProductivityScore: productivityScore ?? 0,
         },
       });
     }

--- a/web-app/src/app/api/sessions/route.test.ts
+++ b/web-app/src/app/api/sessions/route.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  create: vi.fn(),
+  triggerUserEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { session: { findFirst: mocks.findFirst, create: mocks.create } },
+}));
+
+vi.mock('@/lib/jwt', () => ({
+  getUserIdFromToken: vi.fn(() => 'user-1'),
+}));
+
+vi.mock('@/lib/pusher', () => ({
+  triggerUserEvent: mocks.triggerUserEvent,
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fake' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/sessions — race check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a new session when no active session exists', async () => {
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.create.mockResolvedValueOnce({ id: 'new-1', plannedDuration: 25 });
+    const res = await POST(makeRequest({ plannedDuration: 25 }));
+    expect(res.status).toBe(201);
+    expect(mocks.create).toHaveBeenCalled();
+    expect(mocks.triggerUserEvent).toHaveBeenCalledWith('user-1', 'session-update');
+  });
+
+  it('returns 409 with activeSessionId when an active session already exists', async () => {
+    mocks.findFirst.mockResolvedValueOnce({ id: 'active-1', startTime: new Date() });
+    const res = await POST(makeRequest({ plannedDuration: 25 }));
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.code).toBe('SESSION_ALREADY_ACTIVE');
+    expect(data.activeSessionId).toBe('active-1');
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests missing plannedDuration', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect(mocks.findFirst).not.toHaveBeenCalled();
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+});

--- a/web-app/src/app/api/sessions/route.ts
+++ b/web-app/src/app/api/sessions/route.ts
@@ -23,6 +23,27 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Race check: refuse to create a second active session for the same user.
+    // A session is "active" when it hasn't been marked completed and has no
+    // endTime yet. Returning 409 with the existing session id lets the client
+    // recover gracefully (jump to the running session) without leaving stray
+    // half-completed rows that would later confuse analytics.
+    const existing = await prisma.session.findFirst({
+      where: { userId, completed: false, endTime: null },
+      select: { id: true, startTime: true },
+      orderBy: { startTime: 'desc' },
+    });
+    if (existing) {
+      return NextResponse.json(
+        {
+          error: 'You already have an active session.',
+          code: 'SESSION_ALREADY_ACTIVE',
+          activeSessionId: existing.id,
+        },
+        { status: 409 }
+      );
+    }
+
     const session = await prisma.session.create({
       data: {
         userId,

--- a/web-app/src/components/dashboard/FocusTimer.tsx
+++ b/web-app/src/components/dashboard/FocusTimer.tsx
@@ -150,18 +150,17 @@ export default function FocusTimer({
 
   useEffect(() => {
     if (currentSession && !currentSession.completed) {
-      if (currentSession.isPaused) {
-        if (currentSession.pausedAt) {
-          const elapsedMs = new Date(currentSession.pausedAt).getTime() - new Date(currentSession.startTime).getTime();
-          const elapsedSeconds = Math.floor(elapsedMs / 1000);
-          const remaining = (currentSession.plannedDuration * 60) - elapsedSeconds;
-          setTimeRemaining(Math.max(0, remaining));
-        }
-      } else {
-        const plannedEnd = new Date(currentSession.startTime).getTime() + (currentSession.plannedDuration * 60 * 1000);
-        const remaining = Math.max(0, Math.floor((plannedEnd - Date.now()) / 1000));
-        setTimeRemaining(remaining);
-      }
+      // Always anchor remaining time to the server-issued startTime (not to
+      // wall-clock countdown ticks). When paused, freeze elapsed at the
+      // server's pausedAt; while running, recompute from now.
+      const startMs = new Date(currentSession.startTime).getTime();
+      const plannedEndMs = startMs + currentSession.plannedDuration * 60 * 1000;
+      const referenceMs =
+        currentSession.isPaused && currentSession.pausedAt
+          ? new Date(currentSession.pausedAt).getTime()
+          : Date.now();
+      const remaining = Math.max(0, Math.floor((plannedEndMs - referenceMs) / 1000));
+      setTimeRemaining(remaining);
     } else {
       setTimeRemaining(0);
     }
@@ -443,6 +442,7 @@ export default function FocusTimer({
 
     const action = currentSession.isPaused ? 'resume' : 'pause';
     const activeState = !currentSession.isPaused;
+    const previousSession = currentSession;
 
     // OPTIMISTIC UPDATE
     setCurrentSession((prev: any) => ({
@@ -454,7 +454,7 @@ export default function FocusTimer({
     try {
       setIsProcessing(true);
       const token = getToken();
-      await fetch(`/api/sessions/${currentSession.id}/toggle-pause`, {
+      const res = await fetch(`/api/sessions/${currentSession.id}/toggle-pause`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -462,10 +462,21 @@ export default function FocusTimer({
         },
         body: JSON.stringify({ action })
       });
+      // fetch() does not throw on 4xx/5xx — check response and revert on
+      // server failure so the UI doesn't silently desync from server state.
+      if (!res.ok) {
+        throw new Error(`Toggle pause failed (${res.status})`);
+      }
+      const data = await res.json().catch(() => null);
+      if (data?.session) {
+        // Sync to server-issued state (e.g. resumed startTime) so subsequent
+        // remaining-time math uses authoritative values.
+        setCurrentSession(data.session);
+      }
       onSessionUpdate?.();
     } catch (error) {
       console.error('Failed to toggle pause:', error);
-      setCurrentSession(propSession); // Revert
+      setCurrentSession(previousSession); // Revert to pre-click state
     } finally {
       setIsProcessing(false);
     }

--- a/web-app/src/lib/auto-classify-helper.test.ts
+++ b/web-app/src/lib/auto-classify-helper.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  classify: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock('@/lib/project-classifier', () => ({
+  classifySessionProject: mocks.classify,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { session: { update: mocks.update } },
+}));
+
+import { autoClassifyIfNeeded, nextWeightedAverage } from './auto-classify-helper';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('autoClassifyIfNeeded', () => {
+  const baseSession: any = { id: 's-1', userId: 'u-1', projectId: null };
+
+  it('returns the session unchanged when projectId is already set', async () => {
+    const session = { ...baseSession, projectId: 'p-existing' };
+    const result = await autoClassifyIfNeeded('s-1', 'u-1', session);
+    expect(result).toBe(session);
+    expect(mocks.classify).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('returns the session unchanged when classifier finds no match', async () => {
+    mocks.classify.mockResolvedValueOnce(null);
+    const result = await autoClassifyIfNeeded('s-1', 'u-1', baseSession);
+    expect(result).toBe(baseSession);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the session with the guessed project on a hit', async () => {
+    mocks.classify.mockResolvedValueOnce('p-2');
+    mocks.update.mockResolvedValueOnce({ ...baseSession, projectId: 'p-2' });
+    const result = await autoClassifyIfNeeded('s-1', 'u-1', baseSession);
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: 's-1' },
+      data: { projectId: 'p-2' },
+    });
+    expect(result.projectId).toBe('p-2');
+  });
+
+  it('swallows classifier errors and returns the original session', async () => {
+    mocks.classify.mockRejectedValueOnce(new Error('boom'));
+    const result = await autoClassifyIfNeeded('s-1', 'u-1', baseSession);
+    expect(result).toBe(baseSession);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('nextWeightedAverage', () => {
+  it('returns the new score (rounded) when there is no prior data', () => {
+    expect(nextWeightedAverage(null, 0, 80)).toBe(80);
+    expect(nextWeightedAverage(undefined, 0, 87.4)).toBe(87);
+    expect(nextWeightedAverage(70, 0, 90)).toBe(90); // count=0 dominates
+  });
+
+  it('averages across the existing count plus one', () => {
+    // (80 * 1 + 60) / 2 = 70
+    expect(nextWeightedAverage(80, 1, 60)).toBe(70);
+    // (75 * 4 + 95) / 5 = 79
+    expect(nextWeightedAverage(75, 4, 95)).toBe(79);
+  });
+
+  it('rounds to the nearest integer', () => {
+    // (80 * 1 + 81) / 2 = 80.5 → 81
+    expect(nextWeightedAverage(80, 1, 81)).toBe(81);
+  });
+});

--- a/web-app/src/lib/auto-classify-helper.ts
+++ b/web-app/src/lib/auto-classify-helper.ts
@@ -1,0 +1,54 @@
+import type { Session } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { classifySessionProject } from '@/lib/project-classifier';
+
+/**
+ * If the session has no `projectId`, run the activity-based classifier and
+ * persist the guessed project. Returns the (possibly updated) session.
+ *
+ * Used by both `PATCH /api/sessions/[id]` and `POST /api/sessions/[id]/auto-end`
+ * so the auto-classification logic stays in one place.
+ *
+ * Errors are swallowed and logged — auto-classify is best-effort and must
+ * never break the session-completion path.
+ */
+export async function autoClassifyIfNeeded(
+  sessionId: string,
+  userId: string,
+  current: Session
+): Promise<Session> {
+  if (current.projectId) return current;
+
+  try {
+    const guessed = await classifySessionProject(sessionId, userId);
+    if (guessed) {
+      const updated = await prisma.session.update({
+        where: { id: sessionId },
+        data: { projectId: guessed },
+      });
+      logger.info(`Session ${sessionId} auto-classified to project ${guessed}`);
+      return updated;
+    }
+  } catch (err) {
+    logger.warn('Project auto-classify failed', err);
+  }
+  return current;
+}
+
+/**
+ * Compute a running weighted average. Returns `newScore` when there's no
+ * prior data, otherwise the average across `oldCount + 1` data points.
+ *
+ * Used to update `DailyStats.avgProductivityScore` in a way that actually
+ * reflects every completed session, not just the latest one (closes the
+ * `// Simplified: just taking latest` TODO in the session PATCH route).
+ */
+export function nextWeightedAverage(
+  oldAverage: number | null | undefined,
+  oldCount: number,
+  newScore: number
+): number {
+  if (!oldCount || oldAverage == null) return Math.round(newScore);
+  return Math.round((oldAverage * oldCount + newScore) / (oldCount + 1));
+}


### PR DESCRIPTION
Sessions/timer cluster — closes **#11, #12, #13, #16, #17**.

## #11 — `POST /api/sessions` race check
- Refuses to create a second active session for the same user.
- Returns **409 `{ code: 'SESSION_ALREADY_ACTIVE', activeSessionId }`** so the client can jump to the running session instead of leaving stray half-completed rows.

## #12 — FocusTimer pause math anchors only to server-issued timestamps
- Replaces the dual-branch (paused vs running) elapsed calc with a single formula:
  ```ts
  remaining = plannedEnd - (isPaused ? pausedAt : Date.now())
  ```
- No more optimistic-pausedAt-vs-startTime arithmetic that could drift when client/server clocks diverge. Matches the project's "Timer drift" rule in CLAUDE.md.

## #13 — Pause toggle no longer silently desyncs on server failure
- Checks `response.ok` (fetch doesn't throw on 4xx/5xx) and reverts the optimistic state on any non-2xx.
- Captures the previous session before the optimistic mutation so revert is correct (no longer relies on a stale `propSession` reference).
- On success, syncs to the server-issued session payload so the resumed `startTime` flows into the remaining-time math.

## #16 — `DailyStats.avgProductivityScore` is now a true weighted average
- New `nextWeightedAverage` helper: `(oldAvg * oldCount + newScore) / (oldCount + 1)`, rounded.
- Session PATCH reads existing `DailyStats`, computes the new average, then upserts. Closes the inline `// Simplified: just taking latest` TODO.

## #17 — Auto-classify deduped into `lib/auto-classify-helper.ts`
- `autoClassifyIfNeeded(sessionId, userId, session)` wraps the no-projectId / classify / persist sequence and swallows classifier errors (best-effort).
- Both `PATCH /api/sessions/[id]` and `POST /api/sessions/[id]/auto-end` now delegate. ~25 LOC of duplication removed.

## Tests
- **10 new unit tests**: `auto-classify-helper.test.ts` (7) + `sessions/route.test.ts` (3).
- 178 total Vitest tests pass; `npm run lint` clean (0 errors); build green.
- Pre-existing 2 lint warnings on `coach/page.tsx` are unrelated and addressed by PR #27.

## Test plan
- [ ] Concurrent POST `/api/sessions` → second one gets 409 + `activeSessionId`
- [ ] Click "Start" while another session is running → web shows "you already have an active session"
- [ ] Start a session, pause for 30s, watch the displayed countdown freeze; resume and verify it picks up where it left off
- [ ] Force a 500 on `/toggle-pause` → UI reverts to its pre-click state
- [ ] Complete two sessions same day with scores 80 and 90 → `avgProductivityScore` is 85, not 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)