### PR TITLE
fix(desktop-v3): poll active session every 30s for cross-device sync

### DIFF
--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -96,6 +96,24 @@ export function DashboardPage() {
     void refresh();
   }, [refresh]);
 
+  // Cross-device session sync — pause / resume / end fired on the web
+  // app or mobile lands here within 30s. Without this poll, a user who
+  // pauses on one surface and resumes on another sees the desktop frozen
+  // in the stale state. Mirrors v2 desktop's `_reSyncTimer` convention
+  // (see CLAUDE.md gotchas).
+  //
+  // Skips if a local mutation is in flight (`loading`) to avoid an
+  // overwrite race where the poll's stale response lands after a fresh
+  // togglePause / start / end response.
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!useSessionStore.getState().loading) {
+        void refresh();
+      }
+    }, 30_000);
+    return () => clearInterval(id);
+  }, [refresh]);
+
   useEffect(() => {
     void projects.refresh();
   }, [projects.refresh]);


### PR DESCRIPTION
## What was broken

The v3 desktop only refreshed the active session on mount, so a pause/resume/end fired on the web app (or mobile) never propagated until the user clicked something locally. Reproducer:

1. Start a focus session.
2. Pause it from the desktop app.
3. Switch to the web dashboard, click Resume.
4. Look at the desktop — still shows paused. Forever.

The v2 .NET desktop solved this with a 30s \`_reSyncTimer\` (called out in [CLAUDE.md gotchas](.claude/rules/gotchas.md)). v3 just hadn't ported it.

## Fix

Single \`useEffect\` in DashboardPage that registers a \`setInterval\` ticking every 30s, calling \`useSessionStore.refresh()\` which invokes the existing \`session_active\` Tauri command (\`GET /api/sessions/active\`). 30s matches v2's cadence exactly.

Skip guard: if a local mutation is in flight (\`useSessionStore.getState().loading\` is true), skip this iteration — avoids an overwrite race where the poll's stale response lands after a fresh \`togglePause\` / \`start\` / \`end\` response.

## Files

| File | Lines | What |
|---|---|---|
| \`src/routes/DashboardPage.tsx\` | +18 | New useEffect — 30s setInterval calling refresh, with loading-state guard and unmount cleanup |

Net: +18 / -0 LOC, 1 file.

## Out of scope

- **Pusher real-time integration** — proper long-term fix (subsecond cross-device propagation, no polling). v3 doesn't have any Pusher wiring yet; matching v2's polling baseline first, then layering Pusher later as its own phase.

## Verification

\`\`\`bash
cd desktop-app-v3
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
# 1. Start a session on the desktop.
# 2. Open flowshield.app/dashboard in a browser.
# 3. On the web: pause the session.
# 4. Wait up to 30s — desktop dashboard should flip to the paused state automatically.
# 5. On the web: resume.
# 6. Wait up to 30s — desktop should flip back to running.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)