### PR TITLE
feat: release-please automation for desktop-v3

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,32 @@
+name: Release Please (desktop-v3)
+
+# Maintains a "release: <next-version>" PR on every push to main, with
+# the version + changelog auto-derived from Conventional Commit messages
+# (feat / fix / chore / etc.) that touched desktop-app-v3/. Merging that
+# PR creates the git tag v3.x.y, which independently fires
+# .github/workflows/desktop-v3-release.yml to build + sign + publish
+# Linux bundles to a fresh GitHub Release.
+#
+# Authoring conventions (already in use):
+#   feat(desktop-v3): … → minor bump
+#   fix(desktop-v3): …  → patch bump
+#   feat(desktop-v3)!:  → major bump (note the !)
+# Commits without a desktop-v3 scope are ignored for this package.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "desktop-app-v3": "3.0.0-alpha.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "packages": {
+    "desktop-app-v3": {
+      "package-name": "flowshield-desktop-v3",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "src-tauri/tauri.conf.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "src-tauri/Cargo.toml",
+          "jsonpath": "$.package.version"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

[\`googleapis/release-please-action@v5\`](https://github.com/googleapis/release-please-action) drives the **version bump + git tag + CHANGELOG** automation for desktop-v3. Pairs with the existing \`desktop-v3-release.yml\` (PR #51) which fires on the v3.* tag this creates.

## Automated flow

\`\`\`
You: push feat(desktop-v3): foo to main
  ↓
release-please opens / updates "release: 3.x.y" PR
  ↓
You: merge the release PR
  ↓
release-please:
  • bumps tauri.conf.json $.version
  • bumps Cargo.toml $.package.version
  • appends to desktop-app-v3/CHANGELOG.md
  • rewrites .release-please-manifest.json
  • creates git tag v3.x.y
  • creates GitHub Release with the changelog body
  ↓
The v3.x.y tag push fires desktop-v3-release.yml
  • builds Tauri bundles on ubuntu-22.04
  • GPG-signs each artifact + SHA256SUMS (if secret provisioned)
  • uploads .deb / .rpm / .AppImage to the same GitHub Release
\`\`\`

## Conventional Commit → version bump

| Commit prefix | Bump |
|---|---|
| \`feat(desktop-v3): …\` | minor (3.0.0 → 3.1.0) |
| \`fix(desktop-v3): …\` | patch (3.0.0 → 3.0.1) |
| \`feat(desktop-v3)!:\` (or \`BREAKING CHANGE:\` footer) | major (3.0.0 → 4.0.0) |
| Other commits / scopes | ignored for desktop-v3 |

You're already disciplined about this convention — the existing 50+ commits parse cleanly.

## Files

| File | Lines | What |
|---|---|---|
| \`.github/workflows/release-please.yml\` (new) | 33 | push:main + workflow_dispatch trigger; permissions: contents+pull-requests; one step invokes \`release-please-action@v5\` |
| \`release-please-config.json\` (new) | 22 | single package \`desktop-app-v3\`; \`release-type: simple\`; \`include-v-in-tag: true\` (tags are \`v3.0.1\` not \`desktop-app-v3-v3.0.1\`); \`extra-files\` bumps tauri.conf.json + Cargo.toml |
| \`.release-please-manifest.json\` (new) | 3 | bootstraps \`{\"desktop-app-v3\": \"3.0.0-alpha.0\"}\` matching current state |

Net: +59 LOC, 3 new files. No existing files modified.

## What still needs a human

- **Merging the release PR** — intentional gate; releases shouldn't auto-fire on every commit. release-please's "release PR" pattern means there's always a clear preview of what's about to ship.
- **GPG signing key provisioning** (one-time, optional) — bundles publish unsigned if \`GPG_PRIVATE_KEY\` repo secret isn't set.

## What this PR does NOT do

- **Cross-platform build matrix** — macOS + Windows runners would land in `desktop-v3-release.yml` to produce \`.dmg\` + \`.msi\` alongside Linux bundles. Separate PR.
- **AUR auto-push** — CI-driven \`flowshield-aur\` PKGBUILD bump using an SSH deploy key. Separate PR.

## After merge

1. release-please runs on the next push to main.
2. It opens a PR titled "release: 3.0.1" (or "release: 3.1.0" depending on the next commit's bump). The PR body is the auto-generated changelog covering all desktop-v3 commits since 3.0.0-alpha.0.
3. Review the PR. Merge when ready. The tag fires and bundles ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)