### PR TITLE
feat(desktop-v3): phase 4 — offline activity-sync queue

### DIFF
--- a/desktop-app-v3/src-tauri/Cargo.toml
+++ b/desktop-app-v3/src-tauri/Cargo.toml
@@ -30,6 +30,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 # Wraps Win32 / Cocoa / X11 / Wayland under one Result-returning surface.
 active-win-pos-rs = "0.8"
 
+# Local persistent store for the offline activity-sync queue. `bundled`
+# pulls a vendored sqlite3 so the desktop installer doesn't depend on
+# the user having libsqlite3 (matters on Windows + minimal macOS images).
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 thiserror   = "1"

--- a/desktop-app-v3/src-tauri/src/commands/sessions.rs
+++ b/desktop-app-v3/src-tauri/src/commands/sessions.rs
@@ -9,6 +9,7 @@
 
 use crate::api::{self, Session};
 use crate::error::{AppError, AppResult};
+use crate::store;
 use crate::tracker::TrackerHandle;
 use crate::AppState;
 use tauri::State;
@@ -96,6 +97,8 @@ pub async fn session_end(
     };
 
     // Best-effort sync — failure here does NOT fail the end.
+    // On failure, we persist the payload to the local SQLite queue so the
+    // background drainer can retry later (network blip, server hiccup).
     if !samples.is_empty() {
         let count = samples.len();
         match api::activity::sync_activity(&state.http, &token, &session_id, &samples).await {
@@ -103,11 +106,16 @@ pub async fn session_end(
                 synced = result.synced.unwrap_or(count as i32),
                 "activity samples synced"
             ),
-            Err(err) => tracing::warn!(
-                count,
-                ?err,
-                "activity sync failed; samples lost (phase 4 adds offline retry)"
-            ),
+            Err(err) => {
+                tracing::warn!(count, ?err, "activity sync failed; enqueueing for retry");
+                if let Some(db) = state.db.get() {
+                    if let Err(e) = store::pending_sync::enqueue(db, &session_id, &samples) {
+                        tracing::error!(?e, count, "failed to enqueue pending sync; samples lost");
+                    }
+                } else {
+                    tracing::warn!(count, "local store unavailable; samples lost");
+                }
+            }
         }
     }
 

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -4,9 +4,12 @@
 mod api;
 mod commands;
 mod error;
+mod store;
+mod sync_worker;
 mod tracker;
 
 use std::sync::Arc;
+use tauri::Manager;
 use tokio::sync::RwLock;
 
 pub use error::AppError;
@@ -16,12 +19,16 @@ pub use error::AppError;
 /// store on first read so commands don't pay the IPC round-trip every call.
 /// `tracker` holds the activity-monitoring task while a session is running;
 /// session_start populates it, session_end takes() it and drains the buffer.
