### PR TITLE
feat: tag-driven release pipeline for desktop-v3 Linux bundles

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,9 +1,13 @@
 name: Desktop App Release
 
+# v1.* and v2.* tags fire this workflow (the .NET v2 Windows release).
+# v3.* tags fire .github/workflows/desktop-v3-release.yml instead — the
+# Tauri Linux/macOS/Windows pipeline. Don't broaden this glob without
+# disambiguating, or both workflows will fire on the same tag.
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-2].*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -1,0 +1,163 @@
+name: Desktop v3 Release
+
+# v3.* tags fire this workflow (the Tauri 2 desktop pipeline).
+# v1.* / v2.* tags fire .github/workflows/desktop-release.yml instead
+# (the legacy .NET v2 Windows pipeline). Don't broaden either glob
+# without disambiguating, or both workflows will fire on the same tag.
+on:
+  push:
+    tags:
+      - 'v3.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (manual runs only — must already exist on origin)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+jobs:
+  build-linux:
+    name: Build Linux bundles
+    # Pinned to 22.04 because Tauri's webkit2gtk-4.1 dep doesn't ship on
+    # newer Ubuntu yet; bump when 24.04 catches up.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxss-dev \
+            patchelf \
+            file
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: desktop-app-v3/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop-app-v3/src-tauri
+
+      - name: Install JS deps
+        working-directory: desktop-app-v3
+        # `npm ci` requires package-lock.json. The repo currently doesn't
+        # commit it (Cargo.lock convention), so fall back to npm install
+        # if ci fails.
+        run: npm ci || npm install
+
+      - name: Build Tauri bundles
+        working-directory: desktop-app-v3
+        run: npm run tauri:build
+
+      - name: Stage release artifacts
+        run: |
+          mkdir -p release-artifacts
+          cp desktop-app-v3/src-tauri/target/release/bundle/deb/*.deb release-artifacts/ 2>/dev/null || true
+          cp desktop-app-v3/src-tauri/target/release/bundle/rpm/*.rpm release-artifacts/ 2>/dev/null || true
+          cp desktop-app-v3/src-tauri/target/release/bundle/appimage/*.AppImage release-artifacts/ 2>/dev/null || true
+          echo "--- staged artifacts ---"
+          ls -la release-artifacts/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bundles
+          path: release-artifacts/
+          if-no-files-found: error
+          retention-days: 7
+
+  sign-and-release:
+    name: Sign + publish to GitHub Releases
+    needs: build-linux
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-bundles
+          path: release-artifacts
+
+      - name: Generate SHA256SUMS
+        working-directory: release-artifacts
+        run: |
+          sha256sum * > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Import GPG signing key
+        id: gpg
+        # Skip silently if the secret isn't provisioned yet — the release
+        # still ships, just without GPG signatures. Provision the secret
+        # (Settings → Secrets → Actions → GPG_PRIVATE_KEY, ASCII-armored)
+        # when ready.
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "::warning::GPG_PRIVATE_KEY secret not set — skipping signing. Bundles will publish unsigned."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          echo "use-agent" > ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ { print $5; exit }')
+          echo "key_id=$KEY_ID" >> "$GITHUB_OUTPUT"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Imported GPG key $KEY_ID"
+
+      - name: Sign artifacts
+        if: steps.gpg.outputs.signed == 'true'
+        working-directory: release-artifacts
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          KEY_ID: ${{ steps.gpg.outputs.key_id }}
+        run: |
+          # Detached signatures for each bundle artifact. Users verify with:
+          #   gpg --verify flowshield_X.Y.Z_amd64.deb.asc flowshield_X.Y.Z_amd64.deb
+          for f in *.deb *.rpm *.AppImage; do
+            [ -f "$f" ] || continue
+            gpg --batch --yes --pinentry-mode loopback \
+              --passphrase "$GPG_PASSPHRASE" \
+              --local-user "$KEY_ID" \
+              --detach-sign --armor --output "$f.asc" "$f"
+          done
+          # Clearsigned SHA256SUMS — single source of truth that ties all
+          # artifacts together; what most distros expect for verification.
+          gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "$GPG_PASSPHRASE" \
+            --local-user "$KEY_ID" \
+            --clearsign --output SHA256SUMS.asc SHA256SUMS
+          echo "--- signed artifacts ---"
+          ls -la
+
+      - name: Publish to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: FlowShield Desktop ${{ env.TAG }}
+          generate_release_notes: true
+          files: |
+            release-artifacts/*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FlowShield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/desktop-app-v3/README.md
+++ b/desktop-app-v3/README.md
@@ -11,6 +11,49 @@ top of a Rust backend.
 > out of scope for this PR — see the legacy `desktop-app/` for the
 > Windows-only feature set we're working back toward.
 
+## Install (end-user)
+
+Latest builds are on the [Releases page](https://github.com/asifthewebguy/FlowShield/releases?q=v3&expanded=true).
+
+### AppImage (any distro — easiest)
+
+```bash
+chmod +x flowshield_X.Y.Z_amd64.AppImage
+./flowshield_X.Y.Z_amd64.AppImage
+```
+
+### Debian / Ubuntu / Pop!_OS / Mint
+
+```bash
+sudo apt install ./flowshield_X.Y.Z_amd64.deb
+```
+
+### Fedora / RHEL / openSUSE
+
+```bash
+sudo dnf install ./flowshield-X.Y.Z-1.x86_64.rpm
+```
+
+### Arch Linux / Manjaro (AUR)
+
+```bash
+yay -S flowshield-bin
+# or:
+paru -S flowshield-bin
+```
+
+### Verifying signatures
+
+Each release ships with `SHA256SUMS` + `SHA256SUMS.asc` and a `.asc`
+detached signature alongside every binary. Verify with:
+
+```bash
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum --check SHA256SUMS --ignore-missing
+```
+
+The signing key fingerprint is published in the GitHub Release notes.
+
 ## Why Tauri 2 + Rust?
 
 - **~8 MB installers** vs Electron's ~200 MB. Auto-start on every login

--- a/desktop-app-v3/src-tauri/tauri.conf.json
+++ b/desktop-app-v3/src-tauri/tauri.conf.json
@@ -34,7 +34,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm", "appimage", "nsis", "dmg"],
+    "publisher": "FlowShield",
+    "copyright": "Copyright © 2026 FlowShield. MIT License.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -44,6 +46,17 @@
     ],
     "category": "Productivity",
     "shortDescription": "Track your focus across desktop and web.",
-    "longDescription": "FlowShield is a cross-platform productivity tracker that pairs with the FlowShield web dashboard."
+    "longDescription": "FlowShield is a cross-platform productivity tracker that pairs with the FlowShield web dashboard.",
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libayatana-appindicator3-1", "libssl3"]
+      },
+      "rpm": {
+        "depends": ["webkit2gtk4.1", "libappindicator-gtk3", "openssl-libs"]
+      },
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    }
   }
 }

--- a/scripts/release/update-aur.sh
+++ b/scripts/release/update-aur.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Bump the flowshield-bin AUR PKGBUILD to a new GitHub Release.
+#
+# Usage:
+#   cd ~/path/to/flowshield-aur          # the separate AUR repo clone
+#   ../FlowShield/scripts/release/update-aur.sh v3.0.0-alpha.0
+#
+# What it does:
+#   1. Verify the GitHub Release for the given tag exists and has the
+#      .AppImage asset attached.
+#   2. Download the .AppImage, compute its SHA-256.
+#   3. Rewrite the local PKGBUILD's `pkgver` and `sha256sums` to point
+#      at the new release.
+#   4. Run `makepkg --printsrcinfo > .SRCINFO` so the AUR has the
+#      canonical metadata (AUR rejects pushes without a matching one).
+#
+# After running, review `git diff`, then `git commit && git push` to
+# publish to AUR.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <tag>" >&2
+  echo "  e.g. $0 v3.0.0-alpha.0" >&2
+  exit 2
+fi
+
+TAG="$1"
+# Strip the leading 'v' for pkgver. AUR convention: pkgver is just the
+# semver without prefix. The 'v' stays in the GitHub URL though.
+PKGVER="${TAG#v}"
+REPO="asifthewebguy/FlowShield"
+APPIMAGE="flowshield_${PKGVER}_amd64.AppImage"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${APPIMAGE}"
+
+if [ ! -f PKGBUILD ]; then
+  echo "✗ No PKGBUILD in $(pwd) — run this from inside the flowshield-aur clone" >&2
+  exit 1
+fi
+
+echo "→ Verifying release ${TAG} on ${REPO} …"
+if ! curl -sIfL "$URL" >/dev/null; then
+  echo "✗ ${URL} returned non-200. Has the GitHub Actions release workflow finished?" >&2
+  exit 1
+fi
+
+echo "→ Downloading ${APPIMAGE} for SHA-256 calculation …"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+curl -sL -o "$TMP/$APPIMAGE" "$URL"
+SHA=$(sha256sum "$TMP/$APPIMAGE" | awk '{print $1}')
+echo "  sha256 = ${SHA}"
+
+echo "→ Patching PKGBUILD …"
+# Update pkgver + sha256sums in-place. PKGBUILD is just bash, so
+# straightforward sed on the well-known field names works.
+sed -i \
+  -e "s/^pkgver=.*/pkgver=${PKGVER}/" \
+  -e "s/^pkgrel=.*/pkgrel=1/" \
+  -e "s/^sha256sums=(.*)/sha256sums=('${SHA}')/" \
+  PKGBUILD
+
+# Regenerate .SRCINFO — AUR rejects pushes without a matching one.
+if command -v makepkg >/dev/null; then
+  makepkg --printsrcinfo > .SRCINFO
+  echo "→ Regenerated .SRCINFO"
+else
+  echo "⚠ makepkg not installed — skipping .SRCINFO regen. Run manually before pushing:"
+  echo "    makepkg --printsrcinfo > .SRCINFO"
+fi
+
+echo
+echo "✓ PKGBUILD updated to ${PKGVER}"
+echo "  Review:  git diff"
+echo "  Publish: git commit -am 'flowshield-bin ${PKGVER}' && git push"


