### PR TITLE
feat(desktop-v3): phase 6 + 6.5 + 6.6 — hosts-file blocking with cross-platform elevation

### DIFF
--- a/desktop-app-v3/README.md
+++ b/desktop-app-v3/README.md
@@ -96,29 +96,26 @@ npm run tauri icon path/to/source.png
 
 Real icons are needed before any signed release.
 
-## Hosts-file blocking (Phase 6)
+## Hosts-file blocking (Phase 6 + 6.5)
 
 Deep-work mode maps blocked domains to `127.0.0.1` in the OS hosts
-file. Writing the hosts file requires admin/root, so the desktop app
-needs to be launched with elevated privileges for the
-`blocking_apply` / `blocking_clear` commands to succeed:
+file. The GUI itself runs unprivileged; when it needs to edit hosts,
+it re-invokes its own binary as a privileged subprocess via the OS's
+standard prompt:
 
-```bash
-# Linux / macOS — dev:
-sudo -E WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
+| Platform | Elevation mechanism | UX |
+|---|---|---|
+| Linux | `pkexec /proc/self/exe --blocking-apply ...` | polkit graphical password prompt |
+| macOS | `osascript ... 'do shell script ... with administrator privileges'` | Keychain / Touch ID prompt |
+| Windows | not yet wired up — returns a clear error | run the app as administrator manually for now |
 
-# Windows — right-click → "Run as administrator", or via an elevated
-# terminal:  powershell -Command "Start-Process npm 'run tauri:dev' -Verb RunAs"
-```
-
-If launched without elevation the commands return a `Permission
-denied` AppError that the frontend surfaces as a toast — the rest of
-the app keeps working. Phase 6.5 will add a `pkexec`/UAC-based
-helper so users don't have to re-launch with sudo.
+You **don't need** to launch the app with `sudo`. The polkit/Keychain
+prompt fires only when you actually toggle deep-work mode. Cancelling
+the prompt surfaces a friendly `AppError::Storage` to the frontend.
 
 A one-time backup of the user's pristine hosts file is saved to
 `<hosts>.flowshield-backup` before the very first edit and never
-overwritten — you can restore it manually at any time:
+overwritten — manual rollback is always one command away:
 
 ```bash
 sudo cp /etc/hosts.flowshield-backup /etc/hosts

--- a/desktop-app-v3/README.md
+++ b/desktop-app-v3/README.md
@@ -96,6 +96,34 @@ npm run tauri icon path/to/source.png
 
 Real icons are needed before any signed release.
 
+## Hosts-file blocking (Phase 6)
+
+Deep-work mode maps blocked domains to `127.0.0.1` in the OS hosts
+file. Writing the hosts file requires admin/root, so the desktop app
+needs to be launched with elevated privileges for the
+`blocking_apply` / `blocking_clear` commands to succeed:
+
+```bash
+# Linux / macOS — dev:
+sudo -E WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
+
+# Windows — right-click → "Run as administrator", or via an elevated
+# terminal:  powershell -Command "Start-Process npm 'run tauri:dev' -Verb RunAs"
+```
+
+If launched without elevation the commands return a `Permission
+denied` AppError that the frontend surfaces as a toast — the rest of
+the app keeps working. Phase 6.5 will add a `pkexec`/UAC-based
+helper so users don't have to re-launch with sudo.
+
+A one-time backup of the user's pristine hosts file is saved to
+`<hosts>.flowshield-backup` before the very first edit and never
+overwritten — you can restore it manually at any time:
+
+```bash
+sudo cp /etc/hosts.flowshield-backup /etc/hosts
+```
+
 ## Build
 
 ```bash

--- a/desktop-app-v3/README.md
+++ b/desktop-app-v3/README.md
@@ -107,7 +107,7 @@ standard prompt:
 |---|---|---|
 | Linux | `pkexec /proc/self/exe --blocking-apply ...` | polkit graphical password prompt |
 | macOS | `osascript ... 'do shell script ... with administrator privileges'` | Keychain / Touch ID prompt |
