### PR TITLE
feat(desktop-v3): pusher real-time for cross-device session sync

### DIFF
--- a/desktop-app-v3/package.json
+++ b/desktop-app-v3/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/plugin-notification": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "@tauri-apps/plugin-store": "^2.1.0",
+    "pusher-js": "^8.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.0",

--- a/desktop-app-v3/src-tauri/src/api/mod.rs
+++ b/desktop-app-v3/src-tauri/src/api/mod.rs
@@ -7,10 +7,12 @@ pub mod activity;
 pub mod devices;
 pub mod preferences;
 pub mod projects;
+pub mod realtime;
 pub mod sessions;
 
 pub use auth::{login, AuthUser};
 pub use preferences::Preferences;
+pub use realtime::RealtimeConfig;
 pub use sessions::Session;
 
 /// Default API base URL. Overrideable at runtime via the `FLOWSHIELD_API_URL`

--- a/desktop-app-v3/src-tauri/src/api/realtime.rs
+++ b/desktop-app-v3/src-tauri/src/api/realtime.rs
@@ -1,0 +1,31 @@
+//! Realtime (Pusher Channels) configuration fetcher. The web side
+//! exposes the client-safe key + cluster at /api/config/realtime so the
+//! desktop doesn't have to bake them into the binary at compile time.
+
+use crate::error::{AppError, AppResult};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RealtimeConfig {
+    pub key: String,
+    pub cluster: String,
+}
+
+/// GET /api/config/realtime — public endpoint, no bearer token.
+/// Returns empty strings if the server hasn't configured Pusher yet
+/// (e.g. local dev with placeholder env). The frontend treats that as
+/// "Pusher disabled, keep polling" and degrades gracefully.
+pub async fn get_config(http: &reqwest::Client) -> AppResult<RealtimeConfig> {
+    let url = format!("{}/api/config/realtime", super::api_base_url());
+    let res = http.get(&url).send().await?;
+
+    let status = res.status();
+    if !status.is_success() {
+        return Err(AppError::Api {
+            status: status.as_u16(),
+            message: "failed to fetch realtime config".into(),
+            code: None,
+        });
+    }
+    Ok(res.json::<RealtimeConfig>().await.unwrap_or_default())
+}

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -8,4 +8,5 @@ mod elevation;
 pub mod ping;
 pub mod preferences;
 pub mod projects;
+pub mod realtime;
 pub mod sessions;

