### PR TITLE
feat(desktop-v3): phase 6.7 — deep-work toggle UI on the dashboard

### DIFF
--- a/desktop-app-v3/src-tauri/src/api/mod.rs
+++ b/desktop-app-v3/src-tauri/src/api/mod.rs
@@ -4,10 +4,12 @@
 
 mod auth;
 pub mod activity;
+pub mod preferences;
 pub mod projects;
 pub mod sessions;
 
 pub use auth::{login, AuthUser};
+pub use preferences::Preferences;
 pub use sessions::Session;
 
 /// Default API base URL. Overrideable at runtime via the `FLOWSHIELD_API_URL`

--- a/desktop-app-v3/src-tauri/src/api/preferences.rs
+++ b/desktop-app-v3/src-tauri/src/api/preferences.rs
@@ -1,0 +1,61 @@
+//! User preferences fetcher. Right now the only caller is the deep-work
+//! card on the dashboard, which needs the `primaryDistractions` list to
+//! pass to `blocking_apply`. Other fields on the web's `UserPreferences`
+//! row (workStyle, preferredDuration, breakReminders, …) are ignored —
+//! they'll be wired up to settings UI when v3 grows that surface.
+
+use crate::error::{AppError, AppResult};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Preferences {
+    #[serde(default)]
+    pub primary_distractions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PreferencesEnvelope {
+    preferences: Preferences,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    error: Option<String>,
+    code: Option<String>,
+}
+
+/// GET /api/user/preferences. Returns defaults (empty distraction list)
+/// if the user hasn't saved any preferences yet (web returns 404 in
+/// that case).
+pub async fn get_preferences(http: &reqwest::Client, token: &str) -> AppResult<Preferences> {
+    let url = format!("{}/api/user/preferences", super::api_base_url());
+    let res = http.get(&url).bearer_auth(token).send().await?;
+
+    if res.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(Preferences::default());
+    }
+
+    let status = res.status();
+    if !status.is_success() {
+        let body: ApiErrorBody = res.json().await.unwrap_or(ApiErrorBody {
+            error: None,
+            code: None,
+        });
+        return Err(AppError::Api {
+            status: status.as_u16(),
+            message: body
+                .error
+                .unwrap_or_else(|| "Failed to load preferences".into()),
+            code: body.code,
+        });
+    }
+
+    let body: serde_json::Value = res.json().await?;
+    if let Ok(env) = serde_json::from_value::<PreferencesEnvelope>(body.clone()) {
+        return Ok(env.preferences);
+    }
+    // Defensive: accept a bare Preferences object too if the envelope
+    // shape ever changes server-side.
+    Ok(serde_json::from_value::<Preferences>(body).unwrap_or_default())
+}

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -6,5 +6,6 @@ pub mod auth;
 pub mod blocking;
 mod elevation;
 pub mod ping;
+pub mod preferences;
 pub mod projects;
 pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/commands/preferences.rs