-| Windows | not yet wired up — returns a clear error | run the app as administrator manually for now |
+| Windows | `powershell Start-Process -Verb RunAs -Wait` | UAC consent dialog |
 
 You **don't need** to launch the app with `sudo`. The polkit/Keychain
 prompt fires only when you actually toggle deep-work mode. Cancelling

--- a/desktop-app-v3/src-tauri/src/blocking/mod.rs
+++ b/desktop-app-v3/src-tauri/src/blocking/mod.rs
@@ -1,0 +1,231 @@
+//! Hosts-file blocking for deep-work mode.
+//!
+//! Maps blocked domains to `127.0.0.1` in the OS hosts file so the browser
+//! can't reach them while a focus session is active. The edit is scoped to
+//! a marker-delimited region so we never disturb other entries:
+//!
+//! ```text
+//! # >>> FlowShield blocks (do not edit by hand) <<<
+//! 127.0.0.1 youtube.com
+//! 127.0.0.1 www.youtube.com
+//! # <<< FlowShield blocks >>>
+//! ```
+//!
+//! Writes are atomic (temp file + rename) and a one-time backup is kept at
+//! `<hosts>.flowshield-backup` before our first edit so a manual rollback is
+//! always possible. Privilege check is implicit: writing the hosts file
+//! requires root/admin and the OS surfaces a `PermissionDenied` error if
+//! the app isn't elevated. The frontend handles that as a regular AppError.
+//!
+//! Phase 6 keeps this minimum-viable — no automatic session-start/end
+//! integration, no `pkexec`/UAC elevation. Those land in 6.5.
+
+use crate::error::{AppError, AppResult};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const BEGIN_MARKER: &str = "# >>> FlowShield blocks (do not edit by hand) <<<";
+const END_MARKER: &str = "# <<< FlowShield blocks >>>";
+const BACKUP_SUFFIX: &str = "flowshield-backup";
+
+fn os_hosts_path() -> PathBuf {
+    if cfg!(windows) {
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".into());
+        PathBuf::from(system_root)
+            .join("System32")
+            .join("drivers")
+            .join("etc")
+            .join("hosts")
+    } else {
+        PathBuf::from("/etc/hosts")
+    }
+}
+
+/// Replace any existing FlowShield-managed block region with the given
+/// domains. If `domains` is empty the region is removed entirely.
+/// Idempotent — calling twice with the same input leaves the file unchanged.
+pub fn apply_blocks(domains: &[String]) -> AppResult<()> {
+    apply_blocks_at(&os_hosts_path(), domains)
+}
+
+/// Remove FlowShield's managed region without touching anything else.
+pub fn clear_blocks() -> AppResult<()> {
+    apply_blocks_at(&os_hosts_path(), &[])
+}
+
+fn apply_blocks_at(path: &Path, domains: &[String]) -> AppResult<()> {
+    let current =
+        fs::read_to_string(path).map_err(|e| AppError::Storage(format!("read hosts: {e}")))?;
+
+    // One-time backup of the user's pristine hosts file. We never overwrite
+    // an existing backup, so the FIRST untouched copy is preserved across
+    // any number of toggles.
+    let backup = backup_path(path);
+    if !backup.exists() {
+        fs::copy(path, &backup)
+            .map_err(|e| AppError::Storage(format!("backup hosts: {e}")))?;
+    }
+
+    let updated = rewrite(&current, domains);
+    if updated == current {
+        return Ok(());
+    }
+
+    let tmp = path.with_extension(format!("flowshield-tmp-{}", std::process::id()));
+    fs::write(&tmp, &updated)
+        .map_err(|e| AppError::Storage(format!("write tmp hosts: {e}")))?;
+    fs::rename(&tmp, path).map_err(|e| AppError::Storage(format!("rename hosts: {e}")))?;
+    Ok(())
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let mut p = path.as_os_str().to_owned();
+    p.push(".");
+    p.push(BACKUP_SUFFIX);
+    PathBuf::from(p)
+}
+
+/// Pure string transform: strip any existing managed region from `current`,
+/// then append a fresh region for `domains`. Split out from `apply_blocks_at`
+/// so it's trivially testable without touching the FS.
+fn rewrite(current: &str, domains: &[String]) -> String {
+    let stripped = strip_region(current);
+    let mut out = stripped.trim_end().to_string();
+    if domains.is_empty() {
+        out.push('\n');
+        return out;
+    }
+    out.push_str("\n\n");
+    out.push_str(BEGIN_MARKER);
+    out.push('\n');
+    for d in domains {
+        let domain = d
+            .trim()
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        if domain.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("127.0.0.1 {domain}\n"));
+        if !domain.starts_with("www.") {
+            out.push_str(&format!("127.0.0.1 www.{domain}\n"));
+        }
+    }
+    out.push_str(END_MARKER);
+    out.push('\n');
+    out
+}
+
+fn strip_region(input: &str) -> String {
+    let Some(begin) = input.find(BEGIN_MARKER) else {
+        return input.to_string();
+    };
+    let Some(end_off) = input[begin..].find(END_MARKER) else {
+        return input.to_string();
+    };
+    let end = begin + end_off + END_MARKER.len();
+    // Also consume one trailing newline so we don't accumulate blank lines
+    // across repeated apply/clear cycles.
+    let cut_end = if input[end..].starts_with('\n') {
+        end + 1
+    } else {
+        end
+    };
+    let mut out = String::with_capacity(input.len());
+    out.push_str(&input[..begin]);
+    out.push_str(&input[cut_end..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn temp_hosts(initial: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let path = env::temp_dir().join(format!(
+            "flowshield-blocking-test-{}-{n}.hosts",
+            std::process::id()
+        ));
+        fs::write(&path, initial).unwrap();
+        path
+    }
+
+    #[test]
+    fn rewrite_adds_region_when_absent() {
+        let out = rewrite("127.0.0.1 localhost\n", &["youtube.com".into()]);
+        assert!(out.contains(BEGIN_MARKER));
+        assert!(out.contains("127.0.0.1 youtube.com\n"));
+        assert!(out.contains("127.0.0.1 www.youtube.com\n"));
+        assert!(out.contains(END_MARKER));
+    }
+
+    #[test]
+    fn rewrite_replaces_existing_region() {
+        let first = rewrite("127.0.0.1 localhost\n", &["youtube.com".into()]);
+        let second = rewrite(&first, &["reddit.com".into()]);
+        assert!(!second.contains("youtube.com"));
+        assert!(second.contains("127.0.0.1 reddit.com\n"));
+        assert_eq!(second.matches(BEGIN_MARKER).count(), 1);
+    }
+
+    #[test]
+    fn rewrite_with_empty_domains_removes_region() {
+        let with_blocks = rewrite("127.0.0.1 localhost\n", &["youtube.com".into()]);
+        let cleared = rewrite(&with_blocks, &[]);
+        assert!(!cleared.contains(BEGIN_MARKER));
+        assert!(!cleared.contains("youtube.com"));
+        assert!(cleared.contains("127.0.0.1 localhost"));
+    }
+
+    #[test]
+    fn rewrite_strips_url_scheme() {
+        let out = rewrite("", &["https://reddit.com".into(), "http://x.com".into()]);
+        assert!(out.contains("127.0.0.1 reddit.com\n"));
+        assert!(out.contains("127.0.0.1 x.com\n"));
+        assert!(!out.contains("https://"));
+    }
+
+    #[test]
+    fn rewrite_skips_www_doubling_when_already_prefixed() {
+        let out = rewrite("", &["www.youtube.com".into()]);
+        assert!(out.contains("127.0.0.1 www.youtube.com\n"));
+        assert!(!out.contains("www.www."));
+    }
+
+    #[test]
+    fn apply_blocks_at_creates_backup_once() {
+        let path = temp_hosts("127.0.0.1 localhost\n");
+        apply_blocks_at(&path, &["youtube.com".into()]).unwrap();
+        let backup = backup_path(&path);
+        assert!(backup.exists());
+        let backup_contents = fs::read_to_string(&backup).unwrap();
+        assert_eq!(backup_contents, "127.0.0.1 localhost\n");
+
+        // A second apply must NOT overwrite the backup.
+        apply_blocks_at(&path, &["reddit.com".into()]).unwrap();
+        let backup_contents_2 = fs::read_to_string(&backup).unwrap();
+        assert_eq!(backup_contents_2, "127.0.0.1 localhost\n");
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&backup);
+    }
+
+    #[test]
+    fn apply_then_clear_returns_to_original_content() {
+        let original = "127.0.0.1 localhost\n255.255.255.255 broadcasthost\n";
+        let path = temp_hosts(original);
+        apply_blocks_at(&path, &["youtube.com".into()]).unwrap();
+        apply_blocks_at(&path, &[]).unwrap();
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after.trim_end(), original.trim_end());
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&backup_path(&path));
+    }
+}

