### PR TITLE
fix(desktop-v3): sync_worker uses tauri::async_runtime::spawn (was panicking at startup)

### DIFF
--- a/desktop-app-v3/src-tauri/src/sync_worker.rs
+++ b/desktop-app-v3/src-tauri/src/sync_worker.rs
@@ -16,9 +16,12 @@ const TICK_SECS: u64 = 60;
 const BATCH_SIZE: i64 = 16;
 
 pub fn spawn(http: reqwest::Client, token: Arc<RwLock<Option<String>>>, db: Db) {
-    tokio::spawn(async move {
-        // `tokio::time::interval` ticks immediately on the first call,
-        // so we drain on launch without a 60s wait.
+    // `tauri::async_runtime::spawn` (vs `tokio::spawn`) so this works when
+    // called from Tauri's `setup` callback — that runs synchronously before
+    // any task is on a runtime. Tauri's async_runtime IS tokio under the
+    // hood, so `tokio::time::interval` / `tokio::sync::RwLock` inside the
+    // future continue to work.
+    tauri::async_runtime::spawn(async move {
         let mut tick = tokio::time::interval(Duration::from_secs(TICK_SECS));
         loop {
             tick.tick().await;


### PR DESCRIPTION
## What was broken

Phase 4's offline-sync drainer (#37) called \`tokio::spawn\` from inside Tauri's \`setup\` callback. \`setup\` runs synchronously **before** the runtime is established, so the desktop panicked at every startup:

\`\`\`
thread 'main' panicked at src/sync_worker.rs:19:5:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
\`\`\`

This means **the desktop app on \`main\` is currently broken end-to-end** — it crashes before the login window can render.

## Fix

One-line swap: \`tokio::spawn\` → \`tauri::async_runtime::spawn\`. Tauri's async runtime IS tokio under the hood, so the future body (\`tokio::time::interval\`, \`tokio::sync::RwLock\`) keeps working unchanged. The wrapper just lets the spawn call work from any context, including \`setup\`.

## Files

- \`src-tauri/src/sync_worker.rs\` — 1-line change inside \`pub fn spawn(...)\`, plus an explanatory comment.

Net: +6 / -3 LOC, 1 file.

## Verification

- \`cargo check\` passes (no API changes).
- \`cargo test --lib\` passes (existing \`backoff_caps_at_30min\` test unaffected).
- After merge: \`npm run tauri:dev\` no longer panics at the spawn site.

## Should be merged before PR #38

PR #38 (Phase 5 tray + autostart) already includes this same fix on its branch — but trunk needs it independently so anyone pulling \`main\` doesn't hit the panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)