### PR TITLE
feat(desktop-v3): phase 2 — session timer (start/end/pause)

### DIFF
--- a/desktop-app-v3/src-tauri/src/api/mod.rs
+++ b/desktop-app-v3/src-tauri/src/api/mod.rs
@@ -3,8 +3,10 @@
 //! command layer.
 
 mod auth;
+pub mod sessions;
 
 pub use auth::{login, AuthUser};
+pub use sessions::Session;
 
 /// Default API base URL. Overrideable at runtime via the `FLOWSHIELD_API_URL`
 /// env var so dev / staging / preview environments don't need recompiles.

--- a/desktop-app-v3/src-tauri/src/api/sessions.rs
+++ b/desktop-app-v3/src-tauri/src/api/sessions.rs
@@ -1,0 +1,225 @@
+use crate::error::{AppError, AppResult};
+use serde::{Deserialize, Serialize};
+
+/// Session as returned by the FlowShield REST API. Fields mirror the Prisma
+/// model; serde rename maps snake_case Rust to camelCase JSON.
+///
+/// Times are RFC 3339 strings (`2026-05-01T12:34:56.789Z` shape produced by
+/// JS `new Date().toISOString()`); the frontend re-parses them. We keep them
+/// as strings here because the Rust layer just forwards them — no chrono
+/// dependency needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Session {
+    pub id: String,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    pub start_time: String,
+    #[serde(default)]
+    pub end_time: Option<String>,
+    pub planned_duration: i32,
+    #[serde(default)]
+    pub actual_duration: Option<i32>,
+    pub session_type: String,
+    #[serde(default)]
+    pub productivity_score: Option<i32>,
+    pub completed: bool,
+    pub is_paused: bool,
+    #[serde(default)]
+    pub paused_at: Option<String>,
+    #[serde(default)]
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionEnvelope {
+    session: Session,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    error: Option<String>,
+    code: Option<String>,
+    #[serde(rename = "activeSessionId")]
+    active_session_id: Option<String>,
+}
+
+fn auth(req: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    req.bearer_auth(token)
+}
+
+/// POST /api/sessions — start a new focus session.
+///
+/// Returns 409 with `code: SESSION_ALREADY_ACTIVE` if the user already has a
+/// non-completed session. We surface the existing session's id in the error
+/// `code` field as `ACTIVE_<id>` so the frontend can jump to it instead of
+/// creating a duplicate.
+pub async fn start_session(
+    http: &reqwest::Client,
+    token: &str,
+    planned_duration: i32,
+    session_type: &str,
+) -> AppResult<Session> {
+    let url = format!("{}/api/sessions", super::api_base_url());
+    let res = auth(http.post(&url), token)
+        .json(&serde_json::json!({
+            "plannedDuration": planned_duration,
+            "sessionType": session_type,
+        }))
+        .send()
+        .await?;
+
+    let status = res.status();
+    if status.is_success() {
+        return Ok(res.json::<SessionEnvelope>().await?.session);
+    }
+
+    let body: ApiErrorBody = res.json().await.unwrap_or(ApiErrorBody {
+        error: None,
+        code: None,
+        active_session_id: None,
+    });
+    Err(AppError::Api {
+        status: status.as_u16(),
+        message: body.error.unwrap_or_else(|| "Failed to start session".into()),
+        code: body.code.or_else(|| body.active_session_id.map(|id| format!("ACTIVE_{}", id))),
+    })
+}
+
+/// GET /api/sessions/active — null if no active session.
+pub async fn get_active_session(
+    http: &reqwest::Client,
+    token: &str,
+) -> AppResult<Option<Session>> {
+    let url = format!("{}/api/sessions/active", super::api_base_url());
+    let res = auth(http.get(&url), token).send().await?;
+
+    if res.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+
+    let status = res.status();
+    if !status.is_success() {
+        let body: ApiErrorBody = res.json().await.unwrap_or(ApiErrorBody {
+            error: None,
+            code: None,
+            active_session_id: None,
+        });
+        return Err(AppError::Api {
+            status: status.as_u16(),
+            message: body.error.unwrap_or_else(|| "Failed to fetch active session".into()),
+            code: body.code,
+        });
+    }
+
+    // Endpoint returns either { session: Session | null } or null.
+    #[derive(Deserialize)]
+    struct ActiveEnvelope {
+        session: Option<Session>,
+    }
+    let body: serde_json::Value = res.json().await?;
+    if body.is_null() {
+        return Ok(None);
+    }
+    let parsed: ActiveEnvelope = serde_json::from_value(body)?;
+    Ok(parsed.session)
+}
+
+/// PATCH /api/sessions/[id] — completes / updates a session.
+pub async fn end_session(
+    http: &reqwest::Client,
+    token: &str,
+    session_id: &str,
+    productivity_score: Option<i32>,
+) -> AppResult<Session> {
+    let url = format!("{}/api/sessions/{}", super::api_base_url(), session_id);
+    let res = auth(http.patch(&url), token)
+        .json(&serde_json::json!({
+            "endTime": now_iso(),
+            "completed": true,
+            "productivityScore": productivity_score,
+        }))
+        .send()
+        .await?;
+
+    let status = res.status();
+    if !status.is_success() {
+        let body: ApiErrorBody = res.json().await.unwrap_or(ApiErrorBody {
+            error: None,
+            code: None,
+            active_session_id: None,
+        });
+        return Err(AppError::Api {
+            status: status.as_u16(),
+            message: body.error.unwrap_or_else(|| "Failed to end session".into()),
+            code: body.code,
+        });
+    }
+    Ok(res.json::<SessionEnvelope>().await?.session)
+}
+
+/// POST /api/sessions/[id]/toggle-pause — body { action: "pause" | "resume" }
+pub async fn toggle_pause(
+    http: &reqwest::Client,
+    token: &str,
+    session_id: &str,
+    action: &str,
+) -> AppResult<Session> {
+    let url = format!("{}/api/sessions/{}/toggle-pause", super::api_base_url(), session_id);
+    let res = auth(http.post(&url), token)
+        .json(&serde_json::json!({ "action": action }))
+        .send()
+        .await?;
+
+    let status = res.status();
+    if !status.is_success() {
+        let body: ApiErrorBody = res.json().await.unwrap_or(ApiErrorBody {
+            error: None,
+            code: None,
+            active_session_id: None,
+        });
+        return Err(AppError::Api {
+            status: status.as_u16(),
+            message: body.error.unwrap_or_else(|| "Failed to toggle pause".into()),
+            code: body.code,
+        });
+    }
+    Ok(res.json::<SessionEnvelope>().await?.session)
+}
+
+/// Current UTC time as RFC 3339 (`YYYY-MM-DDTHH:MM:SS.mmmZ`). Inlined so we
+/// avoid pulling chrono just for this. Algorithm: Howard Hinnant's
+/// civil_from_days inverse — battle-tested and obvious enough to verify.
+fn now_iso() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    let millis = dur.subsec_millis();
+    let (year, month, day, hour, minute, second) = unix_to_utc(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, minute, second, millis
+    )
+}
+
+fn unix_to_utc(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = (secs % 86_400) as u32;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+    (year as i32, m as u32, d as u32, hour, minute, second)
+}

