### PR TITLE
feat(desktop-v3): in-app update notifications with channel-aware UX

### DIFF
--- a/desktop-app-v3/src-tauri/Cargo.toml
+++ b/desktop-app-v3/src-tauri/Cargo.toml
@@ -58,6 +58,11 @@ thiserror   = "1"
 tracing     = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Version comparison for the in-app update check (update.rs). Handles our
+# `3.x.y-alpha.N` prerelease format correctly, which a hand-rolled string
+# compare wouldn't.
+semver = "1"
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]

--- a/desktop-app-v3/src-tauri/src/commands/mod.rs
+++ b/desktop-app-v3/src-tauri/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod projects;
 pub mod realtime;
 pub mod sessions;
 pub mod tray;
+pub mod update;

--- a/desktop-app-v3/src-tauri/src/commands/update.rs
+++ b/desktop-app-v3/src-tauri/src/commands/update.rs
@@ -1,0 +1,18 @@
+//! Manual "Check for updates" Tauri command. The automatic background
+//! check lives in `lib.rs::setup` (12-hour interval); this command is the
+//! entry point for explicit user-triggered checks (tray menu, settings UI).
+
+use crate::update::{check_and_publish, UpdateInfo};
+use crate::AppState;
+
+/// Force an update check right now. Returns `None` if the app is up-to-date
+/// or if the install source is suppressed (dev / unknown). Also updates the
+/// tray menu + emits the `update-available` event so the in-app banner sees
+/// the same result the periodic background check would have produced.
+#[tauri::command]
+pub async fn update_check_now(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<UpdateInfo>, String> {
+    Ok(check_and_publish(&app, &state.http).await)
+}

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod sync_worker;
 mod tracker;
 mod tray;
 mod tray_indicator;
+mod update;
 
 use std::sync::Arc;
 use tauri::Manager;
@@ -79,6 +80,13 @@ pub struct AppState {
     /// Empty until then — callers should `.get()` and skip registration
     /// if the cache hasn't populated yet (very brief window during launch).
     pub device_id: Arc<std::sync::OnceLock<String>>,
+    /// Most recent UpdateInfo from the periodic background check (if any).
+    /// Read by the tray "Updates available" menu click handler to know
+    /// which URL to open. `None` until the first check finds something
+    /// newer; reset to `None` on app restart (no persistence needed).
+    /// std::sync::Mutex (not tokio's) because the menu click handler is
+    /// synchronous and lock contention is effectively zero.
+    pub latest_update: Arc<std::sync::Mutex<Option<update::UpdateInfo>>>,
 }
 
 impl AppState {
@@ -99,6 +107,7 @@ impl AppState {
             tracker: Arc::new(RwLock::new(None)),
             db: Arc::new(std::sync::OnceLock::new()),
             device_id: Arc::new(std::sync::OnceLock::new()),
+            latest_update: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 }
@@ -212,6 +221,26 @@ pub fn run() {
                     tracing::warn!(?err, path = %db_path.display(), "local store unavailable; offline queue disabled");
                 }
             }
+
+            // Periodic update check. 60s warmup so the network has settled
+            // (DHCP, captive portals) and the user isn't bothered with
+            // banners during the launch flow. Then every 12h. The check
+            // is a no-op for dev builds and PM-channel sources that don't
+            // get a loud prompt — see update::detect_install_source.
+            {
+                let state: tauri::State<'_, AppState> = app.state();
+                let http = state.http.clone();
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    loop {
+                        let _ = update::check_and_publish(&app_handle, &http).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(12 * 60 * 60))
+                            .await;
+                    }
+                });
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -232,6 +261,7 @@ pub fn run() {
             commands::realtime::realtime_config,
             commands::tray::tray_set_session_indicator,
             commands::tray::tray_reset_session_indicator,
+            commands::update::update_check_now,
         ])
         .run(tauri::generate_context!())
         .expect("error while running FlowShield desktop");

--- a/desktop-app-v3/src-tauri/src/tray.rs
+++ b/desktop-app-v3/src-tauri/src/tray.rs
@@ -16,14 +16,18 @@
 //! set the text label to a `MM:SS` countdown.
 
 use crate::tray_indicator;
+use crate::update::UpdateInfo;
+use crate::AppState;
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconEvent;
 use tauri::{App, AppHandle, Manager};