--- a/desktop-app-v3/src-tauri/src/commands/blocking.rs
+++ b/desktop-app-v3/src-tauri/src/commands/blocking.rs
@@ -1,29 +1,37 @@
 //! Hosts-file blocking commands. The frontend invokes these to enter
 //! deep-work mode and to release the block on session end.
 //!
-//! Both commands require the app to be running with admin/root privileges
-//! since the OS hosts file is owned by root. If not, the underlying write
-//! fails with `PermissionDenied` and the error propagates as an
-//! `AppError::Storage` to JS. Phase 6.5 will add a `pkexec`/UAC elevation
-//! path so users don't have to launch the app with sudo.
+//! These commands re-invoke the binary itself with an elevation prompt
+//! (Linux: pkexec; macOS: osascript) so the GUI never holds root. The
+//! privileged child runs `flowshield_desktop_lib::run_blocker_subcommand`
+//! which dispatches `--blocking-apply <domains>` / `--blocking-clear`
+//! and exits.
 //!
-//! Wrapped in `spawn_blocking` because hosts-file I/O is synchronous and
-//! we don't want to stall the runtime — the actual reads/writes are tiny
-//! but `fs::rename` can briefly block on slow disks.
+//! Wrapped in `spawn_blocking` because the elevation subprocess is
+//! synchronous and we don't want to stall the async runtime while the
+//! user types their password.
 
