### PR TITLE
fix(desktop-v3): npm script to install dev .desktop entry on Linux

### DIFF
--- a/desktop-app-v3/README.md
+++ b/desktop-app-v3/README.md
@@ -85,6 +85,26 @@ This is a runtime UX requirement on GNOME Wayland, not a build
 dependency. KDE / XFCE / GNOME-on-X11 ship native tray support and
 need no extension.
 
+### Linux: dev-build taskbar / dock icon shows generic art
+
+GNOME (and most Wayland compositors) match taskbar / dock icons by
+`app_id` against an **installed `.desktop` file**. `npm run tauri:dev`
+just runs the binary out of `target/debug/` — nothing's installed —
+so the OS falls back to a generic icon even though the FlowShield
+logo is bundled into the binary.
+
+Run this **once** per machine to install a dev `.desktop` entry that
+points at the dev binary + the FlowShield icon:
+
+```bash
+npm run dev:install-desktop-entry
+```
+
+Then quit any running FlowShield window (right-click tray → Quit) and
+relaunch `npm run tauri:dev` — the FlowShield logo now appears in the
+taskbar / dock. Released `.deb` / `.rpm` / `.AppImage` installers
+drop their own `.desktop` file and don't need this step.
+
 ## Icons
 
 The FlowShield-branded app icons live in `src-tauri/icons/` and are

--- a/desktop-app-v3/package.json
+++ b/desktop-app-v3/package.json
@@ -11,7 +11,8 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "dev:install-desktop-entry": "node scripts/install-desktop-entry.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",

