### PR TITLE
fix(desktop-v3): minimize-to-tray on Linux to preserve close button

### DIFF
--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -128,10 +128,26 @@ pub fn run() {
             // Close-to-tray: intercept the close button on the main window
             // so the app keeps running (auto-syncing, draining the offline
             // queue). The Quit menu item is the only path to exit.
+            //
+            // Linux gotcha: window.hide() destroys the GTK surface and
+            // window.show() (called from the tray "Show" menu) creates a
+            // new one. After this round-trip libdecor's client-side
+            // decorations get reattached but the close-button hit area
+            // stops registering single clicks reliably — the user sees
+            // the close button "stop working" the second time, and
+            // double-clicking it lands on the title bar (GNOME default
+            // = double-click maximize). Minimizing instead keeps the
+            // surface alive so CSD bindings stay valid.
+            //
+            // macOS / Windows tolerate hide/show fine + the full-hide
+            // UX matches platform convention there, so they keep hide().
             if window.label() == "main" {
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                    let _ = window.hide();
                     api.prevent_close();
+                    #[cfg(target_os = "linux")]
+                    let _ = window.minimize();
+                    #[cfg(not(target_os = "linux"))]
+                    let _ = window.hide();
                 }
             }
         })


### PR DESCRIPTION
## Reproducer

1. Open the app, click X — window hides ✓
2. Reopen via tray "Show FlowShield"
3. Click X again — **nothing happens**
4. Double-click X — window MAXIMIZES (??) and then closes

## Root cause

\`window.hide()\` on Linux destroys the GTK surface; \`window.show()\` (from the tray "Show" menu) creates a fresh one. After this round-trip libdecor reattaches client-side decorations to the new surface — but the close-button hit area stops registering single clicks reliably. Clicks slip through to the title bar underneath. Two clicks within the double-click interval = title-bar double-click = GNOME's default "maximize" action.

## Fix

On Linux, call \`window.minimize()\` instead of \`window.hide()\`. Surface stays alive → CSD button bindings stay valid → close button works forever.

Tradeoff: the window stays in the workspace switcher (minimized) instead of fully disappearing. On most Linux desktops this is the more discoverable UX anyway, and the tray icon still provides quick restore.

macOS / Windows continue to use \`hide()\` because:
- Their toolkits don't recreate surfaces on show — no CSD bug
- "Fully hidden, only tray icon visible" matches platform-native convention (macOS NSStatusItem-resident apps + Windows tray apps)

Also reverses the \`prevent_close()\` / hide-or-minimize order so the close is definitely marked prevented before any state transition runs (defensive against any future re-emit-during-hide paths).

\`tray.rs::focus_main\` already calls \`show() + unminimize() + set_focus()\` so the restore path works unchanged for both code paths — no edit needed in tray.rs.

## Files

| File | Lines | What |
|---|---|---|
| \`src-tauri/src/lib.rs\` | +17/-1 | cfg-gate close-to-tray: minimize on Linux, hide elsewhere; reverse prevent_close order; 14-line comment block explaining the libdecor bug |

Net: +17 / -1 LOC, 1 file.

## Verification

After install:

\`\`\`bash
flowshield-desktop &
# Click X → window minimizes (now visible-but-minimized in workspace switcher)
# Right-click tray → "Show FlowShield" → window restores
# Click X again → minimizes (no double-click required, no maximize)
# Repeat any number of times — close button stays responsive
\`\`\`

\`fix(desktop-v3):\` prefix → release-please will roll this into a patch bump (3.2.0-alpha.0 → 3.2.1-alpha.0). Merge → release PR auto-updates → merge that → tag fires → bundles ship → next \`dnf upgrade\` and the close button stays alive across hide/show cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)