### PR TITLE
feat(desktop-v3): show focus-session countdown + progress ring on tray

### DIFF
--- a/desktop-app-v3/src-tauri/Cargo.toml
+++ b/desktop-app-v3/src-tauri/Cargo.toml
@@ -48,6 +48,10 @@ whoami = "1"
 sha2 = "0.10"
 base64 = "0.22"
 
+# Pixel manipulation for the dynamic tray icon (focus-session progress
+# ring overlay). PNG-only feature set keeps compile fast — no jpeg/gif/etc.
+image = { version = "0.25", default-features = false, features = ["png"] }
+
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 thiserror   = "1"

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod preferences;
 pub mod projects;
 pub mod realtime;
 pub mod sessions;
+pub mod tray;

--- a/desktop-app-v3/src-tauri/src/commands/tray.rs
+++ b/desktop-app-v3/src-tauri/src/commands/tray.rs
@@ -1,0 +1,27 @@
+//! Tray-icon update commands. The frontend ticks once per second while
+//! a focus session is running and calls `tray_set_session_indicator` to
+//! refresh the progress ring + countdown label. On session end / pause /
+//! cancellation it calls `tray_reset_session_indicator` to restore the
+//! default FlowShield logo and clear the label.
+//!
+//! Both commands are sync-flavored (no I/O beyond the cheap PNG render
+//! + Tauri's tray-icon swap), so they don't need spawn_blocking.
+
+use crate::error::{AppError, AppResult};
+use tauri::AppHandle;
+
+#[tauri::command]
+pub async fn tray_set_session_indicator(
+    app: AppHandle,
+    label: String,
+    progress: f32,
+) -> AppResult<()> {
+    crate::tray::update_session_indicator(&app, &label, progress)
+        .map_err(|e| AppError::Storage(format!("update tray indicator: {e}")))
+}
+
+#[tauri::command]
+pub async fn tray_reset_session_indicator(app: AppHandle) -> AppResult<()> {
+    crate::tray::reset_session_indicator(&app)
+        .map_err(|e| AppError::Storage(format!("reset tray indicator: {e}")))
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod store;
 mod sync_worker;
 mod tracker;
 mod tray;
+mod tray_indicator;
 
 use std::sync::Arc;
 use tauri::Manager;
@@ -213,6 +214,8 @@ pub fn run() {
             commands::blocking::blocking_status,
             commands::preferences::prefs_load,
             commands::realtime::realtime_config,
+            commands::tray::tray_set_session_indicator,
+            commands::tray::tray_reset_session_indicator,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src-tauri/src/tray.rs
+++ b/desktop-app-v3/src-tauri/src/tray.rs
@@ -1,13 +1,22 @@
 //! System-tray menu wiring. The tray icon itself is declared in
 //! `tauri.conf.json` (`app.trayIcon`) so Tauri creates it before our
-//! `setup` callback runs; here we just attach a menu and event handlers.
+//! `setup` callback runs; here we just attach a menu + event handlers,
+//! plus expose helpers for updating the icon during a focus session.
 //!
 //! Menu items:
 //! - **Show FlowShield** — show + focus the main window (used after the
 //!   user has hidden it via close-to-tray).
 //! - **Quit** — actually exit the process. Without this menu, hide-to-tray
 //!   would leave no obvious way to quit.
+//!
+//! Session indicator: while a focus session is running, the frontend
+//! ticks once per second and calls `tray_set_session_indicator` (in
+//! `commands::tray`) which routes here via `update_session_indicator`.
+//! We swap the icon (FlowShield logo with a progress ring overlay) and
+//! set the text label to a `MM:SS` countdown.
 
+use crate::tray_indicator;
+use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconEvent;
 use tauri::{App, AppHandle, Manager};
@@ -15,6 +24,14 @@ use tauri::{App, AppHandle, Manager};
 const TRAY_ID: &str = "main";
 const SHOW_ID: &str = "show";
 const QUIT_ID: &str = "quit";
+
+/// Embedded base FlowShield logo, used to reset the tray icon when no
+/// session is active. Same source as the bundle icons (PR #48).
+const BASE_ICON_PNG: &[u8] = include_bytes!("../icons/icon.png");
+/// Tray icon size at which we render the progress overlay. 32px is a
+/// sweet spot — large enough for a readable ring, small enough that
+/// rendering once per second is sub-ms.
+const TRAY_ICON_SIZE: u32 = 32;
 
 pub fn install(app: &App) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, SHOW_ID, "Show FlowShield", true, None::<&str>)?;
@@ -61,4 +78,48 @@ fn focus_main(app: &AppHandle) {
         let _ = win.unminimize();
         let _ = win.set_focus();
     }
+}
+
+/// Swap the tray icon to a progress-ring overlay and set the text label
+/// next to the icon. Called once per second from the frontend while a
+/// session is active.
+///
+/// `label` is shown as a freedesktop label (libayatana on Linux, NSStatusItem
+/// title on macOS). On Windows the tray-icon crate's `set_title` is a no-op
+/// so the label only shows on hover via the existing tooltip — not perfect,
+/// but harmless. The icon swap works on all three platforms.
+pub fn update_session_indicator(
+    handle: &AppHandle,
+    label: &str,
+    progress: f32,
+) -> tauri::Result<()> {
+    let Some(tray) = handle.tray_by_id(TRAY_ID) else {
+        return Ok(()); // tray not installed (rare — only if `install()` failed)
+    };
+    let img = tray_indicator::render_progress_icon(progress, TRAY_ICON_SIZE);
+    let (w, h) = (img.width(), img.height());
+    let icon = Image::new_owned(img.into_raw(), w, h);
+    tray.set_icon(Some(icon))?;
+    tray.set_title(Some(label))?;
+    Ok(())
+}
+
+/// Restore the default tray icon + clear the text label. Called when the
+/// session ends (auto, manual, or stale-cleanup).
+pub fn reset_session_indicator(handle: &AppHandle) -> tauri::Result<()> {
+    let Some(tray) = handle.tray_by_id(TRAY_ID) else {
+        return Ok(());
+    };
+    // Decode the embedded base PNG to raw RGBA so we can hand it to
+    // tauri::image::Image::new (which doesn't decode PNG by itself —
+    // would require the `image-png` Tauri feature, but we already pull
+    // the `image` crate for the indicator render anyway).
+    let decoded = image::load_from_memory_with_format(BASE_ICON_PNG, image::ImageFormat::Png)
+        .map_err(|e| tauri::Error::AssetNotFound(format!("decode base tray icon: {e}")))?
+        .into_rgba8();
+    let (w, h) = (decoded.width(), decoded.height());
+    let icon = Image::new_owned(decoded.into_raw(), w, h);
+    tray.set_icon(Some(icon))?;
+    tray.set_title(None::<String>)?;
+    Ok(())
 }

