### PR TITLE
fix(desktop-v3): register device with /api/devices on login + sync

### DIFF
--- a/desktop-app-v3/src-tauri/Cargo.toml
+++ b/desktop-app-v3/src-tauri/Cargo.toml
@@ -41,6 +41,13 @@ user-idle = "0.6"
 # the user having libsqlite3 (matters on Windows + minimal macOS images).
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# Hostname / username lookup for device registration. Cross-platform —
+# wraps gethostname / GetUserName / SCDynamicStoreCopyComputerName.
+whoami = "1"
+# SHA-256 + base64-url for the v2-compatible deviceId derivation.
+sha2 = "0.10"
+base64 = "0.22"
+
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 thiserror   = "1"

--- a/desktop-app-v3/src-tauri/src/api/devices.rs
+++ b/desktop-app-v3/src-tauri/src/api/devices.rs
@@ -1,0 +1,47 @@
+//! Device-registration call. POST /api/devices upserts a row keyed by
+//! `deviceId` (unique on the web side) and bumps `lastSyncAt` /
+//! `lastActiveAt` so the dashboard's "Connected Devices" card shows
+//! the desktop online.
+//!
+//! Best-effort: callers spawn this as a background task and ignore
+//! errors — registration failure shouldn't block login or session end.
+
+use crate::error::{AppError, AppResult};
+
+/// POST /api/devices. Returns Ok on any 2xx; non-success surfaces as
+/// `AppError::Api` for the caller to log (and ignore).
+pub async fn register_device(
+    http: &reqwest::Client,
+    token: &str,
+    device_id: &str,
+    device_name: &str,
+    platform: &str,
+    app_version: &str,
+) -> AppResult<()> {
+    let url = format!("{}/api/devices", super::api_base_url());
+    let res = http
+        .post(&url)
+        .bearer_auth(token)
+        .json(&serde_json::json!({
+            "deviceId": device_id,
+            "deviceName": device_name,
+            "platform": platform,
+            "appVersion": app_version,
+        }))
+        .send()
+        .await?;
+
+    let status = res.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let message = res
+        .text()
+        .await
+        .unwrap_or_else(|_| "device registration failed".to_string());
+    Err(AppError::Api {
+        status: status.as_u16(),
+        message,
+        code: None,
+    })
+}

--- a/desktop-app-v3/src-tauri/src/api/mod.rs
+++ b/desktop-app-v3/src-tauri/src/api/mod.rs
@@ -4,6 +4,7 @@
 
 mod auth;
 pub mod activity;
+pub mod devices;
 pub mod preferences;
 pub mod projects;
 pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/commands/auth.rs
+++ b/desktop-app-v3/src-tauri/src/commands/auth.rs
@@ -5,11 +5,39 @@
 //! login round-trip working.
 
 use crate::api::{self, AuthUser};
+use crate::device;
 use crate::error::{AppError, AppResult};
 use crate::AppState;
 use serde::Serialize;
 use tauri::{AppHandle, Runtime, State};
 use tauri_plugin_store::StoreExt;
+
+/// Fire-and-forget POST /api/devices so the web app's "Connected Devices"
+/// card lists this desktop. No-op if the device id cache hasn't populated
+/// yet (very brief launch window). Errors are logged + ignored — device
+/// registration must never block authentication.
+fn fire_register(state: &State<'_, AppState>, token: String) {
+    let Some(device_id) = state.device_id.get().cloned() else {
+        tracing::debug!("device id not cached yet; skipping registration");
+        return;
+    };
+    let http = state.http.clone();
+    tauri::async_runtime::spawn(async move {
+        match api::devices::register_device(
+            &http,
+            &token,
+            &device_id,
+            &device::device_name(),
+            device::platform(),
+            device::app_version(),
+        )
+        .await
+        {
+            Ok(()) => tracing::info!("device registered"),
+            Err(err) => tracing::warn!(?err, "device registration failed"),
+        }
+    });
+}
 
 const STORE_FILE: &str = "auth.bin";
 const KEY_TOKEN: &str = "token";
