### PR TITLE
feat(desktop-v3): auto-publish flowshield-bin to AUR on release

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -164,3 +164,73 @@ jobs:
           generate_release_notes: true
           files: |
             release-artifacts/*
+
+  publish-to-aur:
+    # Pushes flowshield-bin to AUR after every v3.* tag. Bootstrap (account,
+    # SSH key, initial PKGBUILD) is documented in scripts/release/aur/README.md.
+    # The whole job no-ops cleanly if AUR_SSH_PRIVATE_KEY isn't provisioned —
+    # so this can ship before AUR setup is finished without breaking releases.
+    name: Publish to AUR
+    needs: sign-and-release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check AUR secret presence
+        id: gate
+        env:
+          AUR_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "$AUR_KEY" ]; then
+            echo "::warning::AUR_SSH_PRIVATE_KEY not set — skipping AUR publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.publish == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Download bundles
+        if: steps.gate.outputs.publish == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-bundles
+          path: release-artifacts
+
+      - name: Render PKGBUILD from template
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          # SHA against the locally built artifact, not the GitHub Release —
+          # avoids a re-download and a race against asset-upload propagation.
+          APPIMAGE=$(ls release-artifacts/FlowShield_*_amd64.AppImage)
+          SHA=$(sha256sum "$APPIMAGE" | awk '{print $1}')
+          # AUR rejects hyphens in pkgver. Keep _tagver with the original
+          # form for the GitHub URL.
+          TAGVER="${TAG#v}"
+          PKGVER="${TAGVER//-/.}"
+          mkdir -p aur-pkg
+          sed \
+            -e "s/__PKGVER__/${PKGVER}/g" \
+            -e "s/__TAGVER__/${TAGVER}/g" \
+            -e "s/__SHA256__/${SHA}/g" \
+            scripts/release/aur/PKGBUILD.template > aur-pkg/PKGBUILD
+          echo "--- rendered PKGBUILD ---"
+          cat aur-pkg/PKGBUILD
+
+      - name: Push to AUR
+        if: steps.gate.outputs.publish == 'true'
+        # The action regenerates .SRCINFO from the PKGBUILD inside an Arch
+        # container, then commits + pushes via SSH. We only feed it the
+        # rendered PKGBUILD; everything else (SRCINFO, git plumbing, ssh
+        # known_hosts) is handled internally.
+        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        with:
+          pkgname: flowshield-bin
+          pkgbuild: ./aur-pkg/PKGBUILD
+          commit_username: FlowShield Release Bot
+          commit_email: noreply@flowshield.app
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: 'flowshield-bin ${{ env.TAG }}'
+          ssh_keyscan_types: ed25519

--- a/scripts/release/aur/PKGBUILD.template
+++ b/scripts/release/aur/PKGBUILD.template
@@ -1,0 +1,49 @@
+# Maintainer: FlowShield <noreply@flowshield.app>
+#
+# Rendered from scripts/release/aur/PKGBUILD.template in the FlowShield
+# repo. The publish-to-aur job in .github/workflows/desktop-v3-release.yml
+# substitutes the version and checksum placeholders at release time, then
+# commits the result to the AUR repository.
+#
+# To regenerate locally:
+#   scripts/release/update-aur.sh v3.x.y   (run from inside flowshield-aur clone)
+
+pkgname=flowshield-bin
+_pkgname=flowshield
+# AUR forbids hyphens in pkgver, so prereleases get hyphens converted to
+# dots (3.2.1-alpha.0 → 3.2.1.alpha.0). _tagver keeps the original form
+# for the GitHub URL, which uses the literal release tag.
+pkgver=__PKGVER__
+_tagver=__TAGVER__
+pkgrel=1
+pkgdesc='Cross-platform productivity tracker that pairs with the FlowShield web dashboard'
+arch=('x86_64')
+url='https://flowshield.app'
+license=('MIT')
+# Runtime libs the AppImage links against. webkit2gtk-4.1 is the big one;
+# libayatana-appindicator powers the system tray icon; gtk3 covers the rest
+# of the GUI surface. We don't extract the AppImage, so its bundled libs
+# stay sandboxed inside it — but it still needs the host's webkit2gtk.
+depends=(
+  'webkit2gtk-4.1'
+  'libayatana-appindicator'
+  'gtk3'
+)
+provides=("${_pkgname}")
+conflicts=("${_pkgname}")
+options=('!strip')
+source=("${_pkgname}-${pkgver}.AppImage::https://github.com/asifthewebguy/FlowShield/releases/download/v${_tagver}/FlowShield_${_tagver}_amd64.AppImage")
+sha256sums=('__SHA256__')
+noextract=("${_pkgname}-${pkgver}.AppImage")
+
+package() {
+  install -Dm755 "${srcdir}/${_pkgname}-${pkgver}.AppImage" \
+    "${pkgdir}/opt/${pkgname}/${_pkgname}.AppImage"
+
+  install -dm755 "${pkgdir}/usr/bin"
+  cat > "${pkgdir}/usr/bin/${_pkgname}" <<EOF
+#!/usr/bin/env bash
+exec /opt/${pkgname}/${_pkgname}.AppImage "\$@"
+EOF
+  chmod 755 "${pkgdir}/usr/bin/${_pkgname}"
+}

--- a/scripts/release/aur/README.md
+++ b/scripts/release/aur/README.md
@@ -1,0 +1,110 @@
+# AUR auto-publish
+
+Tag-driven publishing of the `flowshield-bin` Arch User Repository package.
+
+## How it works
+
+`.github/workflows/desktop-v3-release.yml` has a `publish-to-aur` job that runs
+after `sign-and-release`. On every `v3.*` tag it:
+
+1. Downloads the freshly built `.AppImage` from the workflow artifacts.
+2. Computes its SHA-256.
+3. Renders [`PKGBUILD.template`](./PKGBUILD.template) with the new `pkgver` +
+   `sha256sums` into a working `PKGBUILD`.
+4. Hands that PKGBUILD to [`KSXGitHub/github-actions-deploy-aur`][action], which
+   regenerates `.SRCINFO`, commits, and pushes to `aur@aur.archlinux.org`.
+
+The job no-ops cleanly when the SSH secret isn't set, so unrelated forks and
+test runs don't fail.
+
+[action]: https://github.com/marketplace/actions/github-action-deploy-aur
+
+## One-time bootstrap (you, manually)
+
+These steps only need to happen once. After that, every release flows through
+CI automatically.
+
+### 1. AUR account
+
+Create an account at <https://aur.archlinux.org/register>. Pick any username —
+it's only visible as the package maintainer.
+
+### 2. CI-only SSH keypair
+
+Generate a dedicated key (don't reuse a personal one — this one lives in CI):
+
+```bash
+ssh-keygen -t ed25519 -C "flowshield-aur-ci" -f ~/.ssh/flowshield_aur_ci -N ""
+```
+
+Add the **public** key to your AUR account at
+<https://aur.archlinux.org/account> → "SSH Public Key" field.
+
+### 3. Initial PKGBUILD push (creates the AUR package)
+
+The AUR repo doesn't exist yet; the first commit is what creates it. Render the
+template locally and push by hand. From a scratch directory:
+
+```bash
+git clone ssh://aur@aur.archlinux.org/flowshield-bin.git
+cd flowshield-bin
+
+# Render template against the latest GitHub Release.
+TAG=v3.2.1-alpha.0                 # whatever's current
+TAGVER="${TAG#v}"                  # 3.2.1-alpha.0 (URL form)
+PKGVER="${TAGVER//-/.}"            # 3.2.1.alpha.0 (AUR form, no hyphens)
+APPIMAGE_URL="https://github.com/asifthewebguy/FlowShield/releases/download/${TAG}/FlowShield_${TAGVER}_amd64.AppImage"
+SHA=$(curl -sL "$APPIMAGE_URL" | sha256sum | awk '{print $1}')
+
+sed \
+  -e "s/__PKGVER__/${PKGVER}/g" \
+  -e "s/__TAGVER__/${TAGVER}/g" \
+  -e "s/__SHA256__/${SHA}/g" \
+  ../FlowShield/scripts/release/aur/PKGBUILD.template > PKGBUILD
+
+# Generate .SRCINFO (AUR rejects pushes without one).
+makepkg --printsrcinfo > .SRCINFO
+
+# Sanity-check the build works locally.
+makepkg -srci   # builds + installs locally
+
+git add PKGBUILD .SRCINFO
+git commit -m "flowshield-bin ${PKGVER}: initial release"
+git push
+```
+
+After this, `flowshield-bin` is live on AUR and CI takes over.
+
+### 4. GitHub secret
+
+Add the **private** key to repo secrets:
+
+- Settings → Secrets and variables → Actions → New repository secret
+- Name: `AUR_SSH_PRIVATE_KEY`
+- Value: contents of `~/.ssh/flowshield_aur_ci` (full file, including the
+  `-----BEGIN OPENSSH PRIVATE KEY-----` header)
+
+Once that secret exists, the `publish-to-aur` job will run on the next `v3.*`
+tag.
+
+## Verifying it worked
+
+After a release tag fires:
+
+1. Check the workflow run: `gh run list --workflow desktop-v3-release.yml --limit 1`
+2. The `publish-to-aur` job should report success.
+3. Confirm on AUR: <https://aur.archlinux.org/packages/flowshield-bin>
+   — `pkgver` should match the tag.
+4. End-user install path: `yay -Syu flowshield-bin` (or any AUR helper).
+
+## Troubleshooting
+
+- **SSH auth fails** — verify the public key on the AUR account matches the
+  private key in `AUR_SSH_PRIVATE_KEY`. The error in CI logs will look like
+  `Permission denied (publickey)`.
+- **`.SRCINFO` mismatch** — the action regenerates it; if it still rejects, the
+  `PKGBUILD` is malformed. Render the template locally and run
+  `namcap PKGBUILD` to validate.
+- **AppImage 404** — the `publish-to-aur` job depends on `sign-and-release`, so
+  the GitHub Release should always exist by the time AUR runs. If it doesn't,
+  the `sign-and-release` job failed first.

--- a/scripts/release/update-aur.sh
+++ b/scripts/release/update-aur.sh
@@ -27,11 +27,14 @@ if [ $# -ne 1 ]; then
 fi
 
 TAG="$1"
-# Strip the leading 'v' for pkgver. AUR convention: pkgver is just the
-# semver without prefix. The 'v' stays in the GitHub URL though.
-PKGVER="${TAG#v}"
+# Strip leading 'v'. TAGVER is the GitHub form (3.2.1-alpha.0); PKGVER is
+# the AUR-legal form (3.2.1.alpha.0) since AUR forbids hyphens in pkgver.
+TAGVER="${TAG#v}"
+PKGVER="${TAGVER//-/.}"
 REPO="asifthewebguy/FlowShield"
-APPIMAGE="flowshield_${PKGVER}_amd64.AppImage"
+# Tauri names the AppImage after `productName` (FlowShield, capitalised),
+# not the Cargo package name. Match the actual artifact filename or curl 404s.
+APPIMAGE="FlowShield_${TAGVER}_amd64.AppImage"
 URL="https://github.com/${REPO}/releases/download/${TAG}/${APPIMAGE}"
 
 if [ ! -f PKGBUILD ]; then
@@ -53,10 +56,11 @@ SHA=$(sha256sum "$TMP/$APPIMAGE" | awk '{print $1}')
 echo "  sha256 = ${SHA}"
 
 echo "→ Patching PKGBUILD …"
-# Update pkgver + sha256sums in-place. PKGBUILD is just bash, so
+# Update pkgver + _tagver + sha256sums in-place. PKGBUILD is just bash, so
 # straightforward sed on the well-known field names works.
 sed -i \
   -e "s/^pkgver=.*/pkgver=${PKGVER}/" \
+  -e "s/^_tagver=.*/_tagver=${TAGVER}/" \
   -e "s/^pkgrel=.*/pkgrel=1/" \
   -e "s/^sha256sums=(.*)/sha256sums=('${SHA}')/" \
   PKGBUILD