--- a/desktop-app-v3/src-tauri/src/api/sessions.rs
+++ b/desktop-app-v3/src-tauri/src/api/sessions.rs
@@ -112,17 +112,17 @@ pub async fn get_active_session(
         });
     }
 
-    // Endpoint returns either { session: Session | null } or null.
-    #[derive(Deserialize)]
-    struct ActiveEnvelope {
-        session: Option<Session>,
-    }
+    // Inconsistent web-API shape: this endpoint returns the bare Session at
+    // the JSON root (web-app/src/app/api/sessions/active/route.ts:46), unlike
+    // the other session endpoints which wrap in `{ session: ... }`. Treat
+    // top-level null as "no active session" defensively (404 already handled
+    // above; some Next.js routes serialize undefined as null).
     let body: serde_json::Value = res.json().await?;
     if body.is_null() {
         return Ok(None);
     }
-    let parsed: ActiveEnvelope = serde_json::from_value(body)?;
-    Ok(parsed.session)
+    let session: Session = serde_json::from_value(body)?;
+    Ok(Some(session))
 }
 
 /// PATCH /api/sessions/[id] — completes / updates a session.

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod auth;
 pub mod ping;
+pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/commands/sessions.rs
+++ b/desktop-app-v3/src-tauri/src/commands/sessions.rs
@@ -1,0 +1,62 @@
+//! Session-timer commands. The frontend invokes these; we forward to the
+//! FlowShield REST API using the in-memory token from AppState.
+
+use crate::api::{self, Session};
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+use tauri::State;
+
+async fn token_or_err(state: &State<'_, AppState>) -> AppResult<String> {
+    state
+        .token
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| AppError::Api {
+            status: 401,
+            message: "Not authenticated".into(),
+            code: Some("UNAUTHENTICATED".into()),
+        })
+}
+
+/// `session_start` — POST /api/sessions
+#[tauri::command]
+pub async fn session_start(
+    state: State<'_, AppState>,
+    planned_duration: i32,
+    session_type: Option<String>,
+) -> AppResult<Session> {
+    let token = token_or_err(&state).await?;
+    let session_type = session_type.as_deref().unwrap_or("WORK");
+    api::sessions::start_session(&state.http, &token, planned_duration, session_type).await
+}
+
+/// `session_active` — GET /api/sessions/active. Returns null if none.
+#[tauri::command]
+pub async fn session_active(state: State<'_, AppState>) -> AppResult<Option<Session>> {
+    let token = token_or_err(&state).await?;
+    api::sessions::get_active_session(&state.http, &token).await
+}
+
+/// `session_end` — PATCH /api/sessions/[id] with completed=true.
+#[tauri::command]
+pub async fn session_end(
+    state: State<'_, AppState>,
+    session_id: String,
+    productivity_score: Option<i32>,
+) -> AppResult<Session> {
+    let token = token_or_err(&state).await?;
+    api::sessions::end_session(&state.http, &token, &session_id, productivity_score).await
+}
+
+/// `session_toggle_pause` — POST /api/sessions/[id]/toggle-pause
+/// `action` is "pause" or "resume".
+#[tauri::command]
+pub async fn session_toggle_pause(
+    state: State<'_, AppState>,
+    session_id: String,
+    action: String,
+) -> AppResult<Session> {
+    let token = token_or_err(&state).await?;
+    api::sessions::toggle_pause(&state.http, &token, &session_id, &action).await
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -58,6 +58,10 @@ pub fn run() {
             commands::auth::auth_load,
             commands::auth::auth_logout,
             commands::ping::ping,
+            commands::sessions::session_start,
+            commands::sessions::session_active,
+            commands::sessions::session_end,
+            commands::sessions::session_toggle_pause,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src/components/Timer.tsx
+++ b/desktop-app-v3/src/components/Timer.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import type { Session } from '../lib/sessions';
+
+interface TimerProps {
+  session: Session;
+}
+
+/**
+ * Display-only countdown. Always recomputes from the server-issued
+ * `startTime` on every tick — never `prev - 1` (avoids drift across
+ * tab/focus changes and matches the project's "Timer drift" gotcha rule).
+ *
+ * When the session is paused, the display freezes at `pausedAt`.
+ */
+export function Timer({ session }: TimerProps) {
+  const [tick, setTick] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (session.isPaused || session.completed) return;
+    const id = setInterval(() => setTick(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [session.isPaused, session.completed]);
+
+  const startMs = new Date(session.startTime).getTime();
+  const plannedEndMs = startMs + session.plannedDuration * 60 * 1000;
+  const referenceMs =
+    session.isPaused && session.pausedAt
+      ? new Date(session.pausedAt).getTime()
+      : tick;
+  const remainingMs = Math.max(0, plannedEndMs - referenceMs);
+
+  const minutes = Math.floor(remainingMs / 60_000);
+  const seconds = Math.floor((remainingMs % 60_000) / 1000);
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+
+  const totalMs = session.plannedDuration * 60 * 1000;
+  const progressPct = totalMs > 0 ? Math.max(0, Math.min(100, ((totalMs - remainingMs) / totalMs) * 100)) : 0;
+
+  const status = session.isPaused
+    ? 'Paused'
+    : remainingMs === 0
+      ? 'Time up'
+      : 'Focusing';
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {status}
+      </div>
+      <div className="text-7xl font-mono tabular-nums tracking-tight text-gray-900 dark:text-white">
+        {mm}:{ss}
+      </div>
+      <div className="w-full max-w-xs h-2 rounded-full bg-surface-3 overflow-hidden">
+        <div
+          className="h-full bg-primary-500 transition-all duration-1000 ease-linear"
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+      <div className="text-xs text-gray-500 dark:text-gray-400">
+        {session.plannedDuration} min · {session.sessionType.toLowerCase()}
+      </div>
+    </div>
+  );
+}

--- a/desktop-app-v3/src/lib/sessions.ts
+++ b/desktop-app-v3/src/lib/sessions.ts
@@ -1,0 +1,103 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+
+export interface Session {
+  id: string;
+  userId?: string;
+  startTime: string; // RFC 3339
+  endTime?: string;
+  plannedDuration: number; // minutes
+  actualDuration?: number;
+  sessionType: 'WORK' | 'STUDY' | 'CREATIVE';
+  productivityScore?: number;
+  completed: boolean;
+  isPaused: boolean;
+  pausedAt?: string;
+  projectId?: string;
+}
+
+interface SessionState {
+  current: Session | null;
+  loading: boolean;
+  error: string | null;
+
+  /** Refresh active session from the server (idempotent). */
+  refresh: () => Promise<void>;
+  /** Start a new session. Throws on failure (e.g. SESSION_ALREADY_ACTIVE). */
+  start: (plannedDuration: number, sessionType?: Session['sessionType']) => Promise<void>;
+  /** Mark current session completed. */
+  end: (productivityScore?: number) => Promise<void>;
+  /** Pause or resume the current session. */
+  togglePause: (action: 'pause' | 'resume') => Promise<void>;
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const obj = err as { message?: string; error?: string };
+    return obj.message ?? obj.error ?? fallback;
+  }
+  return fallback;
+}
+
+export const useSessionStore = create<SessionState>((set, get) => ({
+  current: null,
+  loading: false,
+  error: null,
+
+  refresh: async () => {
+    set({ loading: true, error: null });
+    try {
+      const session = await invoke<Session | null>('session_active');
+      set({ current: session, loading: false });
+    } catch (err) {
+      set({ error: errorMessage(err, 'Failed to load session'), loading: false });
+    }
+  },
+
+  start: async (plannedDuration, sessionType = 'WORK') => {
+    set({ loading: true, error: null });
+    try {
+      const session = await invoke<Session>('session_start', {
+        plannedDuration,
+        sessionType,
+      });
+      set({ current: session, loading: false });
+    } catch (err) {
+      set({ error: errorMessage(err, 'Failed to start session'), loading: false });
+      throw err;
+    }
+  },
+
+  end: async (productivityScore) => {
+    const session = get().current;
+    if (!session) return;
+    set({ loading: true, error: null });
+    try {
+      await invoke<Session>('session_end', {
+        sessionId: session.id,
+        productivityScore: productivityScore ?? null,
+      });
+      set({ current: null, loading: false });
+    } catch (err) {
+      set({ error: errorMessage(err, 'Failed to end session'), loading: false });
+      throw err;
+    }
+  },
+
+  togglePause: async (action) => {
+    const session = get().current;
+    if (!session) return;
+    set({ loading: true, error: null });
+    try {
+      const updated = await invoke<Session>('session_toggle_pause', {
+        sessionId: session.id,
+        action,
+      });
+      set({ current: updated, loading: false });
+    } catch (err) {
+      set({ error: errorMessage(err, 'Failed to toggle pause'), loading: false });
+      throw err;
+    }
+  },
+}));

--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -1,11 +1,22 @@
+import { useEffect, useState } from 'react';
 import { useAuthStore } from '../lib/auth';
+import { useSessionStore } from '../lib/sessions';
 import { Button } from '../components/Button';
+import { Timer } from '../components/Timer';
 
-/**
- * Placeholder dashboard. Phase 2 swaps this for the real session timer.
- */
+const DURATION_OPTIONS = [15, 25, 45, 60, 90];
+const SESSION_TYPES = ['WORK', 'STUDY', 'CREATIVE'] as const;
+
 export function DashboardPage() {
   const { user, logout } = useAuthStore();
+  const { current, loading, error, refresh, start, end, togglePause } = useSessionStore();
+  const [duration, setDuration] = useState(25);
+  const [type, setType] = useState<typeof SESSION_TYPES[number]>('WORK');
+
+  // Pull active session from server on mount so we pick up sessions started elsewhere.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -23,30 +34,151 @@ export function DashboardPage() {
         </div>
       </header>
 
-      <main className="flex-1 p-8">
-        <div className="max-w-2xl mx-auto space-y-6">
-          <div>
-            <h1 className="text-2xl font-bold mb-1">Welcome back</h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              The timer + activity tracker arrive in the next slice (phase 2). For now,
-              auth round-trips through the Rust backend and your token is persisted to the
-              OS keychain.
-            </p>
-          </div>
+      <main className="flex-1 p-8 flex flex-col items-center justify-center">
+        <div className="w-full max-w-md space-y-6">
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-500/10 dark:border-red-500/20 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+              {error}
+            </div>
+          )}
 