+++ b/desktop-app-v3/src-tauri/src/commands/preferences.rs
@@ -1,0 +1,26 @@
+//! User-preferences commands. The deep-work card on the dashboard
+//! invokes `prefs_load` to discover which sites to block.
+
+use crate::api::{self, Preferences};
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+use tauri::State;
+
+async fn token_or_err(state: &State<'_, AppState>) -> AppResult<String> {
+    state
+        .token
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| AppError::Api {
+            status: 401,
+            message: "Not authenticated".into(),
+            code: Some("UNAUTHENTICATED".into()),
+        })
+}
+
+#[tauri::command]
+pub async fn prefs_load(state: State<'_, AppState>) -> AppResult<Preferences> {
+    let token = token_or_err(&state).await?;
+    api::preferences::get_preferences(&state.http, &token).await
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -188,6 +188,7 @@ pub fn run() {
             commands::projects::projects_create,
             commands::blocking::blocking_apply,
             commands::blocking::blocking_clear,
+            commands::preferences::prefs_load,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src/lib/preferences.ts
+++ b/desktop-app-v3/src/lib/preferences.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+
+export interface Preferences {
+  primaryDistractions: string[];
+}
+
+interface PrefsState {
+  current: Preferences | null;
+  loading: boolean;
+  error: string | null;
+  /** Pull the user's preferences from the FlowShield API. Idempotent. */
+  refresh: () => Promise<void>;
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const obj = err as { message?: string; error?: string };
+    return obj.message ?? obj.error ?? fallback;
+  }
+  return fallback;
+}
+
+export const usePrefsStore = create<PrefsState>((set) => ({
+  current: null,
+  loading: false,
+  error: null,
+
+  refresh: async () => {
+    set({ loading: true, error: null });
+    try {
+      const prefs = await invoke<Preferences>('prefs_load');
+      set({ current: prefs, loading: false });
+    } catch (err) {
+      set({
+        error: errorMessage(err, 'Failed to load preferences'),
+        loading: false,
+      });
+    }
+  },
+}));

--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import {
   isPermissionGranted,
   requestPermission,
@@ -7,6 +8,7 @@ import {
 import { useAuthStore } from '../lib/auth';
 import { useSessionStore } from '../lib/sessions';
 import { useProjectsStore, type Project } from '../lib/projects';
+import { usePrefsStore } from '../lib/preferences';
 import { Button } from '../components/Button';
 import { Timer } from '../components/Timer';
 
@@ -90,6 +92,11 @@ export function DashboardPage() {
   useEffect(() => {
     void projects.refresh();
   }, [projects.refresh]);
+
+  const prefs = usePrefsStore();
+  useEffect(() => {
+    void prefs.refresh();
+  }, [prefs.refresh]);
 
   // Detect the active → null transition (auto-end OR manual End) and fire
   // notification + start cooldown. Tracks previous session id via ref so we
@@ -179,6 +186,12 @@ export function DashboardPage() {
               onStart={() => void start(duration, type, selectedProjectId)}
             />
           )}
+
+          <DeepWorkCard
+            distractions={prefs.current?.primaryDistractions ?? []}
+            loading={prefs.loading}
+            error={prefs.error}
+          />
         </div>
       </main>
     </div>
@@ -385,6 +398,149 @@ function SessionPicker({
       >
         {inCooldown ? `Cool-down · ${cdLabel}` : `Start ${duration}-minute session`}
       </Button>
+    </div>
+  );
+}
+
+/**
+ * Deep-work toggle card. Shows the user's primaryDistractions (configured
+ * on the web at flowshield.app/settings) and exposes Apply / Stop buttons
+ * that invoke the blocking_apply / blocking_clear Tauri commands. Each
+ * action triggers an OS-native elevation prompt (polkit / Keychain / UAC).
+ *
+ * Phase 6.7 keeps `blocking` UI-only: there's no auto-apply on session
+ * start or auto-clear on session end yet. That lifecycle wiring lands in
+ * 6.8 once we settle on whether Apply should fire silently or always
+ * prompt for elevation.
+ */
+function DeepWorkCard({
+  distractions,
+  loading,
+  error,
+}: {
+  distractions: string[];
+  loading: boolean;
+  error: string | null;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [active, setActive] = useState(false);
+  const [opError, setOpError] = useState<string | null>(null);
+
+  const apply = async () => {
+    setBusy(true);
+    setOpError(null);
+    try {
+      await invoke('blocking_apply', { domains: distractions });
+      setActive(true);
+    } catch (err) {
+      setOpError(
+        err instanceof Error
+          ? err.message
+          : typeof err === 'string'
+            ? err
+            : 'Failed to apply blocks',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    setOpError(null);
+    try {
+      await invoke('blocking_clear');
+      setActive(false);
+    } catch (err) {
+      setOpError(
+        err instanceof Error
+          ? err.message
+          : typeof err === 'string'
+            ? err
+            : 'Failed to clear blocks',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading && distractions.length === 0) {
+    return (
+      <div className="rounded-lg border border-surface-3 bg-surface-1 p-4">
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+          Deep work mode
+        </div>
+        <div className="text-sm text-gray-500 dark:text-gray-400">Loading distractions…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-500/10 dark:border-red-500/20 p-4">
+        <div className="text-xs uppercase tracking-wide text-red-700 dark:text-red-300 mb-1">
+          Deep work mode
+        </div>
+        <div className="text-sm text-red-700 dark:text-red-300">{error}</div>
+      </div>
+    );
+  }
+
+  if (distractions.length === 0) {
+    return (
+      <div className="rounded-lg border border-surface-3 bg-surface-1 p-4">
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+          Deep work mode
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No distraction sites configured. Add some at{' '}
+          <span className="font-mono">flowshield.app/settings</span>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-surface-3 bg-surface-1 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Deep work mode
+        </div>
+        {active && (
+          <span className="text-xs text-emerald-600 dark:text-emerald-400">● blocking</span>
+        )}
+      </div>
+      <p className="text-sm text-gray-700 dark:text-gray-300">
+        Block {distractions.length} site{distractions.length === 1 ? '' : 's'} via the OS hosts
+        file. Toggling will prompt for your password.
+      </p>
+      <div className="flex flex-wrap gap-1">
+        {distractions.slice(0, 6).map((d) => (
+          <span
+            key={d}
+            className="text-xs font-mono px-2 py-0.5 rounded bg-surface-2 text-gray-700 dark:text-gray-300"
+          >
+            {d}
+          </span>
+        ))}
+        {distractions.length > 6 && (
+          <span className="text-xs text-gray-500 dark:text-gray-400 self-center">
+            +{distractions.length - 6} more
+          </span>
+        )}
+      </div>
+      {opError && (
+        <div className="text-xs text-red-600 dark:text-red-400">{opError}</div>
+      )}
+      {active ? (
+        <Button variant="secondary" size="md" loading={busy} onClick={() => void clear()}>
+          Stop blocking
+        </Button>
+      ) : (
+        <Button variant="primary" size="md" loading={busy} onClick={() => void apply()}>
+          Block now
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Phase 6.7 of the cross-platform desktop rewrite. Stacked on top of #41 (Phases 6 + 6.5 + 6.6) — review/merge that one first.

## Verifiable success

> Sign in. The dashboard shows a **Deep work mode** card listing the user's distraction sites (pulled from `/api/user/preferences`). Click **Block now** → polkit / Keychain / UAC prompt fires → after auth, the card shows a green "● blocking" indicator and the button flips to **Stop blocking**. Browser fails to reach those sites. Click **Stop blocking** → prompt fires again → blocks lifted.

## How it works

1. **Backend prefs fetch.** New `api::preferences::get_preferences` calls `GET /api/user/preferences` with the bearer token from `AppState`. Returns a minimal `Preferences { primary_distractions: Vec<String> }` — the v3 desktop only cares about distractions for now; other fields on `UserPreferences` are silently dropped per Karpathy 2.
2. **Tauri command.** `prefs_load` is a thin async wrapper registered in `tauri::generate_handler!`.
3. **Zustand store.** `usePrefsStore` exposes `{ current, loading, error, refresh }`. Refreshes once on mount.
4. **Card UX.** Shows up to 6 distraction chips + a \"+N more\" badge. Apply / Stop buttons invoke `blocking_apply` / `blocking_clear` via `@tauri-apps/api/core`. The loading spinner stays on while the privileged subprocess is running (so the user sees feedback during the OS prompt). Cancelled prompts surface inline as a red error message; the rest of the app keeps working.
5. **Empty / error states.** No prefs yet → \"Add some at flowshield.app/settings\". Fetch failed → red banner with the API error message.

## Files

| File | Lines | What |
|---|---|---|
| `src-tauri/src/api/preferences.rs` (new) | 61 | GET /api/user/preferences fetcher; envelope + bare-object accept |
| `src-tauri/src/commands/preferences.rs` (new) | 26 | `prefs_load` Tauri command |
| `src-tauri/src/api/mod.rs` | +2 | `pub mod preferences;` + `pub use Preferences` |
| `src-tauri/src/commands/mod.rs` | +1 | `pub mod preferences;` |
| `src-tauri/src/lib.rs` | +1 | Register `prefs_load` |
| `src/lib/preferences.ts` (new) | 42 | Zustand `usePrefsStore` |
| `src/routes/DashboardPage.tsx` | +156 | `<DeepWorkCard>` component + prefs refresh on mount |

Net: +289 / -0 LOC, 7 files. Phase 6.7 of 8.

## Out of scope (per Karpathy 2)

- **Auto-apply on session start / auto-clear on session end** — phase 6.8.
- **Crash recovery** from `.flowshield-backup` on next launch if a session ended uncleanly — phase 6.8.
- **Editing the distraction list from the desktop** — web is the source of truth; a v3 settings UI lands later.

## Verification

\`\`\`bash
cd desktop-app-v3
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
# Sign in. The Deep work card appears under the session picker.
# Click "Block now" → polkit prompt → enter password.
# Try opening one of the listed distraction sites in a browser → fails.
# Click "Stop blocking" → polkit prompt → access restored.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)