### PR DESCRIPTION
## Summary

- Adds a `publish-to-aur` job to `desktop-v3-release.yml`. After every `v3.*` tag, the job renders [`PKGBUILD.template`](scripts/release/aur/PKGBUILD.template) against the freshly built AppImage and pushes to `ssh://aur@aur.archlinux.org/flowshield-bin.git` via [`KSXGitHub/github-actions-deploy-aur`](https://github.com/marketplace/actions/github-action-deploy-aur).
- Job gates on `AUR_SSH_PRIVATE_KEY` so it no-ops cleanly when the secret isn't provisioned (forks, downstream test runs).
- `pkgver`/`_tagver` split handles AUR's ban on hyphens in `pkgver`: URL keeps `3.2.1-alpha.0` (matches GitHub release tag), pkgver becomes `3.2.1.alpha.0` (AUR-legal).
- Fixes a latent casing bug in [`scripts/release/update-aur.sh`](scripts/release/update-aur.sh) — Tauri emits `FlowShield_*.AppImage` (capital F from productName), not lowercase.
- Bootstrap walkthrough in [`scripts/release/aur/README.md`](scripts/release/aur/README.md).

## Status

- **AUR package is already live** at <https://aur.archlinux.org/packages/flowshield-bin> (initial `3.2.1.alpha.0` push done manually as part of bootstrap — subsequent releases will auto-publish via this workflow).
- `AUR_SSH_PRIVATE_KEY` secret is provisioned, so this PR's release-please bump (a `feat:` ⇒ minor) will be a real end-to-end test of the new job.

## Test plan

- [ ] CI green on this PR (lint/typecheck only — workflow file itself doesn't run on PRs)
- [ ] Merge → release-please opens its bump PR (expected: `3.3.0-alpha.0`)
- [ ] Merge release-please PR → tag fires → desktop-v3-release.yml runs all 3 jobs (`build-linux`, `sign-and-release`, `publish-to-aur`)
- [ ] Verify `publish-to-aur` job succeeds in the workflow run
- [ ] Verify <https://aur.archlinux.org/packages/flowshield-bin> shows the new pkgver

🤖 Generated with [Claude Code](https://claude.com/claude-code)