### PR TITLE
fix: realtime events + analytics cache + heatmap timezone & streak

### DIFF
--- a/web-app/src/app/api/analytics/distractions/route.ts
+++ b/web-app/src/app/api/analytics/distractions/route.ts
@@ -74,12 +74,19 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Per-app share is meaningful as "% of distracting time spent on this app"
+    // (sums to 100% across the top distractions). The previous denominator
+    // (totalMinutes = all activity) understated each app's distraction share
+    // because productive time inflated the denominator.
     const topDistractions = Object.entries(appTimes)
       .map(([name, data]) => ({
         name,
         category: data.category,
         minutes: Math.round(data.minutes),
-        percentage: totalMinutes > 0 ? Math.round((data.minutes / totalMinutes) * 100) : 0,
+        percentage:
+          totalDistractionMinutes > 0
+            ? Math.round((data.minutes / totalDistractionMinutes) * 100)
+            : 0,
       }))
       .sort((a, b) => b.minutes - a.minutes)
       .slice(0, 5);

--- a/web-app/src/app/api/analytics/yearly/route.ts
+++ b/web-app/src/app/api/analytics/yearly/route.ts
@@ -3,6 +3,25 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
+/**
+ * Format a Date as YYYY-MM-DD in the given IANA timezone. Falls back to UTC
+ * if the timezone is unknown. Used so the yearly heatmap buckets stats into
+ * the user's local days rather than UTC days, which would shift cells by a
+ * day for users in negative-UTC timezones.
+ */
+function formatDateInTz(date: Date, timezone: string): string {
+    try {
+        return new Intl.DateTimeFormat('en-CA', {
+            timeZone: timezone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        }).format(date);
+    } catch {
+        return date.toISOString().split('T')[0];
+    }
+}
+
 export async function GET(request: NextRequest) {
     try {
         const userId = getUserIdFromToken(request);
@@ -13,6 +32,12 @@ export async function GET(request: NextRequest) {
                 { status: 401 }
             );
         }
+
+        const user = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { timezone: true },
+        });
+        const tz = user?.timezone ?? 'UTC';
 
         const endDate = new Date();
         const startDate = new Date();
@@ -36,7 +61,7 @@ export async function GET(request: NextRequest) {
         });
 
         const formattedStats = stats.map((stat) => ({
-            date: stat.date.toISOString().split('T')[0],
+            date: formatDateInTz(stat.date, tz),
             count: stat.totalFocusMinutes,
         }));
 

--- a/web-app/src/app/api/goals/route.ts
+++ b/web-app/src/app/api/goals/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { triggerUserEvent } from '@/lib/pusher';
 import { CreateGoalSchema } from '@/lib/schemas';
 
 export async function GET(req: NextRequest) {
@@ -72,6 +73,7 @@ export async function POST(req: NextRequest) {
           updatedAt: new Date(),
         },
       });
+      triggerUserEvent(userId, 'goal-update', { id: updatedGoal.id });
       return NextResponse.json({ goal: updatedGoal });
     }
 