+use tauri_plugin_shell::ShellExt;
 
 const TRAY_ID: &str = "main";
 const SHOW_ID: &str = "show";
 const QUIT_ID: &str = "quit";
+const UPDATE_ID: &str = "update";
 
 /// Embedded base FlowShield logo, used to reset the tray icon when no
 /// session is active. Same source as the bundle icons (PR #48).
@@ -55,7 +59,30 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
             tracing::info!("quit requested via tray menu");
             app.exit(0);
         }
+        UPDATE_ID => open_update_url(app),
         _ => {}
+    }
+}
+
+/// Click handler for the dynamic "Updates available" menu item. Pulls the
+/// most recent UpdateInfo out of AppState (set by `announce_update`) and
+/// opens the channel-appropriate URL — GitHub Release page for direct
+/// downloads, AUR/Flathub/etc. package page for PM channels.
+fn open_update_url(app: &AppHandle) {
+    let latest_update_arc = app.state::<AppState>().latest_update.clone();
+    let url = match latest_update_arc.lock() {
+        Ok(guard) => guard.as_ref().map(|info| info.release_url.clone()),
+        Err(poisoned) => {
+            tracing::warn!("latest_update mutex poisoned; recovering");
+            poisoned.into_inner().as_ref().map(|info| info.release_url.clone())
+        }
+    };
+    let Some(url) = url else {
+        tracing::warn!("update menu clicked but no UpdateInfo cached — ignoring");
+        return;
+    };
+    if let Err(e) = app.shell().open(&url, None) {
+        tracing::warn!(error = %e, %url, "failed to open update URL");
     }
 }
 