-use crate::blocking;
+use super::elevation;
 use crate::error::{AppError, AppResult};
 
 #[tauri::command]
 pub async fn blocking_apply(domains: Vec<String>) -> AppResult<()> {
-    tauri::async_runtime::spawn_blocking(move || blocking::apply_blocks(&domains))
-        .await
-        .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
+    // Comma-join because we pass through pkexec/osascript argv, where
+    // each token is a separate shell argument; one packed string keeps
+    // the wire format simple. The privileged child splits on commas.
+    let arg = domains.join(",");
+    tauri::async_runtime::spawn_blocking(move || {
+        elevation::run_self_elevated("--blocking-apply", vec![arg])
+    })
+    .await
+    .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
 }
 
 #[tauri::command]
 pub async fn blocking_clear() -> AppResult<()> {
-    tauri::async_runtime::spawn_blocking(blocking::clear_blocks)
-        .await
-        .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
+    tauri::async_runtime::spawn_blocking(|| {
+        elevation::run_self_elevated("--blocking-clear", vec![])
+    })
+    .await
+    .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
 }

--- a/desktop-app-v3/src-tauri/src/commands/blocking.rs
+++ b/desktop-app-v3/src-tauri/src/commands/blocking.rs
@@ -1,0 +1,29 @@
+//! Hosts-file blocking commands. The frontend invokes these to enter
+//! deep-work mode and to release the block on session end.
+//!
+//! Both commands require the app to be running with admin/root privileges
+//! since the OS hosts file is owned by root. If not, the underlying write
+//! fails with `PermissionDenied` and the error propagates as an
+//! `AppError::Storage` to JS. Phase 6.5 will add a `pkexec`/UAC elevation
+//! path so users don't have to launch the app with sudo.
+//!
+//! Wrapped in `spawn_blocking` because hosts-file I/O is synchronous and
+//! we don't want to stall the runtime — the actual reads/writes are tiny
+//! but `fs::rename` can briefly block on slow disks.
+
+use crate::blocking;
+use crate::error::{AppError, AppResult};
+
+#[tauri::command]
+pub async fn blocking_apply(domains: Vec<String>) -> AppResult<()> {
+    tauri::async_runtime::spawn_blocking(move || blocking::apply_blocks(&domains))
+        .await
+        .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
+}
+
+#[tauri::command]
+pub async fn blocking_clear() -> AppResult<()> {
+    tauri::async_runtime::spawn_blocking(blocking::clear_blocks)
+        .await
+        .map_err(|e| AppError::Storage(format!("blocking task: {e}")))?
+}