+/// `db` is opened lazily in `setup()` once we can resolve the OS app-data
+/// directory; it stays `None` in test/headless contexts and the offline
+/// queue is treated as a best-effort feature when absent.
 #[derive(Default)]
 pub struct AppState {
     pub token: Arc<RwLock<Option<String>>>,
     pub user: Arc<RwLock<Option<api::AuthUser>>>,
     pub http: reqwest::Client,
     pub tracker: Arc<RwLock<Option<tracker::TrackerHandle>>>,
+    pub db: Arc<std::sync::OnceLock<store::Db>>,
 }
 
 impl AppState {
@@ -40,6 +47,7 @@ impl AppState {
             user: Arc::new(RwLock::new(None)),
             http,
             tracker: Arc::new(RwLock::new(None)),
+            db: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -59,6 +67,28 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
         .manage(AppState::new())
+        .setup(|app| {
+            // Open the local SQLite store under the OS app-data directory.
+            // If this fails (read-only FS, weird sandbox, …) we log + skip:
+            // the app still works, the offline-sync queue is just unavailable.
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| format!("resolve app_data_dir: {e}"))?;
+            let db_path = app_data_dir.join("local.sqlite");
+            match store::open(&db_path) {
+                Ok(db) => {
+                    let state: tauri::State<'_, AppState> = app.state();
+                    let _ = state.db.set(db.clone());
+                    sync_worker::spawn(state.http.clone(), state.token.clone(), db);
+                    tracing::info!(path = %db_path.display(), "local store opened");
+                }
+                Err(err) => {
+                    tracing::warn!(?err, path = %db_path.display(), "local store unavailable; offline queue disabled");
+                }
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::auth::auth_login,
             commands::auth::auth_load,

--- a/desktop-app-v3/src-tauri/src/store/mod.rs
+++ b/desktop-app-v3/src-tauri/src/store/mod.rs
@@ -1,0 +1,63 @@
+//! Local persistent store backing offline features. Phase 4 introduces
+//! this as a tiny SQLite database living under the OS-conventional app-data
+//! directory (`~/.local/share/FlowShield/local.sqlite` on Linux, equivalent
+//! on macOS/Windows).
+//!
+//! The only resident today is `pending_activity_sync` — payloads from
+//! `/api/activity/sync` requests that failed at session-end so a background
+//! worker can retry them later. A future phase can bolt on more tables
+//! (cached preferences, blocked-domains list, …) without moving the file.
+//!
+//! Threading: rusqlite's `Connection` is `!Sync`, so a single
+//! `Arc<Mutex<Connection>>` is shared and every operation locks. Lock
+//! durations are microseconds (one statement at a time) — sufficient until
+//! we have a reason to switch to a connection pool.
+
+use crate::error::{AppError, AppResult};
+use rusqlite::Connection;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+pub mod pending_sync;
+
+pub type Db = Arc<Mutex<Connection>>;
+
+/// Open the local SQLite database, creating + migrating the schema if
+/// needed. The parent directory is created on first launch.
+pub fn open(path: &Path) -> AppResult<Db> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AppError::Storage(format!("create db dir: {e}")))?;
+    }
+    let conn =
+        Connection::open(path).map_err(|e| AppError::Storage(format!("open db: {e}")))?;
+    // WAL gives us crash-safe writes and concurrent readers; NORMAL
+    // synchronous trades the last few writes' durability on a hard kill
+    // for ~10x write throughput — acceptable since the source data
+    // (in-memory tracker buffer) is already gone in that scenario.
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;\n\
+         PRAGMA synchronous = NORMAL;\n\
+         PRAGMA foreign_keys = ON;",
+    )
+    .map_err(|e| AppError::Storage(format!("pragma: {e}")))?;
+    apply_migrations(&conn)?;
+    Ok(Arc::new(Mutex::new(conn)))
+}
+
+fn apply_migrations(conn: &Connection) -> AppResult<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS pending_activity_sync (\n\
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,\n\
+            session_id    TEXT    NOT NULL,\n\
+            payload       TEXT    NOT NULL,\n\
+            retry_count   INTEGER NOT NULL DEFAULT 0,\n\
+            created_at    INTEGER NOT NULL,\n\
+            next_retry_at INTEGER NOT NULL\n\
+         );\n\
+         CREATE INDEX IF NOT EXISTS idx_pending_activity_next_retry\n\
+            ON pending_activity_sync (next_retry_at);",
+    )
+    .map_err(|e| AppError::Storage(format!("migrate: {e}")))?;
+    Ok(())
+}