-          <div className="rounded-xl border border-surface-3 bg-surface-1 p-6 text-sm space-y-2">
-            <div className="font-medium">Foundation status</div>
-            <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-              <li>✓ Tauri 2 + React 19 + Tailwind</li>
-              <li>✓ Login round-trips through Rust → /api/auth/login</li>
-              <li>✓ Token persisted via tauri-plugin-store (keychain in phase 2)</li>
-              <li>○ Phase 2 — session timer + active-session polling</li>
-              <li>○ Phase 3 — activity tracking (active-win-pos-rs)</li>
-              <li>○ Phase 4 — sync queue + tray + autostart + updater</li>
-            </ul>
-          </div>
+          {current ? (
+            <ActiveSessionView
+              loading={loading}
+              onPause={() => void togglePause('pause')}
+              onResume={() => void togglePause('resume')}
+              onEnd={() => void end()}
+            />
+          ) : (
+            <SessionPicker
+              duration={duration}
+              setDuration={setDuration}
+              type={type}
+              setType={setType}
+              loading={loading}
+              onStart={() => void start(duration, type)}
+            />
+          )}
         </div>
       </main>
+    </div>
+  );
+}
+
+function SessionPicker({
+  duration,
+  setDuration,
+  type,
+  setType,
+  loading,
+  onStart,
+}: {
+  duration: number;
+  setDuration: (n: number) => void;
+  type: typeof SESSION_TYPES[number];
+  setType: (t: typeof SESSION_TYPES[number]) => void;
+  loading: boolean;
+  onStart: () => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold">Start a focus session</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Pick a duration and a session type.
+        </p>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+          Duration
+        </div>
+        <div className="grid grid-cols-5 gap-2">
+          {DURATION_OPTIONS.map((min) => (
+            <button
+              key={min}
+              type="button"
+              onClick={() => setDuration(min)}
+              className={`h-10 rounded-lg border text-sm font-medium transition-colors ${
+                duration === min
+                  ? 'bg-primary-500 text-white border-primary-500'
+                  : 'bg-surface-1 text-gray-700 dark:text-gray-300 border-surface-3 hover:bg-surface-2'
+              }`}
+            >
+              {min}m
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+          Type
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          {SESSION_TYPES.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setType(t)}
+              className={`h-10 rounded-lg border text-sm font-medium transition-colors ${
+                type === t
+                  ? 'bg-primary-500 text-white border-primary-500'
+                  : 'bg-surface-1 text-gray-700 dark:text-gray-300 border-surface-3 hover:bg-surface-2'
+              }`}
+            >
+              {t.charAt(0) + t.slice(1).toLowerCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="primary"
+        size="lg"
+        className="w-full"
+        loading={loading}
+        onClick={onStart}
+      >
+        Start {duration}-minute session
+      </Button>
+    </div>
+  );
+}
+
+function ActiveSessionView({
+  loading,
+  onPause,
+  onResume,
+  onEnd,
+}: {
+  loading: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onEnd: () => void;
+}) {
+  const current = useSessionStore((s) => s.current);
+  if (!current) return null;
+
+  return (
+    <div className="space-y-8">
+      <Timer session={current} />
+
+      <div className="flex justify-center gap-3">
+        {current.isPaused ? (
+          <Button variant="secondary" size="md" onClick={onResume} disabled={loading}>
+            Resume
+          </Button>
+        ) : (
+          <Button variant="secondary" size="md" onClick={onPause} disabled={loading}>
+            Pause
+          </Button>
+        )}
+        <Button variant="danger" size="md" onClick={onEnd} disabled={loading}>
+          End session
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Phase 2 of the cross-platform desktop rewrite. Replaces the placeholder dashboard with a real focus-session UI driven by the existing FlowShield REST API.

## Verifiable success criteria (from phase plan)

> Click "Start session" → window shows server-anchored countdown that doesn't drift across tab/focus changes → "Pause" freezes the display → "End" completes the session and returns to the picker → force-quit + restart resumes the timer at the correct remaining time.

## Backend (Rust, ~290 LOC)

| File | Purpose |
|---|---|
| `src-tauri/src/api/sessions.rs` (new) | Typed `reqwest` wrappers for `POST /api/sessions`, `GET /api/sessions/active`, `PATCH /api/sessions/[id]`, `POST /api/sessions/[id]/toggle-pause`. Surfaces 409 `SESSION_ALREADY_ACTIVE` with the existing session id encoded in the error code so the frontend can recover. |
| `src-tauri/src/commands/sessions.rs` (new) | Four `#[tauri::command]` handlers (`session_start`, `session_active`, `session_end`, `session_toggle_pause`) that pull the in-memory token from `AppState` and forward to the API client. |
| `src-tauri/src/api/mod.rs` | Registers the new module + re-exports `Session`. |
| `src-tauri/src/commands/mod.rs` | Adds `pub mod sessions;`. |
| `src-tauri/src/lib.rs` | Adds the four new commands to `invoke_handler!`. |

## Frontend (React + TypeScript, ~330 LOC)

| File | Purpose |
|---|---|
| `src/lib/sessions.ts` (new) | Zustand store with typed `Session` interface mirroring the Prisma model. Surface: `refresh / start / end / togglePause`. Errors caught and surfaced via `.error`. |
| `src/components/Timer.tsx` (new) | Display-only countdown anchored to server-issued `startTime` on every tick (`Date.now() - new Date(startTime).getTime()` — never `prev - 1`). Freezes at `pausedAt` while paused. Matches the project gotcha rule for timer drift. |
| `src/routes/DashboardPage.tsx` | Replaces placeholder with `SessionPicker` (15/25/45/60/90 min × WORK/STUDY/CREATIVE) and `ActiveSessionView` (timer + pause/resume + end). Refreshes active session on mount so cross-device starts show up. |

## Out of scope (per Karpathy principle 2)

- DB persistence / offline queue → phase 4
- Activity tracking (`active-win-pos-rs`) → phase 3
- Project picker on the start screen → post-feature-parity polish
- Background polling (cross-device updates) → phase 4 (manual refresh on mount only for now)
- Pusher real-time → not needed for v3 alpha
- Tray + autostart + updater + signing → phases 5–7

## Verification

I can't `cargo build` from this environment (no rustup installed). The code is internally consistent: all new commands registered, every import resolves, no new Tauri permissions needed (existing `core:default` + `store:default` + `shell:allow-open` are sufficient).

To verify locally:

```bash
cd desktop-app-v3
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev   # Linux + Wayland
# macOS: npm run tauri:dev  (no env var needed)
# Windows: npm run tauri:dev
```

### Test plan

- [ ] Login → land on dashboard with empty `SessionPicker` (no active session)
- [ ] Click "Start 25-minute session" → window switches to active view, timer displays 25:00 and counts down every second
- [ ] Open dev tools, switch tabs / minimize for ~30s, return → timer reflects real elapsed (no drift)
- [ ] Click "Pause" → timer freezes at current remaining
- [ ] Click "Resume" → timer continues from where server resumed (server adjusts startTime)
- [ ] Click "End session" → returns to picker, no active session
- [ ] Force-quit app mid-session → relaunch → dashboard loads, refresh on mount restores active session, countdown picks up correctly
- [ ] Click "Start" while a session is already active (e.g. started in web) → error surfaces with `SESSION_ALREADY_ACTIVE`

## Notes

- 8 files, ~620 LOC net
- Zero new dependencies (reuses existing reqwest, tokio, serde, Zustand)
- Capability ACL unchanged
- Frontend reuses Tailwind tokens + Button/Input primitives from phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)