--- a/desktop-app-v3/src-tauri/src/commands/elevation.rs
+++ b/desktop-app-v3/src-tauri/src/commands/elevation.rs
@@ -1,0 +1,90 @@
+//! Cross-platform "spawn self with admin privileges" helper.
+//!
+//! Pattern: for operations that need root (writing /etc/hosts, etc.) we
+//! re-invoke our own binary as a privileged subprocess via the OS's
+//! standard prompt mechanism. The same Rust code path runs in the child;
+//! the GUI process never holds elevated privileges.
+//!
+//! - **Linux**: `pkexec /proc/self/exe <subcommand> <args...>` — polkit
+//!   shows a graphical password prompt; default polkit rules already let
+//!   admin-group members elevate without extra `.policy` files.
+//! - **macOS**: `osascript -e 'do shell script "..." with administrator
+//!   privileges'` — Keychain / TouchID prompt.
+//! - **Windows**: not yet wired up. Returns a clear error so the frontend
+//!   can show a "launch as administrator" toast. Real fix is `ShellExecuteW`
+//!   with the `runas` verb — phase 6.6.
+//!
+//! Cancelled prompts (user dismisses the password dialog) surface as a
+//! non-zero exit status, which we map to an `AppError::Storage` with a
+//! user-readable message.
+
+use crate::error::{AppError, AppResult};
+use std::process::Command;
+
+pub fn run_self_elevated(subcommand: &str, args: Vec<String>) -> AppResult<()> {
+    let exe = std::env::current_exe()
+        .map_err(|e| AppError::Storage(format!("current_exe: {e}")))?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut cmd = Command::new("pkexec");
+        cmd.arg(&exe).arg(subcommand).args(&args);
+        return run(cmd, "pkexec");
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let exe_quoted = quote_for_osascript(&exe.to_string_lossy());
+        let args_quoted: String = std::iter::once(subcommand.to_string())
+            .chain(args.into_iter())
+            .map(|s| quote_for_osascript(&s))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let script = format!(
+            "do shell script \"{} {}\" with administrator privileges",
+            exe_quoted, args_quoted
+        );
+        let mut cmd = Command::new("osascript");
+        cmd.args(["-e", &script]);
+        return run(cmd, "osascript");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let _ = (exe, subcommand, args);
+        Err(AppError::Storage(
+            "Windows UAC elevation isn't wired up yet — for now, launch the app as administrator manually."
+                .into(),
+        ))
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn run(mut cmd: Command, name: &str) -> AppResult<()> {
+    let status = cmd
+        .status()
+        .map_err(|e| AppError::Storage(format!("spawn {name}: {e}")))?;
+    if !status.success() {
+        return Err(AppError::Storage(format!(
+            "{name} exited with {} — the elevation prompt may have been cancelled",
+            status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "(no code)".into())
+        )));
+    }
+    Ok(())
+}
+
+/// Escape a string so it can be embedded inside an `osascript`
+/// `do shell script "..."` argument. We end up with two escape layers:
+///   1. The outer Rust `format!` already wraps the script in `"..."`.
+///   2. AppleScript's `do shell script` expects POSIX-shell quoting inside
+///      the string, where backslash + double-quote escape the inner pieces.
+/// Wrapping each token in escaped double-quotes (`\"...\"`) is the
+/// conventional shape and survives spaces in paths.
+#[cfg(target_os = "macos")]
+fn quote_for_osascript(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\\\"{}\\\"", escaped)
+}