--- a/desktop-app-v3/src-tauri/src/tray_indicator.rs
+++ b/desktop-app-v3/src-tauri/src/tray_indicator.rs
@@ -1,0 +1,124 @@
+//! Renders the dynamic tray icon shown while a focus session is running.
+//!
+//! Composes three layers onto a transparent square canvas:
+//!   1. A faint background ring (full circle) — shows the "track" the
+//!      progress sweep moves around.
+//!   2. The progress sweep itself, an arc from 12 o'clock (top) clockwise
+//!      to `progress * 360°`. Painted in FlowShield's brand color.
+//!   3. The FlowShield logo, scaled to fit inside the ring.
+//!
+//! Implemented with the `image` crate's pixel-level access (no need for
+//! a full 2D path engine like skia at this size — the ring math is just
+//! polar-coordinate filtering, which anti-aliases acceptably at 32px).
+
+use image::{ImageFormat, Rgba, RgbaImage};
+use std::sync::OnceLock;
+
+/// Embedded FlowShield logo. Uses the same source PNG that bundles the
+/// installer-side icons (PR #48).
+const BASE_ICON_PNG: &[u8] = include_bytes!("../icons/icon.png");
+
+/// Decoded base icon, cached forever after first render.
+static BASE_ICON: OnceLock<RgbaImage> = OnceLock::new();
+
+fn base_icon() -> &'static RgbaImage {
+    BASE_ICON.get_or_init(|| {
+        image::load_from_memory_with_format(BASE_ICON_PNG, ImageFormat::Png)
+            .expect("base FlowShield icon failed to decode (was bundled wrong?)")
+            .into_rgba8()
+    })
+}
+
+/// Brand color: sky-500 (#0ea5e9). Matches the web app + the
+/// `primary-500` Tailwind token used across the desktop UI.
+const RING_COLOR: Rgba<u8> = Rgba([14, 165, 233, 255]);
+/// Faint backdrop for the unfilled portion of the ring.
+const TRACK_COLOR: Rgba<u8> = Rgba([100, 116, 139, 90]);
+
+/// Render the tray icon for the given progress (0.0 = no fill, 1.0 = full
+/// circle). `size` is the output square edge in pixels (32 is a good fit
+/// for most Linux trays; macOS handles HiDPI itself).
+///
+/// Returns the raw `RgbaImage` — caller hands `(img.into_raw(), w, h)` to
+/// `tauri::image::Image::new` (which expects raw RGBA, not PNG).
+pub fn render_progress_icon(progress: f32, size: u32) -> RgbaImage {
+    let progress = progress.clamp(0.0, 1.0);
+    let mut canvas = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 0]));
+
+    let center = size as f32 / 2.0;
+    let r_outer = (size as f32 / 2.0) - 0.5;
+    let ring_thickness = (size as f32 * 0.12).max(2.0);
+    let r_inner = r_outer - ring_thickness;
+    let progress_rad = progress * std::f32::consts::TAU;
+
+    // Layer 1+2: ring track + progress sweep.
+    for y in 0..size {
+        for x in 0..size {
+            let dx = x as f32 + 0.5 - center;
+            let dy = y as f32 + 0.5 - center;
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist >= r_inner && dist <= r_outer {
+                // atan2 gives angle from +X axis (3 o'clock), positive CCW.
+                // Remap so 12 o'clock = 0 and progress sweeps clockwise.
+                let raw = (-dy).atan2(dx);
+                let from_top =
+                    (std::f32::consts::FRAC_PI_2 - raw).rem_euclid(std::f32::consts::TAU);
+                let pixel = if from_top <= progress_rad {
+                    RING_COLOR
+                } else {
+                    TRACK_COLOR
+                };
+                canvas.put_pixel(x, y, pixel);
+            }
+        }
+    }
+
+    // Layer 3: composite the FlowShield logo inside the ring.
+    let inner_padding = (size as f32 * 0.08).round() as u32;
+    let logo_size = size.saturating_sub(2 * (ring_thickness as u32 + inner_padding));
+    if logo_size > 0 {
+        let logo = image::imageops::resize(
+            base_icon(),
+            logo_size,
+            logo_size,
+            image::imageops::FilterType::Lanczos3,
+        );
+        let offset = ((size - logo_size) / 2) as i64;
+        image::imageops::overlay(&mut canvas, &logo, offset, offset);
+    }
+
+    canvas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_correct_dimensions() {
+        let img = render_progress_icon(0.0, 32);
+        assert_eq!(img.width(), 32);
+        assert_eq!(img.height(), 32);
+    }
+
+    #[test]
+    fn full_progress_paints_more_ring_pixels_than_zero() {
+        // Pixel-count sanity check: full ring should have strictly more
+        // RING_COLOR pixels than no progress.
+        let zero = render_progress_icon(0.0, 64);
+        let full = render_progress_icon(1.0, 64);
+        let count_ring = |img: &RgbaImage| -> u32 {
+            img.pixels()
+                .filter(|p| p[0] == RING_COLOR[0] && p[1] == RING_COLOR[1] && p[2] == RING_COLOR[2])
+                .count() as u32
+        };
+        assert!(count_ring(&full) > count_ring(&zero));
+    }
+
+    #[test]
+    fn clamps_out_of_range_progress() {
+        // -0.5 and 2.0 should not panic.
+        let _ = render_progress_icon(-0.5, 32);
+        let _ = render_progress_icon(2.0, 32);
+    }
+}

