### PR TITLE
fix(ci): bump deploy-aur action from v2.7.2 to v4.1.3

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -289,7 +289,10 @@ jobs:
         # container, then commits + pushes via SSH. We only feed it the
         # rendered PKGBUILD; everything else (SRCINFO, git plumbing, ssh
         # known_hosts) is handled internally.
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        # v2.7.2 had a bug — its entrypoint called `bash --command` (invalid
+        # long option) and exited 2 before pushing. v4.1.3 has the same
+        # input shape, just bumped to the latest stable.
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: flowshield-bin
           pkgbuild: ./aur-pkg/PKGBUILD


### PR DESCRIPTION
## Summary

The `publish-to-aur` job in v3.3.0-alpha.0's release pipeline failed because `KSXGitHub/github-actions-deploy-aur@v2.7.2`'s entrypoint shells out to `bash --command` — an invalid long option — and exits 2 before doing anything useful. Bug in that release, not our config.

v4.1.3 has identical inputs (verified by reading its action.yml). One-line bump.

## After merge

I'll re-run `desktop-v3-release.yml` via `workflow_dispatch` against the existing `v3.3.0-alpha.0` tag — only the AUR job needs to succeed (Linux + macOS bundles + signed release are already up). Result: AUR `flowshield-bin` jumps from 3.2.1.alpha.0 → 3.3.0.alpha.0 with no new GitHub release churn.

## Failed run for reference

https://github.com/asifthewebguy/FlowShield/actions/runs/25321086557

🤖 Generated with [Claude Code](https://claude.com/claude-code)