### PR TITLE
fix(web): cap actualDuration in PATCH /api/sessions/[id] to stop the 24,552h report

### DIFF
--- a/web-app/scripts/backfill/2026-05-fix-stale-session-durations.mjs
+++ b/web-app/scripts/backfill/2026-05-fix-stale-session-durations.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * One-shot backfill for the "24,552h weekly report" bug.
+ *
+ * Bug: PATCH /api/sessions/[id] used to write `actualDuration = (endTime -
+ * startTime) / 60000` with no cap. A stale client (e.g. browser closed for
+ * weeks then reopened) PATCHing endTime: now() against an old session
+ * inflated `actualDuration` to days/weeks of "focus", which then propagated
+ * into DailyStats.totalFocusMinutes. The forward fix is in route.ts; this
+ * script cleans up the historical mess.
+ *
+ * Plan:
+ *   1. Find every Session where actualDuration > plannedDuration + GRACE.
+ *   2. Cap each one to plannedDuration (matches auto-end's contract).
+ *   3. Recompute DailyStats from scratch for every (userId, day) touched.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/backfill/2026-05-fix-stale-session-durations.mjs           # dry run
+ *   node --env-file=.env.local scripts/backfill/2026-05-fix-stale-session-durations.mjs --apply   # actually write
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes('--apply');
+const GRACE_MINUTES = 5;
+
+const mode = APPLY ? 'APPLY (writes DB)' : 'DRY RUN (no writes)';
+console.log(`[backfill] mode: ${mode}\n`);
+
+// 1. Identify bad sessions. We pull all completed sessions with actualDuration
+//    set, then filter in-memory because Prisma can't compare two columns in
+//    a where-clause without a raw query.
+const allCompleted = await prisma.session.findMany({
+  where: { completed: true, actualDuration: { not: null }, endTime: { not: null } },
+  select: { id: true, userId: true, plannedDuration: true, actualDuration: true, endTime: true },
+});
+
+const bad = allCompleted.filter(
+  (s) => (s.actualDuration ?? 0) > s.plannedDuration + GRACE_MINUTES,
+);
+
+console.log(`[backfill] scanned ${allCompleted.length} completed sessions`);
+console.log(`[backfill] found ${bad.length} with actualDuration > plannedDuration + ${GRACE_MINUTES}\n`);
+
+if (bad.length === 0) {
+  console.log('[backfill] nothing to do.');
+  await prisma.$disconnect();
+  process.exit(0);
+}
+
+// Group affected (userId, dayKey) so we know which DailyStats rows to recompute.
+const affectedDays = new Map(); // key = `${userId}|${YYYY-MM-DD}`, value = { userId, day: Date }
+const userBuckets = new Map(); // userId -> count, for quick "blast radius" log
+for (const s of bad) {
+  const day = new Date(s.endTime);
+  day.setUTCHours(0, 0, 0, 0); // matches DailyStats.date storage convention (midnight UTC for Netlify Functions)
+  const key = `${s.userId}|${day.toISOString().slice(0, 10)}`;
+  if (!affectedDays.has(key)) affectedDays.set(key, { userId: s.userId, day });
+  userBuckets.set(s.userId, (userBuckets.get(s.userId) ?? 0) + 1);
+}
+
+console.log(`[backfill] affected users: ${userBuckets.size}`);
+console.log(`[backfill] affected (user, day) DailyStats rows to recompute: ${affectedDays.size}\n`);
+
+// Show a few samples so we can sanity-check before applying.
+const SAMPLES = 8;
+console.log(`[backfill] sample of bad sessions (first ${SAMPLES}):`);
+for (const s of bad.slice(0, SAMPLES)) {
+  console.log(
+    `  ${s.id.slice(0, 8)}  user=${s.userId.slice(0, 8)}  planned=${s.plannedDuration}min  actualDuration=${s.actualDuration}min  → cap=${s.plannedDuration}min`,
+  );
+}
+
+if (!APPLY) {
+  console.log('\n[backfill] DRY RUN complete. Re-run with --apply to actually write.');
+  await prisma.$disconnect();
+  process.exit(0);
+}
+
+// 2. Cap each bad session's actualDuration to plannedDuration. Running in
+//    chunks of 50 to keep transactions bounded.
+console.log('\n[backfill] applying session caps...');
+const CHUNK = 50;
+let capped = 0;
+for (let i = 0; i < bad.length; i += CHUNK) {
+  const slice = bad.slice(i, i + CHUNK);
+  await prisma.$transaction(
+    slice.map((s) =>
+      prisma.session.update({
+        where: { id: s.id },
+        data: { actualDuration: s.plannedDuration },
+      }),
+    ),
+  );
+  capped += slice.length;
+  process.stdout.write(`\r  capped ${capped}/${bad.length}`);
+}
+console.log(`\n[backfill] capped ${capped} sessions.`);
+
+// 3. Recompute DailyStats for every affected (userId, day) by re-summing
+//    the now-fixed Session table. We replace, not increment, because the
+//    original DailyStats values are corrupted.
+console.log(`\n[backfill] recomputing DailyStats for ${affectedDays.size} (user, day) rows...`);
+let recomputed = 0;
+for (const { userId, day } of affectedDays.values()) {
+  const dayEnd = new Date(day.getTime() + 24 * 3600 * 1000);
+
+  const sessionsThatDay = await prisma.session.findMany({
+    where: {
+      userId,
+      completed: true,
+      endTime: { gte: day, lt: dayEnd },
+    },
+    select: { actualDuration: true, productivityScore: true },
+  });
+
+  const totalFocusMinutes = sessionsThatDay.reduce(
+    (sum, s) => sum + (s.actualDuration ?? 0),
+    0,
+  );
+  const sessionsCompleted = sessionsThatDay.length;
+  const scoredSessions = sessionsThatDay.filter(
+    (s) => s.productivityScore !== null && s.productivityScore !== undefined,
+  );
+  const avgProductivityScore =
+    scoredSessions.length > 0
+      ? Math.round(
+          scoredSessions.reduce((a, s) => a + (s.productivityScore ?? 0), 0) /
+            scoredSessions.length,
+        )
+      : 0;
+
+  await prisma.dailyStats.upsert({
+    where: { userId_date: { userId, date: day } },
+    update: { totalFocusMinutes, sessionsCompleted, avgProductivityScore },
+    create: { userId, date: day, totalFocusMinutes, sessionsCompleted, avgProductivityScore },
+  });
+
+  recomputed += 1;
+  if (recomputed % 25 === 0) {
+    process.stdout.write(`\r  recomputed ${recomputed}/${affectedDays.size}`);
+  }
+}
+console.log(`\n[backfill] recomputed ${recomputed} DailyStats rows.`);
+
+console.log('\n[backfill] done.');
+await prisma.$disconnect();

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -51,12 +51,19 @@ export async function PATCH(
       }
     }
 