--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import {
   isPermissionGranted,
   requestPermission,
@@ -127,6 +128,43 @@ export function DashboardPage() {
     }, 30_000);
     return () => clearInterval(id);
   }, [refresh]);
+
+  // Tray-icon session indicator: while a session is active, tick once per
+  // second to update the tray icon (progress ring) and label (MM:SS
+  // countdown) so the user sees focus-session state at a glance from the
+  // top bar / dock — even with the FlowShield window hidden via close-to-
+  // tray. Cleanup resets the icon to the static FlowShield logo.
+  useEffect(() => {
+    if (!current) {
+      void invoke('tray_reset_session_indicator');
+      return;
+    }
+    const totalMs = current.plannedDuration * 60 * 1000;
+    const startMs = new Date(current.startTime).getTime();
+    const plannedEndMs = startMs + totalMs;
+    const tick = () => {
+      // When paused, freeze on pausedAt so the countdown doesn't tick
+      // forward; the web bumps startTime on resume so the active-state
+      // math (Date.now()) keeps working.
+      const refMs =
+        current.isPaused && current.pausedAt
+          ? new Date(current.pausedAt).getTime()
+          : Date.now();
+      const remainingMs = Math.max(0, plannedEndMs - refMs);
+      const progress = Math.min(1, 1 - remainingMs / totalMs);
+      const min = Math.floor(remainingMs / 60_000);
+      const sec = Math.floor((remainingMs % 60_000) / 1000);
+      const time = `${min}:${String(sec).padStart(2, '0')}`;
+      const label = current.isPaused ? `⏸ ${time}` : time;
+      void invoke('tray_set_session_indicator', { label, progress });
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => {
+      clearInterval(id);
+      void invoke('tray_reset_session_indicator');
+    };
+  }, [current]);
 
   useEffect(() => {
     void projects.refresh();


### PR DESCRIPTION
## What this adds

While a focus session is running, the tray icon shows two new things:

1. **Text label** next to the icon — \`MM:SS\` countdown (or \`⏸ MM:SS\` when paused).
   - Linux (libayatana / AppIndicator): label appears next to the icon in the top bar
   - macOS (NSStatusItem): label appears in the menu bar next to the icon
   - Windows: tray-icon crate's \`set_title\` is a no-op there — falls back to the existing tooltip on hover

2. **Progress ring** overlay on the icon itself — 32×32 PNG composited at runtime: faint gray track ring + brand-color (sky-500) progress sweep from 12 o'clock clockwise, FlowShield logo scaled inside. Updates every second.

Result: with the FlowShield window hidden via close-to-tray, you can still see "how much focus time is left" at a glance from the top bar.

## Architecture

\`\`\`
DashboardPage useEffect (keyed on current session)
   │ setInterval 1s
   ▼
invoke('tray_set_session_indicator', { label: '24:32', progress: 0.18 })
   │
   ▼  (Tauri IPC)
commands::tray::tray_set_session_indicator
   │
   ▼
tray::update_session_indicator
   │
   ├── tray_indicator::render_progress_icon(0.18, 32) → RgbaImage
   │     (pixel-iteration ring math + image::imageops::overlay logo)
   │
   ├── Image::new_owned(rgba.into_raw(), 32, 32)
   ├── tray.set_icon(Some(icon))
   └── tray.set_title(Some(\"24:32\"))
\`\`\`

Pause handling: when \`isPaused\`, frontend uses \`new Date(pausedAt)\` instead of \`Date.now()\` so the countdown freezes; web bumps \`startTime\` on resume so wall-clock math keeps working. Label switches to \`⏸ MM:SS\` while paused.

## Files

| File | Lines | What |
|---|---|---|
| \`src-tauri/src/tray_indicator.rs\` (new) | 124 | \`render_progress_icon(progress, size) -> RgbaImage\` + 3 unit tests; embedded base icon decoded once via OnceLock |
| \`src-tauri/src/tray.rs\` | +63 | \`update_session_indicator\` + \`reset_session_indicator\` helpers; uses \`Image::new_owned(rgba, w, h)\` (no PNG round-trip) |
| \`src-tauri/src/commands/tray.rs\` (new) | 27 | Two thin Tauri commands |
| \`src-tauri/src/commands/mod.rs\` | +1 | \`pub mod tray;\` |
| \`src-tauri/src/lib.rs\` | +3 | \`mod tray_indicator;\` + register both commands in \`generate_handler!\` |
| \`src-tauri/Cargo.toml\` | +4 | \`image = \"0.25\"\` (default-features=false, features=[\"png\"]) |
| \`src/routes/DashboardPage.tsx\` | +38 | useEffect keyed on \`current\` session: 1s ticker + cleanup-on-unmount-or-end |

Net: +259 / -1 LOC, 7 files (3 new).

## Tests

\`\`\`
running 3 tests
test tray_indicator::tests::renders_correct_dimensions ... ok
test tray_indicator::tests::clamps_out_of_range_progress ... ok
test tray_indicator::tests::full_progress_paints_more_ring_pixels_than_zero ... ok
\`\`\`

## What ships next

\`feat(desktop-v3):\` prefix → release-please rolls this into a minor bump (3.1.1-alpha.0 → 3.2.0-alpha.0). Merge → release PR auto-updates → merge that → tag fires (PAT-authed) → bundles build, GPG-sign, publish. Fully automated end-to-end now.

## Out of scope (per Karpathy 2)

- Animated transitions between progress steps — would need multi-Hz updates; not worth the cost
- Dark/light mode adaptive ring colors — sky-500 reads on both
- Per-session-type ring colors (work / study / creative each a different hue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)