--- a/desktop-app-v3/src-tauri/src/store/pending_sync.rs
+++ b/desktop-app-v3/src-tauri/src/store/pending_sync.rs
@@ -1,0 +1,161 @@
+//! `pending_activity_sync` queue — payloads that failed to POST at
+//! session-end, persisted so a background worker can retry later.
+//!
+//! Bounded at 500 rows / 7-day TTL. On each enqueue we purge rows older
+//! than `MAX_AGE_SECS` and, if still over `MAX_ROWS`, drop the oldest by
+//! `created_at`. Same invariants the v2 desktop's `PendingOperations`
+//! used so users moving between v2 ↔ v3 see consistent behavior.
+
+use super::Db;
+use crate::error::{AppError, AppResult};
+use crate::tracker::ActivitySample;
+
+const MAX_ROWS: i64 = 500;
+const MAX_AGE_SECS: i64 = 7 * 24 * 60 * 60; // 7 days
+
+/// Exponential backoff between retries: `min(5min · 2^retry, 30min)`.
+/// Same shape v2 desktop used. Retry counts above 8 saturate at the cap.
+pub fn backoff_secs(retry_count: i64) -> i64 {
+    let base: i64 = 5 * 60;
+    let cap: i64 = 30 * 60;
+    let exp = retry_count.clamp(0, 8) as u32;
+    base.saturating_mul(2_i64.saturating_pow(exp)).min(cap)
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingRow {
+    pub id: i64,
+    pub session_id: String,
+    pub samples: Vec<ActivitySample>,
+    pub retry_count: i64,
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn lock(db: &Db) -> AppResult<std::sync::MutexGuard<'_, rusqlite::Connection>> {
+    db.lock()
+        .map_err(|_| AppError::Storage("db mutex poisoned".into()))
+}
+
+/// Persist a failed sync payload for later retry.
+pub fn enqueue(db: &Db, session_id: &str, samples: &[ActivitySample]) -> AppResult<()> {
+    let payload = serde_json::to_string(samples)?;
+    let now = now_secs();
+    let conn = lock(db)?;
+    conn.execute(
+        "INSERT INTO pending_activity_sync\n\
+         (session_id, payload, retry_count, created_at, next_retry_at)\n\
+         VALUES (?1, ?2, 0, ?3, ?3)",
+        rusqlite::params![session_id, payload, now],
+    )
+    .map_err(|e| AppError::Storage(format!("enqueue: {e}")))?;
+    purge_locked(&conn, now)?;
+    Ok(())
+}
+
+/// Fetch up to `limit` rows whose `next_retry_at <= now`, oldest first.
+pub fn ready_rows(db: &Db, limit: i64) -> AppResult<Vec<PendingRow>> {
+    let now = now_secs();
+    let conn = lock(db)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, session_id, payload, retry_count\n\
+             FROM pending_activity_sync\n\
+             WHERE next_retry_at <= ?1\n\
+             ORDER BY created_at ASC\n\
+             LIMIT ?2",
+        )
+        .map_err(|e| AppError::Storage(format!("ready_rows prepare: {e}")))?;
+    let rows = stmt
+        .query_map(rusqlite::params![now, limit], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(|e| AppError::Storage(format!("ready_rows query: {e}")))?;
+    let mut out = Vec::new();
+    for r in rows {
+        let (id, session_id, payload, retry_count) =
+            r.map_err(|e| AppError::Storage(format!("ready_rows row: {e}")))?;
+        let samples: Vec<ActivitySample> = serde_json::from_str(&payload)?;
+        out.push(PendingRow {
+            id,
+            session_id,
+            samples,
+            retry_count,
+        });
+    }
+    Ok(out)
+}
+
+pub fn delete(db: &Db, id: i64) -> AppResult<()> {
+    let conn = lock(db)?;
+    conn.execute(
+        "DELETE FROM pending_activity_sync WHERE id = ?1",
+        rusqlite::params![id],
+    )
+    .map_err(|e| AppError::Storage(format!("delete: {e}")))?;
+    Ok(())
+}
+
+/// Bump retry count + schedule next attempt via `backoff_secs(retry+1)`.
+pub fn record_failure(db: &Db, id: i64, retry_count: i64) -> AppResult<()> {
+    let next = now_secs() + backoff_secs(retry_count + 1);
+    let conn = lock(db)?;
+    conn.execute(
+        "UPDATE pending_activity_sync\n\
+         SET retry_count = ?1, next_retry_at = ?2\n\
+         WHERE id = ?3",
+        rusqlite::params![retry_count + 1, next, id],
+    )
+    .map_err(|e| AppError::Storage(format!("record_failure: {e}")))?;
+    Ok(())
+}
+
+/// Drop rows older than `MAX_AGE_SECS`, then if still over `MAX_ROWS`,
+/// drop the oldest until we're under the cap. Called on each enqueue.
+fn purge_locked(conn: &rusqlite::Connection, now: i64) -> AppResult<()> {
+    conn.execute(
+        "DELETE FROM pending_activity_sync WHERE created_at < ?1",
+        rusqlite::params![now - MAX_AGE_SECS],
+    )
+    .map_err(|e| AppError::Storage(format!("purge ttl: {e}")))?;
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pending_activity_sync", [], |r| r.get(0))
+        .map_err(|e| AppError::Storage(format!("purge count: {e}")))?;
+    if count > MAX_ROWS {
+        let excess = count - MAX_ROWS;
+        conn.execute(
+            "DELETE FROM pending_activity_sync WHERE id IN (\n\
+                SELECT id FROM pending_activity_sync\n\
+                ORDER BY created_at ASC LIMIT ?1\n\
+             )",
+            rusqlite::params![excess],
+        )
+        .map_err(|e| AppError::Storage(format!("purge cap: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_caps_at_30min() {
+        assert_eq!(backoff_secs(0), 5 * 60);
+        assert_eq!(backoff_secs(1), 10 * 60);
+        assert_eq!(backoff_secs(2), 20 * 60);
+        assert_eq!(backoff_secs(3), 30 * 60);
+        assert_eq!(backoff_secs(8), 30 * 60);
+        assert_eq!(backoff_secs(99), 30 * 60);
+    }
+}

--- a/desktop-app-v3/src-tauri/src/sync_worker.rs
+++ b/desktop-app-v3/src-tauri/src/sync_worker.rs
@@ -1,0 +1,71 @@
+//! Background drainer for `pending_activity_sync`. Wakes every minute,
+//! picks rows whose `next_retry_at <= now`, retries the POST, and either
+//! deletes (success) or schedules backoff (failure).
+//!
+//! Spawned once on app launch. Skips work silently when:
+//!   - the user is signed out (no token), or
+//!   - the queue is empty (no rows to drain).
+
+use crate::api;
+use crate::store::{self, Db};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+const TICK_SECS: u64 = 60;
+const BATCH_SIZE: i64 = 16;
+
+pub fn spawn(http: reqwest::Client, token: Arc<RwLock<Option<String>>>, db: Db) {
+    tokio::spawn(async move {
+        // `tokio::time::interval` ticks immediately on the first call,
+        // so we drain on launch without a 60s wait.
+        let mut tick = tokio::time::interval(Duration::from_secs(TICK_SECS));
+        loop {
+            tick.tick().await;
+            if let Err(err) = drain_once(&http, &token, &db).await {
+                tracing::warn!(?err, "offline-sync drain failed");
+            }
+        }
+    });
+}
+
+async fn drain_once(
+    http: &reqwest::Client,
+    token: &Arc<RwLock<Option<String>>>,
+    db: &Db,
+) -> crate::error::AppResult<()> {
+    let token = match token.read().await.clone() {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+
+    let rows = store::pending_sync::ready_rows(db, BATCH_SIZE)?;
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let count = rows.len();
+    tracing::debug!(count, "draining pending activity-sync rows");
+
+    for row in rows {
+        match api::activity::sync_activity(http, &token, &row.session_id, &row.samples).await {
+            Ok(_) => {
+                store::pending_sync::delete(db, row.id)?;
+                tracing::info!(
+                    session_id = %row.session_id,
+                    samples = row.samples.len(),
+                    "pending activity sync drained"
+                );
+            }
+            Err(err) => {
+                store::pending_sync::record_failure(db, row.id, row.retry_count)?;
+                tracing::debug!(
+                    ?err,
+                    session_id = %row.session_id,
+                    retry = row.retry_count + 1,
+                    "drain attempt failed; backing off"
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/desktop-app-v3/src-tauri/src/tracker/mod.rs
+++ b/desktop-app-v3/src-tauri/src/tracker/mod.rs
@@ -20,14 +20,14 @@
 //!   integration or kernel-level tracing).
 
 use crate::api::sessions::now_iso;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinHandle;
 
 /// One bucketed observation of "user was looking at <window> for <N>s".
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivitySample {
     pub application_name: String,


### PR DESCRIPTION
Phase 4 of the cross-platform desktop rewrite. Stacked on top of #36 — review/merge that one first.

## Verifiable success

> If `/api/activity/sync` fails at session-end (network blip, server hiccup, anything non-2xx), the activity samples are persisted locally and a background drainer retries them on a 5min→30min exponential backoff. When the user comes back online, no sample loss; when they don't come back for 7 days, the queue caps at 500 rows and discards oldest-first.

## How it works

1. **Local SQLite store** (`<app_data_dir>/local.sqlite`, WAL + NORMAL synchronous) opened lazily in the Tauri `setup` callback. Single table `pending_activity_sync(id, session_id, payload, retry_count, created_at, next_retry_at)`.
2. **`session_end`**: when the post-end POST to `/api/activity/sync` errors, `store::pending_sync::enqueue` writes the JSON-encoded `Vec<ActivitySample>` to disk instead of logging-and-losing.
3. **Background drainer** (`sync_worker::spawn`): tokio task ticks every 60s (immediately on launch). Fetches up to 16 due rows, retries POST. Success → delete row. Failure → bump `retry_count`, set `next_retry_at = now + min(5min · 2^retry, 30min)`. Same backoff shape v2's `PendingOperations` used.
4. **Bounded queue**: 500 rows / 7-day TTL. Purge runs on every enqueue — TTL drops first, then oldest-first if still over cap.

## Files

| File | Lines | What |
|---|---|---|
| `src-tauri/src/store/mod.rs` (new) | 63 | DB open + WAL pragmas + schema migration |
| `src-tauri/src/store/pending_sync.rs` (new) | 161 | enqueue / ready_rows / delete / record_failure / backoff_secs (+ unit test) |
| `src-tauri/src/sync_worker.rs` (new) | 71 | tokio-spawned drainer |
| `src-tauri/src/lib.rs` | +30 | `db: Arc<OnceLock<Db>>` on AppState; setup() opens store + spawns worker |
| `src-tauri/src/commands/sessions.rs` | +18/-7 | session_end enqueues on sync failure |
| `src-tauri/src/tracker/mod.rs` | +2/-1 | `ActivitySample` now also `Deserialize` (round-trip through SQLite payload) |
| `src-tauri/Cargo.toml` | +5 | `rusqlite = { version = "0.32", features = ["bundled"] }` |

Net: +345 / -7 LOC, 7 files. Phase 4 of 8.

## Out of scope (per Karpathy 2)

- **Idle detection** — wants per-OS native APIs; better as its own focused PR (4.5).
- **DB encryption** — later phase, will mirror v2's SQLCipher when secrets land in the local store.
- **Tray indicator** showing pending-sync count — phase 5 (tray + autostart).

## Verification

```bash
cd desktop-app-v3
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
```

**Test plan:**
- [ ] Build succeeds (cargo pulls `rusqlite` with bundled sqlite3 cleanly)
- [ ] Run a session online → end → log shows `activity samples synced` (existing phase-3 path, regression check)
- [ ] Disconnect network → end a session → log shows `activity sync failed; enqueueing for retry`
- [ ] Reconnect → within 60s, log shows `pending activity sync drained` and the row is deleted
- [ ] `sqlite3 ~/.local/share/FlowShield/local.sqlite "SELECT COUNT(*) FROM pending_activity_sync"` shows 0 once drained

## Tests

```
running 1 test
test store::pending_sync::tests::backoff_caps_at_30min ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)