### PR DESCRIPTION
Phase 1 of the v3 publishing plan (\`~/.claude/plans/ethereal-purring-canyon.md\`): ship signed \`.deb\` + \`.rpm\` + \`.AppImage\` to GitHub Releases on every \`v3.*\` tag.

## What ships when this lands

Push a \`v3.*\` tag → GitHub Actions builds Linux bundles → signs each artifact + a SHA256SUMS manifest with our GPG key → publishes everything to a new GitHub Release.

\`\`\`bash
git tag v3.0.0-alpha.0
git push origin v3.0.0-alpha.0
# 5–10 min later: GitHub Releases has flowshield_3.0.0-alpha.0_amd64.{deb,rpm,AppImage}
# + matching .asc detached sigs + SHA256SUMS + SHA256SUMS.asc
\`\`\`

## Files

| File | Lines | What |
|---|---|---|
| \`.github/workflows/desktop-v3-release.yml\` (new) | 163 | build-linux + sign-and-release jobs; GPG signing degrades gracefully if secret unset |
| \`.github/workflows/desktop-release.yml\` | +6/-1 | Tighten v* trigger → \`v[0-2].*\` so v2 .NET pipeline doesn't double-fire on v3 tags |
| \`LICENSE\` (new) | 21 | Full MIT text at repo root (was only a README badge) |
| \`desktop-app-v3/src-tauri/tauri.conf.json\` | +17/-2 | Explicit \`targets\` array, publisher/copyright, \`linux.deb.depends\`, \`linux.rpm.depends\`, \`linux.appimage.bundleMediaFramework\` |
| \`desktop-app-v3/README.md\` | +43 | New \"Install (end-user)\" section: AppImage / .deb / .rpm / AUR + signature verification |
| \`scripts/release/update-aur.sh\` (new, +x) | 76 | Post-release helper to bump the separate flowshield-aur clone's PKGBUILD + .SRCINFO |

Net: +323 / -3 LOC, 6 files (3 new).

## GPG signing setup (one-time)

The signing step in the workflow is gated on two repo secrets:
- \`GPG_PRIVATE_KEY\` — ASCII-armored private key (\`gpg --armor --export-secret-key <key-id>\`)
- \`GPG_PASSPHRASE\` — passphrase for the key

Generate a release-signing key locally (or use an existing one):

\`\`\`bash
gpg --full-generate-key  # RSA 4096, expires 2 years
gpg --armor --export-secret-key release@flowshield.app
# Paste output into Settings → Secrets → Actions → New repository secret → GPG_PRIVATE_KEY
gpg --armor --export release@flowshield.app  # public key — paste into release notes
\`\`\`

If the secret isn't set, the signing step logs a \`::warning::\` and skips. Bundles publish unsigned. **No release is blocked by signing-not-yet-set-up.**

## Tag namespace disambiguation

v2 (.NET) workflow listened on \`v*\` — that would have double-fired on v3 tags. Tightened to \`v[0-2].*\` (matches v0.x / v1.x / v2.x). v2 has only ever shipped \`v1.*\` and \`v2.*\` tags so no existing tag is excluded.

## What this PR does NOT do

- **No Flathub** (Phase 2 of the plan — separate flathub repo with Flatpak manifest)
- **No Snap Store** (Phase 3 — snapcraft.yaml + Snap reviewer process)
- **No actual release tagged yet** — this PR ships the pipeline; you tag when ready.

## Verification

\`\`\`bash
# Local dry-run — produce the same bundles the CI would produce:
cd desktop-app-v3 && npm run tauri:build
ls src-tauri/target/release/bundle/{deb,rpm,appimage}/

# Smoke-test:
sudo dnf install src-tauri/target/release/bundle/rpm/*.rpm
flowshield  # FlowShield logo in taskbar; sign in; deep-work fires polkit

# Trigger CI:
git tag v3.0.0-alpha.0
git push origin v3.0.0-alpha.0
# Watch Actions tab. Once green, check the new GitHub Release.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)