--- a/desktop-app-v3/scripts/install-desktop-entry.mjs
+++ b/desktop-app-v3/scripts/install-desktop-entry.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Install a freedesktop .desktop file pointing at the dev binary so GNOME /
+// KDE / etc. show the FlowShield icon in the taskbar / dock when running
+// `npm run tauri:dev`. One-time setup per machine.
+//
+// Without this, GNOME Shell on Wayland matches taskbar icons by `app_id`
+// against an installed .desktop file — and dev builds aren't installed
+// anywhere, so it falls back to a generic icon. This is a Linux-only
+// workaround; macOS / Windows handle dev icons differently and don't
+// need it.
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The Tauri bundle identifier already ends in `.desktop`, which IS the
+// XDG file extension — so the filename matches the identifier verbatim.
+// (No re-appending `.desktop` or we'd end up with `*.desktop.desktop`.)
+const APP_ID = 'app.flowshield.desktop';
+
+if (platform() !== 'linux') {
+  console.log(`Not Linux (${platform()}) — skipping. macOS / Windows dev builds`);
+  console.log(`already pick up the right icon from the bundle config.`);
+  process.exit(0);
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..'); // desktop-app-v3/
+const binary = resolve(repoRoot, 'src-tauri/target/debug/flowshield-desktop');
+const iconPath = resolve(repoRoot, 'src-tauri/icons/icon.png');
+
+if (!existsSync(iconPath)) {
+  console.error(`✗ Icon not found at ${iconPath}`);
+  console.error(`  Did you check out the latest main? The branded icons live in src-tauri/icons/.`);
+  process.exit(1);
+}
+
+const installDir = join(homedir(), '.local', 'share', 'applications');
+const targetPath = join(installDir, APP_ID); // APP_ID already ends in .desktop
+
+// Transitional cleanup: an earlier version of this script appended an
+// extra `.desktop`, leaving `app.flowshield.desktop.desktop` lying around.
+// Remove it if present so GNOME doesn't pick the wrong one.
+const legacyDuplicate = join(installDir, `${APP_ID}.desktop`);
+if (existsSync(legacyDuplicate)) {
+  rmSync(legacyDuplicate);
+  console.log(`✓ Removed legacy duplicate ${legacyDuplicate}`);
+}
+
+const contents = `[Desktop Entry]
+Name=FlowShield (dev)
+Comment=FlowShield desktop client — development build
+Exec=${binary}
+Icon=${iconPath}
+Type=Application
+Terminal=false
+StartupWMClass=${APP_ID}
+StartupNotify=true
+Categories=Utility;Productivity;
+`;
+
+mkdirSync(installDir, { recursive: true });
+writeFileSync(targetPath, contents);
+console.log(`✓ Wrote ${targetPath}`);
+
+// Best-effort: refresh GNOME's desktop file cache so the new entry shows up
+// without a logout/login. Not all distros ship update-desktop-database; if
+// it's missing we just continue — GNOME picks it up at next session start.
+try {
+  execSync(`update-desktop-database ${installDir}`, { stdio: 'ignore' });
+  console.log(`✓ Refreshed desktop database`);
+} catch {
+  console.log(`⚠ update-desktop-database not available — entry will activate at next login`);
+}
+
+if (!existsSync(binary)) {
+  console.log('');
+  console.log(`Note: ${binary} doesn't exist yet.`);
+  console.log(`Run \`npm run tauri:dev\` once to build it. The .desktop entry`);
+  console.log(`will start working as soon as the binary appears.`);
+}
+
+console.log('');
+console.log(`Done. Quit any running FlowShield window (right-click tray → Quit) and`);
+console.log(`relaunch \`npm run tauri:dev\` — the FlowShield logo should now appear`);
+console.log(`in your taskbar / dock.`);


### PR DESCRIPTION
## What was broken

GNOME (and most Wayland compositors) match taskbar / dock icons by \`app_id\` against an installed \`.desktop\` file. \`npm run tauri:dev\` runs the binary out of \`target/debug/\` — nothing's installed — so the OS falls back to a generic icon even though the FlowShield logo is bundled into the binary (PR #48).

User-facing symptom: branded icons in PR #48 land, but the **taskbar still shows a generic icon** in dev. Released installers (\`.deb\` / \`.rpm\` / \`.AppImage\`) drop their own .desktop file at install time so this is a dev-only paper-cut.

## Fix

New \`npm run dev:install-desktop-entry\` Node script:

- **Skips on macOS / Windows** with a friendly message — they handle dev icons differently and don't need this.
- **Resolves absolute paths** to the dev binary (\`target/debug/flowshield-desktop\`) and the FlowShield icon (\`src-tauri/icons/icon.png\`) at runtime via \`import.meta.url\` + \`os.homedir()\`.
- **Writes** \`~/.local/share/applications/app.flowshield.desktop\` with the right \`Exec\`, \`Icon\`, and \`StartupWMClass\` (matches Tauri's bundle id so the WM connects window → entry).
- **Refreshes GNOME's cache** via \`update-desktop-database\` (best-effort; missing tool is non-fatal).
- **Errors clearly** if the icon hasn't been checked out (PR #48 must be merged) or the binary doesn't exist yet (build first).
- **Cleans up** the legacy \`app.flowshield.desktop.desktop\` (double-extension) duplicate from an early iteration of the script.

## Files

| File | Lines | What |
|---|---|---|
| \`scripts/install-desktop-entry.mjs\` (new) | 88 | The Node ESM script |
| \`package.json\` | +1 | New \`dev:install-desktop-entry\` npm script |
| \`README.md\` | +20 | New \"Linux: dev-build taskbar / dock icon\" subsection pointing at the script |

Net: +110 / -1 LOC, 3 files (1 new).

## Verification

\`\`\`bash
cd desktop-app-v3
npm run dev:install-desktop-entry
# ✓ Wrote /home/<user>/.local/share/applications/app.flowshield.desktop
# ✓ Refreshed desktop database

# Quit any running FlowShield window (right-click tray → Quit)
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev
# Taskbar / dock now shows the FlowShield logo.
\`\`\`

Idempotent — running the script again overwrites the file with current paths (useful if you move the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)