@@ -34,6 +62,8 @@ pub async fn auth_login<R: Runtime>(
     *state.token.write().await = Some(response.token.clone());
     *state.user.write().await = Some(response.user.clone());
 
+    fire_register(&state, response.token.clone());
+
     Ok(PersistedAuth {
         token: response.token,
         user: response.user,
@@ -50,6 +80,7 @@ pub async fn auth_load<R: Runtime>(
         let token = state.token.read().await.clone();
         let user = state.user.read().await.clone();
         if let (Some(token), Some(user)) = (token, user) {
+            fire_register(&state, token.clone());
             return Ok(Some(PersistedAuth { token, user }));
         }
     }
@@ -66,6 +97,7 @@ pub async fn auth_load<R: Runtime>(
         (Some(token), Some(user)) => {
             *state.token.write().await = Some(token.clone());
             *state.user.write().await = Some(user.clone());
+            fire_register(&state, token.clone());
             Ok(Some(PersistedAuth { token, user }))
         }
         _ => Ok(None),

--- a/desktop-app-v3/src-tauri/src/commands/sessions.rs
+++ b/desktop-app-v3/src-tauri/src/commands/sessions.rs
@@ -8,6 +8,7 @@
 //!     fail the end since the user already clicked "End")
 
 use crate::api::{self, Session};
+use crate::device;
 use crate::error::{AppError, AppResult};
 use crate::store;
 use crate::tracker::TrackerHandle;
@@ -117,6 +118,28 @@ pub async fn session_end(
                 }
             }
         }
+    }
+
+    // Refresh the device row's lastSyncAt — mirrors v2's SyncService which
+    // re-registers after every activity-sync round. Fire-and-forget so a
+    // network blip on the registration POST doesn't fail the session end.
+    if let Some(device_id) = state.device_id.get().cloned() {
+        let http = state.http.clone();
+        let token = token.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(err) = api::devices::register_device(
+                &http,
+                &token,
+                &device_id,
+                &device::device_name(),
+                device::platform(),
+                device::app_version(),
+            )
+            .await
+            {
+                tracing::debug!(?err, "device re-register on session end failed");
+            }
+        });
     }
 
     Ok(session)