@@ -85,6 +87,7 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    triggerUserEvent(userId, 'goal-update', { id: newGoal.id });
     return NextResponse.json({ goal: newGoal });
   } catch (error) {
     logger.error('Error creating/updating goal', error);

--- a/web-app/src/app/api/projects/[id]/route.test.ts
+++ b/web-app/src/app/api/projects/[id]/route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   projectFindFirst: vi.fn(),
   projectDelete: vi.fn(),
   projectUpdate: vi.fn(),
+  triggerUserEvent: vi.fn(),
 }));
 
 vi.mock('@/lib/jwt', () => ({
@@ -21,6 +22,10 @@ vi.mock('@/lib/prisma', () => ({
       update: mocks.projectUpdate,
     },
   },
+}));
+
+vi.mock('@/lib/pusher', () => ({
+  triggerUserEvent: mocks.triggerUserEvent,
 }));
 
 vi.mock('@/lib/schemas', () => ({

--- a/web-app/src/app/api/projects/[id]/route.ts
+++ b/web-app/src/app/api/projects/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { triggerUserEvent } from '@/lib/pusher';
 import { UpdateProjectCostSchema } from '@/lib/schemas';
 
 export async function PATCH(
@@ -33,6 +34,7 @@ export async function PATCH(
       data: parsed.data,
     });
 
+    triggerUserEvent(userId, 'project-update', { id });
     return NextResponse.json(updated);
   } catch (error) {
     logger.error('Error updating project:', error);
@@ -63,6 +65,7 @@ export async function DELETE(
     await prisma.project.delete({ where: { id } });
     logger.info(`Project deleted: ${id} by user ${userId}`);
 
+    triggerUserEvent(userId, 'project-update', { id, deleted: true });
     return NextResponse.json({ ok: true });
   } catch (error) {
     logger.error('Error deleting project:', error);

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.ts
@@ -6,6 +6,7 @@ import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 import { sendSessionEndPush } from '@/lib/pushNotify';
 import { autoClassifyIfNeeded } from '@/lib/auto-classify-helper';
+import { invalidateAnalyticsCache } from '@/lib/analytics-cache';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -85,6 +86,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     });
 
     triggerUserEvent(userId, 'session-update');
+    await invalidateAnalyticsCache(userId);
 
     // Bust coach cache for paid tiers; FREE quota is durable via DB column.
     await bustCoachCacheIfPaid(userId);

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 import { autoClassifyIfNeeded, nextWeightedAverage } from '@/lib/auto-classify-helper';
+import { invalidateAnalyticsCache } from '@/lib/analytics-cache';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -114,6 +115,7 @@ export async function PATCH(
     }
 
     triggerUserEvent(userId, 'session-update');
+    await invalidateAnalyticsCache(userId);
 
     // Bust the AI Coach cache for paid tiers so their next visit gets fresh
     // advice that reflects this session. FREE users are intentionally NOT

--- a/web-app/src/app/api/sessions/route.ts
+++ b/web-app/src/app/api/sessions/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
+import { invalidateAnalyticsCache } from '@/lib/analytics-cache';
 
 // Create a new session
 export async function POST(request: NextRequest) {
@@ -58,6 +59,7 @@ export async function POST(request: NextRequest) {
     });
 
     triggerUserEvent(userId, 'session-update');
+    await invalidateAnalyticsCache(userId);
     return NextResponse.json({ session }, { status: 201 });
   } catch (error) {
     logger.error('Session creation error:', error);

--- a/web-app/src/components/analytics/HeatmapWidget.tsx
+++ b/web-app/src/components/analytics/HeatmapWidget.tsx
@@ -12,6 +12,24 @@ interface HeatmapWidgetProps {
     year?: number;
 }
 
+/**
+ * Longest run of consecutive days with focus minutes > 0. Days are walked
+ * in calendar order (the `days` array is already chronological).
+ */
+function computeMaxStreak(days: HeatmapData[]): number {
+    let best = 0;
+    let current = 0;
+    for (const day of days) {
+        if (day.count > 0) {
+            current++;
+            if (current > best) best = current;
+        } else {
+            current = 0;
+        }
+    }
+    return best;
+}
+
 export default function HeatmapWidget({ data, year = new Date().getFullYear() }: HeatmapWidgetProps) {
     const [hoveredDay, setHoveredDay] = useState<{ date: string; count: number } | null>(null);
 
@@ -46,7 +64,7 @@ export default function HeatmapWidget({ data, year = new Date().getFullYear() }:
     // Calculate stats
     const totalMinutes = data.reduce((sum, item) => sum + item.count, 0);
     const activeDays = data.filter(item => item.count > 0).length;
-    const maxStreak = 0; // Placeholder, would need logic to calculate from sorted dates
+    const maxStreak = computeMaxStreak(days);
 
     return (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
@@ -57,6 +75,7 @@ export default function HeatmapWidget({ data, year = new Date().getFullYear() }:
                     </h3>
                     <p className="text-gray-500 dark:text-gray-400 text-sm">
                         {totalMinutes} minutes focused across {activeDays} active days
+                        {maxStreak > 0 && ` · ${maxStreak}-day streak`}
                     </p>
                 </div>
 

--- a/web-app/src/lib/analytics-cache.ts
+++ b/web-app/src/lib/analytics-cache.ts
@@ -1,0 +1,21 @@
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
+
+/**
+ * Drop the cached analytics payload for a user across all periods so the
+ * next /api/analytics request returns fresh data instead of waiting up to
+ * 5 minutes for the TTL to expire after a session/activity write.
+ *
+ * Call this from any route that creates, updates, or deletes a session,
+ * activity log, or daily stats row.
+ */
+export async function invalidateAnalyticsCache(userId: string): Promise<void> {
+  try {
+    await Promise.all([
+      redis.del(`analytics:${userId}:week`),
+      redis.del(`analytics:${userId}:month`),
+    ]);
+  } catch (err) {
+    logger.warn('Analytics cache invalidation failed', err);
+  }
+}

--- a/web-app/src/lib/pusher.ts
+++ b/web-app/src/lib/pusher.ts
@@ -1,4 +1,5 @@
 import Pusher from 'pusher';
+import { logger } from './logger';
 
 export const pusher = new Pusher({
   appId:   process.env.PUSHER_APP_ID!,
@@ -9,13 +10,16 @@ export const pusher = new Pusher({
 });
 
 /**
- * Trigger a per-user channel event. Errors are swallowed so a Pusher
- * outage never breaks the main API response.
+ * Trigger a per-user channel event. Errors are logged (so a misconfigured
+ * key or outage isn't invisible) but never thrown — keeping the request
+ * path resilient when realtime is degraded.
  */
 export function triggerUserEvent(
   userId: string,
   event: string,
   data: object = {}
 ): void {
-  pusher.trigger(`user-${userId}`, event, data).catch(() => {});
+  pusher.trigger(`user-${userId}`, event, data).catch((err) => {
+    logger.warn('Pusher trigger failed', { userId, event, err });
+  });
 }


### PR DESCRIPTION
Realtime + analytics cluster — closes **#14, #15, #18, #19, #20**.

## #14 — Real-time events on project + goal writes
- `triggerUserEvent('project-update', { id, deleted? })` after PATCH and DELETE in `/api/projects/[id]/route.ts`.
- `triggerUserEvent('goal-update', { id })` after POST (create + update) in `/api/goals/route.ts`.
- Dashboards/widgets that subscribe will refresh on the next render instead of waiting for the 30 s SWR poll.

## #15 — Pusher errors no longer silently swallowed
`lib/pusher.ts:triggerUserEvent` now logs via `lib/logger` (Sentry-aware) before swallowing. A misconfigured key or outage becomes visible in logs / Sentry instead of "real-time just stopped" with no signal.

## #18 — Analytics cache invalidated on session writes
- New `lib/analytics-cache.ts` exposing `invalidateAnalyticsCache(userId)` which deletes both `analytics:{userId}:week` and `:month`.
- Wired into:
  - `POST /api/sessions` (start)
  - `PATCH /api/sessions/[id]` (update / complete)
  - `POST /api/sessions/[id]/auto-end`
- Dashboards now see fresh analytics within ~one request after a write instead of up to 5 minutes of stale TTL.

## #19 — Yearly heatmap timezone + maxStreak
- Yearly route reads `User.timezone` and formats dates via `Intl.DateTimeFormat('en-CA', { timeZone })`. Cells no longer shift by a day for users in negative-UTC timezones.
- `HeatmapWidget.computeMaxStreak()` walks the chronological days and returns the longest run of `count > 0`. The streak surfaces in the heatmap subtitle (was hardcoded 0).

## #20 — Distractions per-app percentage denominator
`topDistractions[].percentage` now divides by **`totalDistractionMinutes`** instead of `totalMinutes` (all activity). The previous denominator understated each app's share because productive time inflated it. Per-app numbers now answer "what fraction of distracting time was on this app" and roughly sum to 100% across the top 5.

The aggregate `distractionPercentage` field (line 124 in the API) keeps using `totalMinutes` since that's still the right "what % of activity was distracting" measure.

## Tests
- Updated `/api/projects/[id]/route.test.ts` to mock `@/lib/pusher` (the new `triggerUserEvent` call broke the green test).
- All 168 Vitest tests pass; `npm run lint` clean (0 errors); `npm run build` succeeds.

## Test plan
- [ ] Edit a project's cost → dashboard timer reflects the change without a 30 s wait
- [ ] Set a daily-time goal → goals widget updates immediately
- [ ] Complete a session → `/api/analytics?period=week` returns fresh `summary.totalFocusMinutes` (no 5-min stale window)
- [ ] User with `timezone: 'America/Los_Angeles'` and a session at 23:30 local → heatmap puts it on the local calendar day, not the next-day UTC slot
- [ ] User with 5 consecutive active days → heatmap shows "5-day streak" instead of nothing
- [ ] Distractions UI: top 5 percentages add up to ~100% (not artificially small)

🤖 Generated with [Claude Code](https://claude.com/claude-code)