--- a/desktop-app-v3/src-tauri/src/commands/realtime.rs
+++ b/desktop-app-v3/src-tauri/src/commands/realtime.rs
@@ -1,0 +1,12 @@
+//! Realtime config command. The frontend calls `realtime_config` once on
+//! login to discover the Pusher key + cluster for its WebSocket connection.
+
+use crate::api::{self, RealtimeConfig};
+use crate::error::AppResult;
+use crate::AppState;
+use tauri::State;
+
+#[tauri::command]
+pub async fn realtime_config(state: State<'_, AppState>) -> AppResult<RealtimeConfig> {
+    api::realtime::get_config(&state.http).await
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -212,6 +212,7 @@ pub fn run() {
             commands::blocking::blocking_clear,
             commands::blocking::blocking_status,
             commands::preferences::prefs_load,
+            commands::realtime::realtime_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src-tauri/tauri.conf.json
+++ b/desktop-app-v3/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       "tooltip": "FlowShield"
     },
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' data: blob:; connect-src 'self' https://flowshield.app https://*.flowshield.app ipc: http://ipc.localhost; img-src 'self' data: https:"
+      "csp": "default-src 'self' 'unsafe-inline' data: blob:; connect-src 'self' https://flowshield.app https://*.flowshield.app wss://*.pusher.com https://*.pusher.com wss://*.pusherapp.com https://*.pusherapp.com ipc: http://ipc.localhost; img-src 'self' data: https:"
     }
   },
   "bundle": {

--- a/desktop-app-v3/src/lib/realtime.ts
+++ b/desktop-app-v3/src/lib/realtime.ts
@@ -1,0 +1,117 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import Pusher, { type Channel } from 'pusher-js';
+import { useSessionStore } from './sessions';
+
+interface RealtimeConfig {
+  key: string;
+  cluster: string;
+}
+
+type RealtimeStatus = 'idle' | 'connecting' | 'connected' | 'failed';
+
+interface RealtimeState {
+  status: RealtimeStatus;
+  error: string | null;
+
+  /**
+   * Spin up the Pusher client and subscribe to `user-${userId}` channel.
+   * Idempotent — calling twice while already connected is a no-op. Calling
+   * with a different userId disconnects and reconnects.
+   */
+  connect: (userId: string) => Promise<void>;
+  /** Tear down the Pusher client + channel subscription. */
+  disconnect: () => void;
+}
+
+// Module-private — held outside the Zustand store because Pusher's client
+// instance isn't serializable and shouldn't trigger re-renders. The store
+// only tracks observable status flags.
+let client: Pusher | null = null;
+let channel: Channel | null = null;
+let connectedUserId: string | null = null;
+
+function teardown(): void {
+  if (channel) {
+    channel.unbind_all();
+    channel = null;
+  }
+  if (client) {
+    client.disconnect();
+    client = null;
+  }
+  connectedUserId = null;
+}
+
+export const useRealtimeStore = create<RealtimeState>((set) => ({
+  status: 'idle',
+  error: null,
+
+  connect: async (userId: string) => {
+    if (connectedUserId === userId && client) {
+      return; // Already connected to the right channel.
+    }
+    teardown();
+    set({ status: 'connecting', error: null });
+
+    let config: RealtimeConfig;
+    try {
+      config = await invoke<RealtimeConfig>('realtime_config');
+    } catch (err) {
+      set({ status: 'failed', error: errorMessage(err, 'failed to fetch realtime config') });
+      return;
+    }
+
+    if (!config.key || !config.cluster) {
+      // Server hasn't configured Pusher (placeholder env, etc). Stay idle so
+      // callers know real-time is off; the 30s session-active poll keeps the
+      // dashboard fresh as a fallback.
+      set({ status: 'idle', error: null });
+      return;
+    }
+
+    try {
+      client = new Pusher(config.key, {
+        cluster: config.cluster,
+        forceTLS: true,
+      });
+      channel = client.subscribe(`user-${userId}`);
+      // session-update is the canonical "something changed" ping; the web
+      // sends it for start/end/pause/resume. Empty payload — we always
+      // re-fetch authoritative state from /api/sessions/active to avoid
+      // trusting partial events.
+      channel.bind('session-update', () => {
+        void useSessionStore.getState().refresh();
+      });
+
+      client.connection.bind('connected', () => {
+        set({ status: 'connected', error: null });
+      });
+      client.connection.bind('error', (err: unknown) => {
+        // Pusher auto-reconnects; we just surface the most recent error
+        // for diagnostics. Status stays 'connected' / 'connecting' as it
+        // walks through reconnect states.
+        set({ error: errorMessage(err, 'realtime connection error') });
+      });
+
+      connectedUserId = userId;
+    } catch (err) {
+      teardown();
+      set({ status: 'failed', error: errorMessage(err, 'failed to connect to realtime') });
+    }
+  },
+
+  disconnect: () => {
+    teardown();
+    set({ status: 'idle', error: null });
+  },
+}));
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const obj = err as { message?: string; error?: string };
+    return obj.message ?? obj.error ?? fallback;
+  }
+  return fallback;
+}

--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { useSessionStore } from '../lib/sessions';
 import { useProjectsStore, type Project } from '../lib/projects';
 import { usePrefsStore } from '../lib/preferences';
 import { useBlockingStore } from '../lib/blocking';
+import { useRealtimeStore } from '../lib/realtime';
 import { Button } from '../components/Button';
 import { Timer } from '../components/Timer';
 
@@ -96,11 +97,24 @@ export function DashboardPage() {
     void refresh();
   }, [refresh]);
 
-  // Cross-device session sync — pause / resume / end fired on the web
-  // app or mobile lands here within 30s. Without this poll, a user who
-  // pauses on one surface and resumes on another sees the desktop frozen
-  // in the stale state. Mirrors v2 desktop's `_reSyncTimer` convention
-  // (see CLAUDE.md gotchas).
+  // Real-time cross-device session sync via Pusher Channels. Subscribes
+  // to `user-${user.id}` and refreshes on every session-update event the
+  // web emits (start / end / pause / resume). Subsecond instead of the
+  // 30s poll's worst case. If Pusher isn't configured (placeholder env)
+  // or the connection fails, the poll below picks up the slack.
+  useEffect(() => {
+    const userId = user?.id;
+    if (!userId) return;
+    void useRealtimeStore.getState().connect(userId);
+    return () => {
+      useRealtimeStore.getState().disconnect();
+    };
+  }, [user?.id]);
+
+  // Polling fallback for cross-device session sync — kept as a backstop
+  // for transient Pusher disconnects, dev environments without Pusher
+  // configured, and the brief window before the WebSocket connects.
+  // Mirrors v2 desktop's `_reSyncTimer` convention (CLAUDE.md gotchas).
   //
   // Skips if a local mutation is in flight (`loading`) to avoid an
   // overwrite race where the poll's stale response lands after a fresh