@@ -101,6 +128,36 @@ pub fn update_session_indicator(
     let icon = Image::new_owned(img.into_raw(), w, h);
     tray.set_icon(Some(icon))?;
     tray.set_title(Some(label))?;
+    Ok(())
+}
+
+/// Cache the new UpdateInfo and rebuild the tray menu with an "Updates
+/// available" item prepended. Idempotent — calling this twice with the
+/// same info is a no-op user-visible (the menu just gets rebuilt with the
+/// same label). Called both from the periodic background check and from
+/// the manual `update_check_now` command.
+pub fn announce_update(handle: &AppHandle, info: &UpdateInfo) -> tauri::Result<()> {
+    // Stash the URL where `open_update_url` can fetch it on click. Lock
+    // contention isn't a concern — at most one writer (the check task) and
+    // one reader (the menu click handler). We clone the Arc to detach the
+    // guard's lifetime from `tauri::State`'s reference wrapper (which would
+    // otherwise borrow a temporary).
+    let latest_update_arc = handle.state::<AppState>().latest_update.clone();
+    match latest_update_arc.lock() {
+        Ok(mut guard) => *guard = Some(info.clone()),
+        Err(poisoned) => *poisoned.into_inner() = Some(info.clone()),
+    }
+
+    let Some(tray) = handle.tray_by_id(TRAY_ID) else {
+        return Ok(()); // tray install failed earlier — log already emitted
+    };
+
+    let label = format!("▲ Updates: {} available", info.latest_version);
+    let update_item = MenuItem::with_id(handle, UPDATE_ID, &label, true, None::<&str>)?;
+    let show = MenuItem::with_id(handle, SHOW_ID, "Show FlowShield", true, None::<&str>)?;
+    let quit = MenuItem::with_id(handle, QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(handle, &[&update_item, &show, &quit])?;
+    tray.set_menu(Some(menu))?;
     Ok(())
 }
 

--- a/desktop-app-v3/src-tauri/src/update.rs
+++ b/desktop-app-v3/src-tauri/src/update.rs
@@ -1,0 +1,335 @@
+//! In-app update notifications.
+//!
+//! Polls the GitHub Releases API on a schedule, compares the latest v3.*
+//! release to the running binary's version, and emits an `update-available`
+//! Tauri event when a newer release exists.
+//!
+//! The notification's UX intensity depends on how the app was installed —
+//! AUR / Flatpak / Snap / Homebrew users get a quiet tray menu badge that
+//! points them at the right `yay -Syu` / `flatpak update` flow, while users
+//! who downloaded the .AppImage / .deb / .rpm / .dmg directly get a loud
+//! in-app banner with a Download button. Dev builds get nothing.
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+const RELEASES_API_URL: &str =
+    "https://api.github.com/repos/asifthewebguy/FlowShield/releases?per_page=20";
+
+/// Our PKGBUILD installs the wrapped AppImage to /opt/flowshield-bin/. AUR
+/// users can be distinguished from direct-AppImage users by checking whether
+/// $APPIMAGE points into this prefix.
+const AUR_INSTALL_PATH_PREFIX: &str = "/opt/flowshield-bin/";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallSource {
+    Aur,
+    AppImageDirect,
+    /// .deb or .rpm — direct download from a GitHub Release. We don't try
+    /// to distinguish them (dpkg -S vs rpm -qf is heavy + same UX anyway).
+    LinuxPackage,
+    DmgDirect,
+    Flatpak,
+    Snap,
+    Homebrew,
+    Dev,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptStyle {
+    /// Banner + tray menu item — direct downloads with no auto-update.
+    Loud,
+    /// Tray menu item only — let the package manager handle updates.
+    Quiet,
+    /// Suppress entirely (dev builds, unknown sources).
+    None,
+}
+
+impl InstallSource {
+    pub fn prompt_style(self) -> PromptStyle {
+        match self {
+            InstallSource::Aur
+            | InstallSource::Flatpak
+            | InstallSource::Snap
+            | InstallSource::Homebrew => PromptStyle::Quiet,
+            InstallSource::AppImageDirect
+            | InstallSource::LinuxPackage
+            | InstallSource::DmgDirect => PromptStyle::Loud,
+            InstallSource::Dev | InstallSource::Unknown => PromptStyle::None,
+        }
+    }
+
+    /// URL the user is sent to for updating, given the new tag. PM channels
+    /// open their package page (so the user can verify + run their helper);
+    /// direct downloads open the GitHub Release page (where the assets live).
+    pub fn update_url(self, latest_tag: &str) -> String {
+        match self {
+            InstallSource::Aur => {
+                "https://aur.archlinux.org/packages/flowshield-bin".to_string()
+            }
+            InstallSource::Flatpak => {
+                "https://flathub.org/apps/app.flowshield.desktop".to_string()
+            }
+            InstallSource::Snap => "https://snapcraft.io/flowshield".to_string(),
+            InstallSource::Homebrew => {
+                "https://github.com/asifthewebguy/FlowShield#install".to_string()
+            }
+            _ => format!(
+                "https://github.com/asifthewebguy/FlowShield/releases/tag/{latest_tag}"
+            ),
+        }
+    }
+}
+
+/// Decide which install channel the running binary came from. Cheap (env
+/// var lookups + path prefix check); safe to call on every update tick.
+pub fn detect_install_source() -> InstallSource {
+    if cfg!(debug_assertions) {
+        return InstallSource::Dev;
+    }
+    // Sandbox runtimes set their own env vars and the binary lives inside
+    // the sandbox FS — check these first because they take precedence over
+    // the AppImage check (a Flatpak'd Tauri build still has $APPIMAGE unset
+    // but a Snap-wrapped one might).
+    if std::env::var_os("FLATPAK_ID").is_some() {
+        return InstallSource::Flatpak;
+    }
+    if std::env::var_os("SNAP_NAME").is_some() {
+        return InstallSource::Snap;
+    }
+    if let Some(appimage_path) = std::env::var_os("APPIMAGE") {
+        let path = PathBuf::from(appimage_path);
+        if path.starts_with(AUR_INSTALL_PATH_PREFIX) {
+            return InstallSource::Aur;
+        }
+        return InstallSource::AppImageDirect;
+    }
+
+    let exe_path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return InstallSource::Unknown,
+    };
+    let exe_str = exe_path.to_string_lossy();
+
+    #[cfg(target_os = "macos")]
+    {
+        // Homebrew Cask installs the .app under /Applications/ but symlinks
+        // the executable from /opt/homebrew/Caskroom/. Check Caskroom first
+        // so a Homebrew install doesn't mis-detect as DmgDirect.
+        if exe_str.contains("/Caskroom/") || exe_str.starts_with("/opt/homebrew/") {
+            return InstallSource::Homebrew;
+        }
+        if exe_str.starts_with("/Applications/") {
+            return InstallSource::DmgDirect;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if exe_str.starts_with("/usr/bin/") || exe_str.starts_with("/usr/local/bin/") {
+            return InstallSource::LinuxPackage;
+        }
+    }
+
+    let _ = exe_str;
+    InstallSource::Unknown
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateInfo {
+    pub current_version: String,
+    pub latest_version: String,
+    pub latest_tag: String,
+    /// Channel-appropriate URL the click action opens.
+    pub release_url: String,
+    /// Always points at the GitHub Release page so users can read changelog
+    /// even on PM channels.
+    pub release_notes_url: String,
+    pub source: InstallSource,
+    pub prompt_style: PromptStyle,
+    /// PM channels: the recommended one-liner (e.g. `yay -Syu flowshield-bin`).
+    /// `None` for direct-download channels (no command to run).
+    pub update_command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    html_url: String,
+    draft: bool,
+}
+
+async fn fetch_latest_v3_release(http: &reqwest::Client) -> Result<GhRelease, String> {
+    let resp = http
+        .get(RELEASES_API_URL)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("github releases fetch: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("github releases status: {e}"))?;
+
+    let releases: Vec<GhRelease> = resp
+        .json()
+        .await
+        .map_err(|e| format!("github releases parse: {e}"))?;
+
+    // Filter to v3.* tags (skipping drafts), then sort by semver descending.
+    // GitHub's `releases/latest` excludes prereleases, which is wrong for us
+    // since every shipping build is currently `-alpha.0`. Hence the manual
+    // filter + sort over `releases?per_page=20`.
+    let mut v3: Vec<GhRelease> = releases
+        .into_iter()
+        .filter(|r| !r.draft && r.tag_name.starts_with("v3."))
+        .collect();
+
+    v3.sort_by(|a, b| {
+        let av = Version::parse(a.tag_name.trim_start_matches('v')).ok();
+        let bv = Version::parse(b.tag_name.trim_start_matches('v')).ok();
+        bv.cmp(&av)
+    });
+
+    v3.into_iter()
+        .next()
+        .ok_or_else(|| "no v3.* releases found".to_string())
+}
+
+/// Check the current binary's version against GitHub's latest v3.* release.
+/// Returns `None` if up-to-date or if `prompt_style()` is `None` (dev /
+/// unknown sources). Errors are logged but never bubbled — a flaky GitHub
+/// API call should never break the app.
+pub async fn check_for_updates(http: &reqwest::Client) -> Option<UpdateInfo> {
+    let source = detect_install_source();
+    if matches!(source.prompt_style(), PromptStyle::None) {
+        tracing::debug!(?source, "update check skipped (suppressed source)");
+        return None;
+    }
+
+    let current_str = env!("CARGO_PKG_VERSION");
+    let current = match Version::parse(current_str) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, version = current_str, "current version parse failed");
+            return None;
+        }
+    };
+
+    let release = match fetch_latest_v3_release(http).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "fetch latest release failed");
+            return None;
+        }
+    };
+
+    let latest = match Version::parse(release.tag_name.trim_start_matches('v')) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, tag = %release.tag_name, "latest version parse failed");
+            return None;
+        }
+    };
+
+    if latest <= current {
+        tracing::debug!(%current, %latest, "already on latest");
+        return None;
+    }
+
+    let update_command = match source {
+        InstallSource::Aur => Some("yay -Syu flowshield-bin".to_string()),
+        InstallSource::Flatpak => Some("flatpak update app.flowshield.desktop".to_string()),
+        InstallSource::Snap => Some("sudo snap refresh flowshield".to_string()),
+        InstallSource::Homebrew => Some("brew upgrade --cask flowshield".to_string()),
+        _ => None,
+    };
+
+    tracing::info!(%current, %latest, ?source, "update available");
+
+    Some(UpdateInfo {
+        current_version: current.to_string(),
+        latest_version: latest.to_string(),
+        latest_tag: release.tag_name.clone(),
+        release_url: source.update_url(&release.tag_name),
+        release_notes_url: release.html_url,
+        source,
+        prompt_style: source.prompt_style(),
+        update_command,
+    })
+}
+
+/// Composite: check + (if found) announce via tray + emit `update-available`
+/// Tauri event for the frontend banner. Both the periodic background task
+/// and the manual `update_check_now` command go through this so the tray
+/// menu and the in-app banner stay in sync regardless of trigger.
+pub async fn check_and_publish(
+    handle: &tauri::AppHandle,
+    http: &reqwest::Client,
+) -> Option<UpdateInfo> {
+    use tauri::Emitter;
+    let info = check_for_updates(http).await?;
+    if let Err(e) = crate::tray::announce_update(handle, &info) {
+        tracing::warn!(error = %e, "tray announce_update failed");
+    }
+    if let Err(e) = handle.emit("update-available", &info) {
+        tracing::warn!(error = %e, "emit update-available failed");
+    }
+    Some(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_suppresses_prompt() {
+        // Test binary always runs with debug_assertions enabled.
+        assert_eq!(detect_install_source(), InstallSource::Dev);
+        assert!(matches!(
+            InstallSource::Dev.prompt_style(),
+            PromptStyle::None
+        ));
+    }
+
+    #[test]
+    fn aur_url_points_at_aur_package_page() {
+        assert_eq!(
+            InstallSource::Aur.update_url("v3.4.0"),
+            "https://aur.archlinux.org/packages/flowshield-bin"
+        );
+    }
+
+    #[test]
+    fn direct_url_points_at_github_release() {
+        assert_eq!(
+            InstallSource::AppImageDirect.update_url("v3.4.0"),
+            "https://github.com/asifthewebguy/FlowShield/releases/tag/v3.4.0"
+        );
+    }
+
+    #[test]
+    fn package_manager_sources_get_quiet_style() {
+        for s in [
+            InstallSource::Aur,
+            InstallSource::Flatpak,
+            InstallSource::Snap,
+            InstallSource::Homebrew,
+        ] {
+            assert!(matches!(s.prompt_style(), PromptStyle::Quiet), "{s:?}");
+        }
+    }
+
+    #[test]
+    fn direct_download_sources_get_loud_style() {
+        for s in [
+            InstallSource::AppImageDirect,
+            InstallSource::LinuxPackage,
+            InstallSource::DmgDirect,
+        ] {
+            assert!(matches!(s.prompt_style(), PromptStyle::Loud), "{s:?}");
+        }
+    }
+}

--- a/desktop-app-v3/src/App.tsx
+++ b/desktop-app-v3/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-
 import { LoginPage } from './routes/LoginPage';
 import { DashboardPage } from './routes/DashboardPage';
 import { useAuthStore } from './lib/auth';
+import { useUpdateStore } from './lib/update';
 
 export default function App() {
   const { token, hydrated, hydrate } = useAuthStore();
@@ -13,6 +14,17 @@ export default function App() {
   useEffect(() => {
     void hydrate();
   }, [hydrate]);
+
+  // Subscribe to backend update-available events for the in-app banner +
+  // tray indicator. The backend's periodic check fires the events; this is
+  // just the listener side. App is mounted for the whole session, so the
+  // unlisten cleanup only runs in dev hot-reload.
+  useEffect(() => {
+    const unlistenPromise = useUpdateStore.getState().bootstrap();
+    return () => {
+      void unlistenPromise.then((fn) => fn());
+    };
+  }, []);
 
   // Once hydration finishes, redirect unauthenticated users to /login and
   // authenticated users away from /login.

--- a/desktop-app-v3/src/components/UpdateBanner.tsx
+++ b/desktop-app-v3/src/components/UpdateBanner.tsx
@@ -1,0 +1,60 @@
+import { open } from '@tauri-apps/plugin-shell';
+import { Button } from './Button';
+import { useUpdateStore, selectShowBanner } from '../lib/update';
+
+/**
+ * Top-of-dashboard banner that appears when a newer release is available
+ * AND the user installed via a direct-download channel (.AppImage / .deb /
+ * .rpm / .dmg). For package-manager channels (AUR, Flatpak, Snap, Homebrew)
+ * the prompt_style is `quiet` and this component renders null — those users
+ * see only the tray menu badge and let their package manager handle it.
+ *
+ * Dismiss is in-memory only — re-appears on next launch if still applicable.
+ * That's intentional: a missed update on a long-running app deserves another
+ * nudge after a restart, but persistent dismiss could mask a critical fix.
+ */
+export function UpdateBanner() {
+  const visible = useUpdateStore(selectShowBanner);
+  const info = useUpdateStore((s) => s.available);
+  const dismiss = useUpdateStore((s) => s.dismiss);
+
+  if (!visible || !info) return null;
+
+  const handleDownload = async () => {
+    try {
+      await open(info.release_url);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[update] open url failed', err);
+    }
+  };
+
+  return (
+    <div className="bg-primary-500/10 border-b border-primary-500/30 px-3 py-2 flex items-center gap-2">
+      <svg
+        className="w-4 h-4 text-primary-600 dark:text-primary-400 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16" />
+      </svg>
+      <span className="text-sm text-gray-800 dark:text-gray-200 flex-1 min-w-0 truncate">
+        <span className="font-medium">v{info.latest_version}</span> is available
+      </span>
+      <Button variant="primary" size="sm" onClick={handleDownload}>
+        Download
+      </Button>
+      <button
+        onClick={dismiss}
+        className="text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 text-lg leading-none px-1.5"
+        aria-label="Dismiss update notification"
+        type="button"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/desktop-app-v3/src/lib/update.ts
+++ b/desktop-app-v3/src/lib/update.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+// Mirrors the Rust enums in src-tauri/src/update.rs. Serde's
+// `rename_all = "snake_case"` produces these exact strings.
+export type InstallSource =
+  | 'aur'
+  | 'app_image_direct'
+  | 'linux_package'
+  | 'dmg_direct'
+  | 'flatpak'
+  | 'snap'
+  | 'homebrew'
+  | 'dev'
+  | 'unknown';
+
+export type PromptStyle = 'loud' | 'quiet' | 'none';
+
+export interface UpdateInfo {
+  current_version: string;
+  latest_version: string;
+  latest_tag: string;
+  release_url: string;
+  release_notes_url: string;
+  source: InstallSource;
+  prompt_style: PromptStyle;
+  /** Recommended one-liner for PM channels (e.g. `yay -Syu flowshield-bin`). */
+  update_command: string | null;
+}
+
+interface UpdateState {
+  available: UpdateInfo | null;
+  /**
+   * Tag the user dismissed the banner for. In-memory only — re-appears on
+   * next app launch if still applicable. Reset implicitly when a *newer*
+   * tag arrives (the inequality below switches back to true).
+   */
+  dismissedTag: string | null;
+
+  /** Subscribe to the backend's `update-available` event. App.tsx calls
+   *  this once on mount and stores the unlisten fn for cleanup. */
+  bootstrap: () => Promise<UnlistenFn>;
+  /** Manual trigger — used from a future Settings → "Check for updates"
+   *  button. Backend updates the tray itself; this just refreshes state. */
+  checkNow: () => Promise<void>;
+  /** Dismiss the banner for the currently-known available release. */
+  dismiss: () => void;
+}
+
+export const useUpdateStore = create<UpdateState>((set, get) => ({
+  available: null,
+  dismissedTag: null,
+
+  bootstrap: async () => {
+    return listen<UpdateInfo>('update-available', (event) => {
+      set({ available: event.payload });
+    });
+  },
+
+  checkNow: async () => {
+    try {
+      const info = await invoke<UpdateInfo | null>('update_check_now');
+      if (info) set({ available: info });
+    } catch (err) {
+      // Surface to console — failures are non-fatal (network blip, GitHub
+      // rate limit). Backend already logged via tracing.
+      // eslint-disable-next-line no-console
+      console.warn('[update] check failed', err);
+    }
+  },
+
+  dismiss: () => {
+    const current = get().available;
+    if (current) set({ dismissedTag: current.latest_tag });
+  },
+}));
+
+/** Selector: should the loud in-app banner render right now? */
+export function selectShowBanner(state: UpdateState): boolean {
+  if (!state.available) return false;
+  if (state.available.prompt_style !== 'loud') return false;
+  return state.available.latest_tag !== state.dismissedTag;
+}

--- a/desktop-app-v3/src/routes/DashboardPage.tsx
+++ b/desktop-app-v3/src/routes/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { useBlockingStore } from '../lib/blocking';
 import { useRealtimeStore } from '../lib/realtime';
 import { Button } from '../components/Button';
 import { Timer } from '../components/Timer';
+import { UpdateBanner } from '../components/UpdateBanner';
 
 const DURATION_OPTIONS = [15, 25, 45, 60, 90];
 const SESSION_TYPES = ['WORK', 'STUDY', 'CREATIVE'] as const;
@@ -281,6 +282,8 @@ export function DashboardPage() {
           </Button>
         </div>
       </header>
+
+      <UpdateBanner />
 
       <main className="flex-1 p-8 flex flex-col items-center justify-center">
         <div className="w-full max-w-md space-y-6">


### PR DESCRIPTION
## Summary

Polls GitHub Releases every 12h (60s after launch) for newer v3.* releases. The notification's intensity depends on the install channel — direct downloads see a banner + tray badge, package-manager channels see only a quiet tray badge, dev builds see nothing.

## Behavior matrix

| Channel | Tray menu item | In-app banner | Click action |
|---|---|---|---|
| AUR | ✓ (quiet) | ✗ | Opens AUR package page |
| AppImage / .deb / .rpm / .dmg (direct download) | ✓ | ✓ (loud) | Opens GitHub Release page |
| Flatpak / Snap / Homebrew (future) | ✓ (quiet) | ✗ | Opens project page with install instructions |
| Dev build (`cfg(debug_assertions)`) | ✗ | ✗ | No-op |

## Why channel-aware

AUR users get auto-updates via `yay -Syu`. Nagging them with an in-app banner that they should run pacman is redundant — they'll see it, run yay, and pacman does the right thing. So they get a quiet tray badge that confirms an update exists + a click target that opens the AUR package page (where the install command is right there).

Direct-download users have no auto-update path, so the loud banner is the right CTA.

## Detection (runtime, not build-time)

- **AUR:** binary path starts with `/opt/flowshield-bin/` (where our PKGBUILD installs the wrapped AppImage). Distinguishes from a direct-download AppImage in `~/Downloads/` etc., even though both have `$APPIMAGE` set.
- **AppImage direct:** `$APPIMAGE` env var set, path NOT `/opt/flowshield-bin/`.
- **Flatpak / Snap:** `$FLATPAK_ID` / `$SNAP_NAME` env vars.
- **macOS .dmg:** binary at `/Applications/...` (and not in `/Caskroom/`).
- **Homebrew Cask:** binary path under `/opt/homebrew/` or contains `/Caskroom/`.
- **.deb / .rpm:** binary at `/usr/bin/` on Linux without `$APPIMAGE`. Doesn't try to distinguish dpkg vs rpm — same UX either way.

## What's new

**Backend:**
- `src-tauri/src/update.rs` — install-source detection, GitHub Releases API poll, semver compare, `UpdateInfo` struct, `check_and_publish` orchestrator. 5 unit tests.
- `src-tauri/src/commands/update.rs` — `update_check_now` Tauri command for future Settings page.
- `src-tauri/src/lib.rs` — adds `latest_update` field to `AppState`; spawns the periodic check task in `setup()`.
- `src-tauri/src/tray.rs` — new `announce_update` rebuilds the menu with an "▲ Updates: vX.Y.Z available" item; click handler opens the channel-appropriate URL via `tauri-plugin-shell`.
- `src-tauri/Cargo.toml` — `semver = "1"` (one new dep).

**Frontend:**
- `src/lib/update.ts` — Zustand store + listener for the `update-available` event; `selectShowBanner` predicate (loud + not dismissed).
- `src/components/UpdateBanner.tsx` — top-of-dashboard banner with Download + Dismiss.
- `src/App.tsx` — bootstraps the listener on mount.
- `src/routes/DashboardPage.tsx` — mounts `<UpdateBanner />` between header and main.

## Verification

- ✓ `cargo check` clean
- ✓ `cargo test --lib update::tests` — 5/5 pass
- ✓ `npm run typecheck` clean

## Test plan

- [ ] After merge, release-please bumps to v3.3.0 (first `feat:` since v3.2.1)
- [ ] Tag fires `desktop-v3-release.yml` — first real run of the new macOS .dmg job (#62) AND the new AUR auto-publish job (#61)
- [ ] AUR `flowshield-bin` package version updates to 3.3.0 within minutes of the tag
- [ ] Install the new .rpm locally → no banner (we're on the latest)
- [ ] Manually force banner: temporarily edit `Cargo.toml` to `version = "3.0.0"` → rebuild → confirm banner shows + Download opens GitHub Release page
- [ ] Tray menu shows "▲ Updates: 3.3.0 available" item; click opens correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)