--- a/desktop-app-v3/src-tauri/src/device.rs
+++ b/desktop-app-v3/src-tauri/src/device.rs
@@ -1,0 +1,111 @@
+//! Local device identity helpers — used by the `/api/devices` registration
+//! call so the web app can list connected desktops under "Connected Devices".
+//!
+//! `device_id` is intentionally stable across launches AND v2-compatible:
+//! the same `SHA256("$hostname-$username")` → base64url[..32] algorithm the
+//! .NET v2 client uses (see `desktop-app/Services/ApiClient.cs::GetDeviceId`).
+//! That way a user upgrading from v2 to v3 gets the same `deviceId` and the
+//! existing `device_connections` row is updated instead of duplicated.
+//!
+//! The id is cached at `<app_data_dir>/device_id.txt` after first compute so
+//! a hostname/username change post-install doesn't silently mint a new
+//! device row — once a v3 instance has an id, it keeps it.
+
+use crate::error::{AppError, AppResult};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::Path;
+
+const CACHE_FILE: &str = "device_id.txt";
+const ID_LEN: usize = 32;
+
+pub fn platform() -> &'static str {
+    if cfg!(target_os = "linux") {
+        "Linux"
+    } else if cfg!(target_os = "macos") {
+        "macOS"
+    } else if cfg!(target_os = "windows") {
+        "Windows"
+    } else {
+        "Unknown"
+    }
+}
+
+pub fn device_name() -> String {
+    // `devicename()` is whoami's name for the machine (hostname / NetBIOS
+    // name). Falls back to `realname()` (the human-set machine name) only
+    // if the OS hostname read failed — better than empty.
+    let n = whoami::devicename();
+    if n.is_empty() {
+        whoami::realname()
+    } else {
+        n
+    }
+}
+
+pub fn app_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Read the cached device id from disk, or compute + write it on first call.
+/// Caching means the id stays stable even if the user renames their machine
+/// post-install, mirroring v2's behavior.
+pub fn ensure_device_id(app_data_dir: &Path) -> AppResult<String> {
+    let cache_path = app_data_dir.join(CACHE_FILE);
+    if let Ok(existing) = fs::read_to_string(&cache_path) {
+        let trimmed = existing.trim();
+        if trimmed.len() == ID_LEN {
+            return Ok(trimmed.to_string());
+        }
+    }
+    let computed = compute_device_id(&whoami::devicename(), &whoami::username());
+    fs::create_dir_all(app_data_dir)
+        .map_err(|e| AppError::Storage(format!("mkdir app_data_dir: {e}")))?;
+    fs::write(&cache_path, &computed)
+        .map_err(|e| AppError::Storage(format!("write device_id.txt: {e}")))?;
+    Ok(computed)
+}
+
+/// Pure-function device-id derivation. Matches v2 desktop's algorithm so
+/// migrating users get the same id.
+fn compute_device_id(hostname: &str, username: &str) -> String {
+    let unique = format!("{hostname}-{username}");
+    let digest = Sha256::digest(unique.as_bytes());
+    // Standard base64 (with `+` `/` chars), then map to URL-safe to match v2's
+    // `Replace("+", "-").Replace("/", "_")`. NO_PAD strips trailing `=` —
+    // v2 keeps padding but truncates to 32 chars before any `=` shows up
+    // (SHA-256 → 44 b64 chars, the single `=` is at position 43).
+    let b64 = URL_SAFE_NO_PAD.encode(digest);
+    b64.chars().take(ID_LEN).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_id_is_stable() {
+        let a = compute_device_id("host", "user");
+        let b = compute_device_id("host", "user");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), ID_LEN);
+    }
+
+    #[test]
+    fn device_id_changes_with_input() {
+        let a = compute_device_id("host", "alice");
+        let b = compute_device_id("host", "bob");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn device_id_is_url_safe() {
+        let id = compute_device_id("host", "user");
+        // No `+` or `/` — those would break URL handling on the server side.
+        assert!(!id.contains('+'));
+        assert!(!id.contains('/'));
+        assert!(!id.contains('='));
+    }
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@
 mod api;
 mod blocking;
 mod commands;
+mod device;
 mod error;
 mod store;
 mod sync_worker;
@@ -72,6 +73,11 @@ pub struct AppState {
     pub http: reqwest::Client,
     pub tracker: Arc<RwLock<Option<tracker::TrackerHandle>>>,
     pub db: Arc<std::sync::OnceLock<store::Db>>,
+    /// 32-char URL-safe base64 id derived once from hostname+username
+    /// and cached at `<app_data_dir>/device_id.txt`. Set in `setup`.
+    /// Empty until then — callers should `.get()` and skip registration
+    /// if the cache hasn't populated yet (very brief window during launch).
+    pub device_id: Arc<std::sync::OnceLock<String>>,
 }
 
 impl AppState {
@@ -91,6 +97,7 @@ impl AppState {
             http,
             tracker: Arc::new(RwLock::new(None)),
             db: Arc::new(std::sync::OnceLock::new()),
+            device_id: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -161,6 +168,21 @@ pub fn run() {
                 .path()
                 .app_data_dir()
                 .map_err(|e| format!("resolve app_data_dir: {e}"))?;
+
+            // Compute (or load) the cached device id. Best-effort: a failure
+            // here means the "Connected Devices" card on the web won't list
+            // this desktop, but everything else still works.
+            match device::ensure_device_id(&app_data_dir) {
+                Ok(id) => {
+                    let state: tauri::State<'_, AppState> = app.state();
+                    let _ = state.device_id.set(id);
+                    tracing::info!("device id cached");
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "device id unavailable; /api/devices won't be called");
+                }
+            }
+
             let db_path = app_data_dir.join("local.sqlite");
             match store::open(&db_path) {
                 Ok(db) => {


### PR DESCRIPTION
## What was broken

The web app's **Connected Devices** card never listed v3 desktop installs. Reproduces with: install v3, sign in → web settings page shows "No devices connected" instead of your machine.

Root cause: the v3 desktop never called `POST /api/devices`. The endpoint exists and the v2 .NET client uses it; v3 just hadn't wired it up.

## Fix

Mirrors the v2 pattern in [desktop-app/Services/ApiClient.cs::RegisterDeviceAsync](desktop-app/Services/ApiClient.cs#L381-L417) — same deviceId algorithm so a user upgrading v2 → v3 updates their existing `device_connections` row instead of duplicating it.

### Wire-up

| Trigger | Where |
|---|---|
| Fresh login | `commands::auth::auth_login` → fire-and-forget after token persisted |
| Cached-token cold start | `commands::auth::auth_load` (cache hit + store hit paths) |
| Periodic heartbeat | `commands::sessions::session_end` after activity sync — refreshes `lastSyncAt` / `lastActiveAt` |

All registration calls are **best-effort**: errors log + ignore so a flaky network never blocks auth or session end.

### Files

| File | Lines | What |
|---|---|---|
| `src-tauri/src/device.rs` (new) | 111 | deviceId derivation (SHA-256 of `"$hostname-$username"` → URL-safe base64, first 32 chars), cached at `<app_data_dir>/device_id.txt`; `platform()` / `device_name()` / `app_version()` helpers; 3 unit tests |
| `src-tauri/src/api/devices.rs` (new) | 47 | `register_device()` — POST /api/devices with `{deviceId, deviceName, platform, appVersion}` |
| `src-tauri/src/api/mod.rs` | +1 | `pub mod devices;` |
| `src-tauri/src/lib.rs` | +22 | `mod device;` + `AppState.device_id` OnceLock + setup() populates the cache |
| `src-tauri/src/commands/auth.rs` | +32 | `fire_register()` helper invoked from auth_login + auth_load |
| `src-tauri/src/commands/sessions.rs` | +23 | Re-register after activity sync to keep `lastSyncAt` fresh |
| `src-tauri/Cargo.toml` | +7 | `whoami = \"1\"`, `sha2 = \"0.10\"`, `base64 = \"0.22\"` |

Net: +243 / -0 LOC, 7 files.

### v2 compatibility

The deviceId is deterministic and identical to v2's output:
1. `unique = "$hostname-$username"`
2. `digest = SHA256(unique)`
3. `b64 = base64_url(digest)` (`+` → `-`, `/` → `_`, no padding)
4. `id = b64[..32]`

A user with v2 installed who switches to v3 sees their existing device row's `lastSyncAt` refresh — no duplicate entry.

## Tests

```
running 3 tests
test device::tests::device_id_changes_with_input ... ok
test device::tests::device_id_is_url_safe ... ok
test device::tests::device_id_is_stable ... ok
```

## Verification

```bash
cd desktop-app-v3
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
# Sign in. The Tauri terminal should log "device registered".
# Refresh flowshield.app/settings → "Connected Devices" now lists this machine.
# Run a 1-min session and let it auto-end → "device re-register on session end" or another success log.
# `lastSyncAt` on the web should have moved forward.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)