### PR TITLE
fix(desktop-v3): disable WebKitGTK DMA-BUF renderer on Linux

### DIFF
--- a/desktop-app-v3/src-tauri/src/main.rs
+++ b/desktop-app-v3/src-tauri/src/main.rs
@@ -2,6 +2,21 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // WebKitGTK 2.44+ has a DMA-BUF renderer that crashes on many Wayland
+    // compositors with "Gdk-Message: Error 71 (Protocol error) dispatching
+    // to Wayland display" — Fedora 43 + GNOME hits this reliably. Disabling
+    // the DMA-BUF renderer falls back to a software path that works
+    // everywhere. Must be set BEFORE any GTK code runs; doing it in main()
+    // before flowshield_desktop_lib::run() is the earliest point.
+    //
+    // Setting the var on non-Linux platforms has no effect (no WebKitGTK
+    // there). Users who deliberately set the var (including to "0" to opt
+    // back into DMA-BUF on a known-good system) are respected.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     // When the binary is re-invoked as a privileged child by `pkexec` /
     // `osascript`, we run the requested blocking subcommand and exit
     // without booting the GUI. Returns None for normal launches.


### PR DESCRIPTION
## What was broken

Real-world install bug surfaced after \`v3.1.0-alpha.0\` shipped:

- \`sudo dnf install ./FlowShield-3.1.0-alpha.0-1.x86_64.rpm\` succeeds.
- Launching \`flowshield-desktop\` from a terminal works — window opens, tray icon appears, normal operation.
- Clicking the FlowShield icon in the GNOME app menu: window flickers open then immediately closes. No tray icon. Process exits.

## Root cause

WebKitGTK 2.44+ has a DMA-BUF renderer that crashes on many Wayland compositors (including Fedora 43 + GNOME) with:

\`\`\`
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
\`\`\`

Diagnosis confirmed by \`env -i\`-clearing the user's terminal env and reproducing the same crash that GNOME's clean .desktop launch produced.

The terminal launch coincidentally worked because contributors had \`WEBKIT_DISABLE_DMABUF_RENDERER=1\` in their shell env (left over from when we documented that workaround for \`npm run tauri:dev\` in the README). GNOME's clean launch env doesn't inherit shell rc files, so the renderer crashes.

## Fix

Set \`WEBKIT_DISABLE_DMABUF_RENDERER=1\` inside \`main()\` before any GTK code runs:

\`\`\`rust
#[cfg(target_os = \"linux\")]
if std::env::var_os(\"WEBKIT_DISABLE_DMABUF_RENDERER\").is_none() {
    std::env::set_var(\"WEBKIT_DISABLE_DMABUF_RENDERER\", \"1\");
}
\`\`\`

- **Linux-only via \`#[cfg]\`** — no WebKitGTK on macOS/Windows so setting the var would be no-op anyway, but cleaner to gate.
- **Respects user override** — if the var is already set (e.g. \`=0\` to opt back into DMA-BUF on a known-good system), we don't clobber.
- **Earliest possible call site** — main() before \`run_blocker_subcommand\` and \`run()\`. WebKitGTK reads the var when the GTK runtime initializes, which happens deep inside \`tauri::Builder::run()\`.

The README's dev-mode env-var advice and the dev \`.desktop\` install script remain accurate — they're now belt-and-braces; the binary itself handles the case.

## Verification

Pre-fix:
\`\`\`bash
env -i HOME=\$HOME XDG_RUNTIME_DIR=\$XDG_RUNTIME_DIR DISPLAY=\$DISPLAY WAYLAND_DISPLAY=\$WAYLAND_DISPLAY DBUS_SESSION_BUS_ADDRESS=\$DBUS_SESSION_BUS_ADDRESS /usr/bin/flowshield-desktop
# → Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
# → process exits
\`\`\`

Post-fix (next release): same \`env -i\` invocation → window opens, stays open, tray icon present.

## Files

| File | Lines | What |
|---|---|---|
| \`desktop-app-v3/src-tauri/src/main.rs\` | +15 | Set \`WEBKIT_DISABLE_DMABUF_RENDERER=1\` inside \`main()\` (Linux-only, respects user override) + 11-line comment block explaining why |

Net: +15 / -0 LOC, 1 file.

## What ships next

Conventional Commit prefix is \`fix(desktop-v3):\` so release-please will roll this into a patch bump (3.1.0-alpha.0 → 3.1.1-alpha.0 or similar). Merge → release-please opens / updates the release PR → merge that PR → tag fires (PAT-authed, fully automatic now per #54) → bundles build, GPG-sign, publish → end users on the next \`dnf upgrade\` get an app that just works from the GNOME app menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)