-    // Calculate actual duration if endTime is provided
+    // Calculate actual duration if endTime is provided. Clamp to
+    // plannedDuration + 5min grace (same contract as the auto-end route)
+    // so a stale client PATCHing endTime: now() against a session started
+    // weeks ago can't write months of "focus" — that's the bug behind the
+    // 24,552h weekly report. Negative values (clock-skew) clamp to 0.
     let actualDuration;
     if (endTime) {
       const start = new Date(existingSession.startTime);
       const end = new Date(endTime);
-      actualDuration = Math.round((end.getTime() - start.getTime()) / 60000); // minutes
+      const SESSION_GRACE_MINUTES = 5;
+      const computed = Math.round((end.getTime() - start.getTime()) / 60000);
+      const cap = existingSession.plannedDuration + SESSION_GRACE_MINUTES;
+      actualDuration = Math.max(0, Math.min(computed, cap));
     }
 
     let updatedSession = await prisma.session.update({


### PR DESCRIPTION
## Summary

The Weekly Performance Report was showing **24,552 hours of focus this week** (+190232% vs last week) because `PATCH /api/sessions/[id]` had no upper bound on `actualDuration`. A stale client PATCHing `endTime: now()` against a session started months ago wrote `actualDuration = (now - oldStart) / 60000` minutes, which then propagated into `DailyStats.totalFocusMinutes`.

Worst offender in prod: one session with `actualDuration = 191,696 minutes` (133 days).

## What changed

- **Forward fix** ([web-app/src/app/api/sessions/[id]/route.ts](web-app/src/app/api/sessions/%5Bid%5D/route.ts)): clamp computed `actualDuration` to `plannedDuration + 5min grace`, matching the auto-end route's existing contract. Negative values (clock-skew) clamp to 0.

- **Backfill script** ([web-app/scripts/backfill/2026-05-fix-stale-session-durations.mjs](web-app/scripts/backfill/2026-05-fix-stale-session-durations.mjs)): one-shot cleanup that finds sessions with `actualDuration > plannedDuration + 5`, caps each to `plannedDuration`, then recomputes `DailyStats` from scratch for every affected `(userId, day)`. Dry-run by default; `--apply` writes.

## Already run against prod

```
[backfill] scanned 110 completed sessions
[backfill] found 28 with actualDuration > plannedDuration + 5
[backfill] affected users: 2
[backfill] capped 28 sessions, recomputed 13 DailyStats rows
```

Dev account's weekly focus total: **24,552.8h → 11.2h** (24 sessions × ~25min ≈ 10h, sanity-checks).

## Why this works

`auto-end/route.ts:57` already clamps to `plannedDuration` when the grace window expires without manual end. This PR brings manual end into parity with a slightly more generous `+5min` cap so a user finishing 1-3 minutes after their planned end still gets the real duration recorded.

Tradeoff: a user who legitimately works 30+ minutes past plan (without a new session) loses the overtime in the record. Acceptable — auto-end already drops it entirely, and the catastrophic-bug elimination matters more.

## Test plan

- [ ] CI green
- [ ] Visit `flowshield.app/reports/weekly` after merge — focus hours should still be ~11h, not regressed
- [ ] Start a real focus session, end it normally → `actualDuration` matches wall time
- [ ] (Long tail) Stale-client repro: open dashboard with browser tools, change system clock forward 1 day, click "End session" — server should clamp instead of writing 1440min

🤖 Generated with [Claude Code](https://claude.com/claude-code)