--- a/desktop-app-v3/src-tauri/src/commands/elevation.rs
+++ b/desktop-app-v3/src-tauri/src/commands/elevation.rs
@@ -10,9 +10,10 @@
 //!   admin-group members elevate without extra `.policy` files.
 //! - **macOS**: `osascript -e 'do shell script "..." with administrator
 //!   privileges'` — Keychain / TouchID prompt.
-//! - **Windows**: not yet wired up. Returns a clear error so the frontend
-//!   can show a "launch as administrator" toast. Real fix is `ShellExecuteW`
-//!   with the `runas` verb — phase 6.6.
+//! - **Windows**: `powershell Start-Process -Verb RunAs -Wait` — UAC
+//!   prompt. Using PowerShell instead of FFI'ing `ShellExecuteExW` keeps
+//!   the dep tree small and the elevation logic readable. PowerShell ships
+//!   with every Windows ≥ 7.
 //!
 //! Cancelled prompts (user dismisses the password dialog) surface as a
 //! non-zero exit status, which we map to an `AppError::Storage` with a
@@ -51,15 +52,45 @@ pub fn run_self_elevated(subcommand: &str, args: Vec<String>) -> AppResult<()> {
 
     #[cfg(target_os = "windows")]
     {
-        let _ = (exe, subcommand, args);
-        Err(AppError::Storage(
-            "Windows UAC elevation isn't wired up yet — for now, launch the app as administrator manually."
-                .into(),
-        ))
+        // PowerShell's Start-Process -Verb RunAs triggers UAC. -Wait blocks
+        // until the elevated child exits; -PassThru gives us the process
+        // object so we can read $proc.ExitCode and forward it. We exit the
+        // PowerShell host with the same code so our `run()` helper sees a
+        // non-zero status when the child failed (or the user cancelled UAC,
+        // which throws and falls into PowerShell's $? = false → exit 1).
+        let exe_str = exe
+            .to_str()
+            .ok_or_else(|| AppError::Storage("exe path not valid UTF-8".into()))?
+            .to_string();
+        let argument_list = std::iter::once(subcommand.to_string())
+            .chain(args.into_iter())
+            .map(|s| ps_single_quote(&s))
+            .collect::<Vec<_>>()
+            .join(",");
+        let script = format!(
+            "$ErrorActionPreference='Stop'; \
+             try {{ \
+               $proc = Start-Process -FilePath {} -ArgumentList {} -Verb RunAs -Wait -PassThru -WindowStyle Hidden; \
+               exit $proc.ExitCode \
+             }} catch {{ \
+               Write-Error $_; \
+               exit 1 \
+             }}",
+            ps_single_quote(&exe_str),
+            argument_list
+        );
+        let mut cmd = Command::new("powershell");
+        cmd.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+        return run(cmd, "powershell");
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn ps_single_quote(s: &str) -> String {
+    // PowerShell single-quoted strings: '' is a literal '. No other escapes.
+    format!("'{}'", s.replace('\'', "''"))
+}
+
 fn run(mut cmd: Command, name: &str) -> AppResult<()> {
     let status = cmd
         .status()

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@
 //! modules makes the per-feature surface obvious.
 
 pub mod auth;
+pub mod blocking;
 pub mod ping;
 pub mod projects;
 pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod auth;
 pub mod blocking;
+mod elevation;
 pub mod ping;
 pub mod projects;
 pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -16,6 +16,47 @@ use tokio::sync::RwLock;
 
 pub use error::AppError;
 
+/// Privileged-child entrypoint. When the binary is re-invoked via
+/// `pkexec` / `osascript` with one of our blocking subcommands, this
+/// function runs the requested operation and returns an exit code. If
+/// the args don't match a subcommand, returns None and the caller falls
+/// through to the normal GUI launch path.
+///
+/// Args layout:
+///   `flowshield-desktop --blocking-apply <comma,separated,domains>`
+///   `flowshield-desktop --blocking-clear`
+pub fn run_blocker_subcommand(args: &[String]) -> Option<i32> {
+    let sub = args.get(1)?.as_str();
+    match sub {
+        "--blocking-apply" => {
+            let domains: Vec<String> = args
+                .get(2)
+                .map(|s| {
+                    s.split(',')
+                        .filter(|d| !d.is_empty())
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default();
+            Some(match blocking::apply_blocks(&domains) {
+                Ok(()) => 0,
+                Err(e) => {
+                    eprintln!("flowshield-blocker apply: {e}");
+                    1
+                }
+            })
+        }
+        "--blocking-clear" => Some(match blocking::clear_blocks() {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("flowshield-blocker clear: {e}");
+                1
+            }
+        }),
+        _ => None,
+    }
+}
+
 /// Shared application state. The HTTP client is reused across requests so
 /// connections are pooled. Token + user are mirrored from the persistent
 /// store on first read so commands don't pay the IPC round-trip every call.

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 //! same code can be unit-tested without spinning up a webview.
 
 mod api;
+mod blocking;
 mod commands;
 mod error;
 mod store;
@@ -144,6 +145,8 @@ pub fn run() {
             commands::sessions::session_toggle_pause,
             commands::projects::projects_list,
             commands::projects::projects_create,
+            commands::blocking::blocking_apply,
+            commands::blocking::blocking_clear,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src-tauri/src/main.rs
+++ b/desktop-app-v3/src-tauri/src/main.rs
@@ -2,5 +2,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // When the binary is re-invoked as a privileged child by `pkexec` /
+    // `osascript`, we run the requested blocking subcommand and exit
+    // without booting the GUI. Returns None for normal launches.
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(code) = flowshield_desktop_lib::run_blocker_subcommand(&args) {
+        std::process::exit(code);
+    }
+
     flowshield_desktop_lib::run();
 }


### PR DESCRIPTION
Phase 6 + 6.5 + 6.6 of the cross-platform desktop rewrite. Adds deep-work mode (distraction domains pinned to 127.0.0.1 in the OS hosts file) plus on-demand privilege elevation on **all three platforms** so the GUI never needs to be launched with sudo / as administrator.

## Verifiable success

> Launch the app **without** sudo. From the dev console, run \`invoke('blocking_apply', { domains: ['youtube.com'] })\`. The platform-native admin prompt fires (polkit on Linux, Keychain on macOS, UAC on Windows). After authentication, the OS hosts file gains a FlowShield-marked region with 127.0.0.1 entries for \`youtube.com\` and \`www.youtube.com\`. youtube.com fails to resolve in the browser. \`invoke('blocking_clear')\` triggers the same prompt and reverts.

## Three parts

### Phase 6 — hosts-file blocking core

1. **Marker-delimited region.** Edits between \`# >>> FlowShield blocks <<<\` and \`# <<< FlowShield blocks >>>\`. Lines outside are never touched. Idempotent.
2. **Atomic writes.** Temp file → \`fs::rename\` into place.
3. **One-time backup.** Pristine hosts copied to \`<hosts>.flowshield-backup\` before the first edit and never overwritten.
4. **Cross-platform paths.** \`/etc/hosts\` on Unix; \`%SystemRoot%\\System32\\drivers\\etc\\hosts\` on Windows.
5. **Domain normalization.** Strips http(s):// prefixes; auto-adds \`www.\` variant.

### Phase 6.5 — Linux + macOS elevation

The GUI re-invokes its own binary as a privileged subprocess with a \`--blocking-apply <domains>\` / \`--blocking-clear\` flag. \`main.rs\` dispatches via \`flowshield_desktop_lib::run_blocker_subcommand\` before booting the GUI, so the elevated process never opens a webview.

### Phase 6.6 — Windows UAC elevation

PowerShell's \`Start-Process -Verb RunAs -Wait -PassThru\` triggers UAC. The script propagates the elevated child's \`$proc.ExitCode\` so cancelled prompts and non-zero exits both surface as \`AppError::Storage\` — same shape as Linux/macOS.

| Platform | Elevation | UX |
|---|---|---|
| **Linux** | \`pkexec /proc/self/exe --blocking-apply ...\` | polkit graphical password prompt |
| **macOS** | \`osascript ... 'do shell script ... with administrator privileges'\` | Keychain / Touch ID prompt |
| **Windows** | \`powershell Start-Process -Verb RunAs -Wait\` | UAC consent dialog |

## Files

| File | Lines | What |
|---|---|---|
| \`src-tauri/src/blocking/mod.rs\` (new) | 231 | apply_blocks / clear_blocks + 7 unit tests |
| \`src-tauri/src/commands/blocking.rs\` (new) | 38 | Two thin async Tauri commands; spawn_blocking around the elevation call |
| \`src-tauri/src/commands/elevation.rs\` (new) | ~120 | Cross-platform "spawn self elevated" helper; pkexec / osascript / PowerShell |
| \`src-tauri/src/commands/mod.rs\` | +2 | mod declarations |
| \`src-tauri/src/lib.rs\` | +44 | mod blocking; pub fn run_blocker_subcommand |
| \`src-tauri/src/main.rs\` | +8 | Dispatch run_blocker_subcommand before run() |
| \`desktop-app-v3/README.md\` | +24 | Document the elevation flow per platform |

Net: ~+509 / -31 LOC, 7 files. Phases 6 + 6.5 + 6.6 of 8.

## Tests

\`\`\`
running 7 tests
test blocking::tests::rewrite_skips_www_doubling_when_already_prefixed ... ok
test blocking::tests::rewrite_replaces_existing_region ... ok
test blocking::tests::rewrite_adds_region_when_absent ... ok
test blocking::tests::rewrite_strips_url_scheme ... ok
test blocking::tests::rewrite_with_empty_domains_removes_region ... ok
test blocking::tests::apply_blocks_at_creates_backup_once ... ok
test blocking::tests::apply_then_clear_returns_to_original_content ... ok
\`\`\`

## Verification status

- **Linux**: end-to-end verified locally (polkit prompt → /etc/hosts edited → DNS routes to 127.0.0.1 → clear restores) ✓
- **macOS**: code review only (same osascript pattern used by countless other Tauri apps; high confidence)
- **Windows**: code review only — I'm developing on Linux. The PowerShell + Start-Process pattern is textbook but please run the verification flow on Windows before merging if Windows is a release target.

## Out of scope (per Karpathy 2)

- **Frontend toggle UI** on the dashboard — phase 6.7. Will integrate with \`user.preferences.primaryDistractions\`.
- **Auto-apply on session start / auto-clear on session end** — phase 6.8. Needs the frontend toggle first.
- **Crash recovery** — auto-restore from \`.flowshield-backup\` on next app launch if a session ended uncleanly. Phase 6.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)