--- a/web-app/src/app/api/config/realtime/route.ts
+++ b/web-app/src/app/api/config/realtime/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Public endpoint exposing the client-safe Pusher Channels configuration
+ * (key + cluster). These values are already inlined into the web's client
+ * bundle as NEXT_PUBLIC_PUSHER_*; this endpoint exists so non-web clients
+ * (the v3 desktop, future mobile native, etc.) can fetch them at runtime
+ * without a recompile per environment.
+ *
+ * No auth — same surface as the JS bundle. The PUSHER_SECRET is never
+ * returned and lives only on the server.
+ *
+ * Returns empty strings (not 404 / 500) when env isn't configured so
+ * clients can degrade gracefully — the desktop falls back to its 30s
+ * session-active poll if the key comes back empty.
+ */
+export async function GET() {
+  return NextResponse.json({
+    key: process.env.NEXT_PUBLIC_PUSHER_KEY ?? process.env.PUSHER_KEY ?? '',
+    cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER ?? process.env.PUSHER_CLUSTER ?? '',
+  });
+}


### PR DESCRIPTION
## What changes

Replaces the 30s session-active poll's UX with **subsecond Pusher push events**. Polling stays as a backstop for transient WebSocket drops + dev environments without Pusher configured.

The user-visible bug from PR #47 (pause on desktop → resume on web → desktop frozen for up to 30s) collapses to subsecond.

## How it works

| Layer | Change |
|---|---|
| **Web** | New public \`GET /api/config/realtime\` returns \`{ key, cluster }\` from server env. No auth — these values are already inlined into the Next.js client bundle as \`NEXT_PUBLIC_PUSHER_*\`. Empty strings (not 4xx/5xx) when env isn't configured so clients degrade gracefully. |
| **Desktop Rust** | \`api::realtime::get_config\` HTTP wrapper + \`commands::realtime::realtime_config\` Tauri command exposing the config to JS. |
| **Desktop frontend** | New \`useRealtimeStore\` Zustand store using \`pusher-js\`. \`connect(userId)\` fetches config, opens WebSocket, subscribes to \`user-${userId}\` channel, binds \`session-update\` event. Empty payload — handler always re-fetches authoritative state via \`useSessionStore.refresh()\` (no trusting partial events). |
| **DashboardPage** | \`useEffect\` keyed on \`user?.id\` calls \`connect\` on mount, \`disconnect\` on unmount/logout. The 30s poll's role updated from \"primary cross-device sync\" to \"fallback for Pusher down/disabled\". |
| **CSP** | \`tauri.conf.json\` \`connect-src\` extended with \`wss://*.pusher.com https://*.pusher.com wss://*.pusherapp.com https://*.pusherapp.com\` to authorize the WebSocket + sockjs fallback. |

The web side already emits \`session-update\` on every start/end/pause/resume + auto-end (existing — no web change beyond the new config endpoint).

## Files

| File | Lines | What |
|---|---|---|
| \`web-app/src/app/api/config/realtime/route.ts\` (new) | 22 | Public GET — returns Pusher key + cluster |
| \`src-tauri/src/api/realtime.rs\` (new) | 31 | HTTP fetcher + RealtimeConfig struct |
| \`src-tauri/src/commands/realtime.rs\` (new) | 12 | \`realtime_config\` Tauri command |
| \`src-tauri/src/api/mod.rs\` | +2 | mod registration + RealtimeConfig re-export |
| \`src-tauri/src/commands/mod.rs\` | +1 | mod registration |
| \`src-tauri/src/lib.rs\` | +1 | Register \`realtime_config\` in invoke_handler |
| \`src-tauri/tauri.conf.json\` | +1/-1 | CSP connect-src extended for Pusher endpoints |
| \`src/lib/realtime.ts\` (new) | 117 | useRealtimeStore Zustand: status/error + connect/disconnect; pusher-js client |
| \`src/routes/DashboardPage.tsx\` | +24/-6 | useEffect for connect/disconnect + comment updates on the poll |
| \`package.json\` | +1 | pusher-js ^8 dep (~63KB gzip) |

Net: +207 / -6 LOC, 10 files (4 new).

## Verification

\`\`\`bash
cd desktop-app-v3
npm install               # picks up pusher-js
WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri:dev

# 1. Sign in. Open the dev console.
# 2. window.__TAURI_INTERNALS__ should still resolve as before.
# 3. Open flowshield.app/dashboard in a browser, signed into the same account.
# 4. On the web: pause the session. The desktop should reflect the change
#    within ~1 second (instead of up to 30s).
# 5. On the web: resume. Same — subsecond.
\`\`\`

If \`/api/config/realtime\` returns empty strings (local dev with placeholder env), the desktop logs nothing and the 30s poll keeps the dashboard fresh.

## Out of scope

- **Goal-update / activity-synced events** — the web emits these too but the desktop doesn't surface goals or live activity rendering yet. Easy to add if a future surface needs them.
- **Authenticated channels** — current channel is public per v2's pattern. Pusher private/presence channels would need a server-side auth endpoint. Not needed for the data we publish (no PII in the empty payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)