### PR TITLE
fix(ci): two reliability fixes for the v3 release pipeline

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -47,8 +47,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: desktop-app-v3/package-lock.json
+        # Skipping `cache: npm` because the repo doesn't commit
+        # package-lock.json (matches the gitignored Cargo.lock convention).
+        # setup-node's cache feature requires a lockfile to compute the
+        # cache key. Costs ~30s of npm install per run; revisit if we ever
+        # commit lockfiles.
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,5 +28,12 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
+          # Use a fine-grained PAT (not the default GITHUB_TOKEN) so the tag
+          # release-please pushes triggers downstream workflows. GitHub
+          # silently suppresses workflow events for tags/commits authored by
+          # GITHUB_TOKEN to prevent infinite-loop scenarios; using a PAT
+          # bypasses that guard so desktop-v3-release.yml fires automatically
+          # on the v3.x.y tag this action creates.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Two issues from the first end-to-end test

After PRs #51 + #52 landed and the first release-please PR (#53) merged, two latent issues showed up. Both are workflow-config-only fixes; no code touched.

### 1. release-please's tag didn't fire the downstream build

GitHub deliberately suppresses workflow events for tags/commits authored by the default \`GITHUB_TOKEN\` to prevent infinite-loop scenarios. release-please created \`v3.1.0-alpha.0\` cleanly but \`desktop-v3-release.yml\` never saw the tag-push event.

**Fix:** pass a fine-grained PAT (\`RELEASE_PLEASE_TOKEN\` secret, already provisioned) to the action so the tag is created under a "real user" identity that DOES fire downstream events.

\`\`\`yaml
- uses: googleapis/release-please-action@v5
  with:
    token: \${{ secrets.RELEASE_PLEASE_TOKEN }}
    config-file: …
    manifest-file: …
\`\`\`

### 2. setup-node \`cache: npm\` failed without a lockfile

The repo gitignores \`package-lock.json\` (matches the Cargo.lock convention). But setup-node's \`cache: npm\` requires a lockfile to compute the cache key. First build failed in 48s:

> \`##[error]Some specified paths were not resolved, unable to cache dependencies.\`

**Fix:** drop the \`cache:\` and \`cache-dependency-path:\` keys from setup-node. Costs ~30s of \`npm install\` per workflow run; revisit if we ever commit lockfiles.

## After this lands

The next release-please PR you merge fully auto-publishes:
1. release-please uses the PAT to create tag \`v3.x.y\`
2. Tag-push event fires \`desktop-v3-release.yml\` (no longer suppressed)
3. Builds .deb / .rpm / .AppImage on \`ubuntu-22.04\`
4. GPG-signs with the now-provisioned key → \`.asc\` files + signed \`SHA256SUMS\`
5. Publishes to the existing GitHub Release auto-created by release-please

**Zero manual steps after merging the release PR.**

## Files

| File | Lines | What |
|---|---|---|
| \`.github/workflows/release-please.yml\` | +8/-1 | Pass PAT via \`token:\` input + 7-line comment explaining why |
| \`.github/workflows/desktop-v3-release.yml\` | +5/-3 | Drop \`cache: npm\` config + 5-line comment |

Net: +12 / -2 LOC, 2 files.

## Verification

After merging, push any \`feat(desktop-v3):\` or \`fix(desktop-v3):\` commit to main → release-please opens / updates a release PR → merge it → tag fires → bundles ship — without any \`gh workflow run\` invocations from you.

Today's release \`v3.1.0-alpha.0\` will need a one-time manual rerun after this PR lands (its tag was created under GITHUB_TOKEN, so re-trigger via \`gh workflow run desktop-v3-release.yml --ref main -f tag=v3.1.0-alpha.0\`). Future tags are fully automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)