### PR TITLE
fix(web): derive weekly report productivity score from session completion

### DIFF
--- a/web-app/src/app/api/reports/weekly/route.ts
+++ b/web-app/src/app/api/reports/weekly/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const since = new Date();
     since.setDate(since.getDate() - weeks * 7);
 
-    const [dailyStats, currentWeekLogs] = await Promise.all([
+    const [dailyStats, currentWeekLogs, sessionsInRange] = await Promise.all([
       prisma.dailyStats.findMany({
         where: { userId, date: { gte: since } },
         orderBy: { date: 'asc' },
@@ -31,9 +31,27 @@ export async function GET(request: NextRequest) {
         },
         select: { category: true, durationSeconds: true },
       }),
+      // Sessions in the same range — fed to getWeeklyStats so productivity
+      // score is derived from completion + duration-match (the same signal
+      // /api/analytics uses) instead of read from DailyStats.avgProductivityScore
+      // (which stays null/0 because the desktop client never collects ratings).
+      prisma.session.findMany({
+        where: { userId, completed: true, endTime: { gte: since } },
+        select: {
+          endTime: true,
+          plannedDuration: true,
+          actualDuration: true,
+          completed: true,
+        },
+      }),
     ]);
 
-    const weeklyStats = getWeeklyStats(dailyStats, weeks);
+    // Filter out the rare row where endTime is null despite completed=true
+    // (older bad data); the SessionInput type requires a real timestamp.
+    const sessionsForReport = sessionsInRange.flatMap((s) =>
+      s.endTime ? [{ ...s, endTime: s.endTime }] : [],
+    );
+    const weeklyStats = getWeeklyStats(dailyStats, weeks, sessionsForReport);
 
     const catMap = new Map<string, number>();
     for (const log of currentWeekLogs) {

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -95,28 +95,34 @@ export async function PATCH(
         select: { avgProductivityScore: true, sessionsCompleted: true },
       });
 
-      const newAvg =
-        productivityScore !== undefined
-          ? nextWeightedAverage(
-              existingStats?.avgProductivityScore ?? null,
-              existingStats?.sessionsCompleted ?? 0,
-              productivityScore
-            )
-          : existingStats?.avgProductivityScore ?? 0;
+      // Tighten check from `!== undefined` to `typeof === 'number'` so a
+      // client sending productivityScore: null (the desktop sends None →
+      // null when the user didn't rate) doesn't crash through
+      // nextWeightedAverage(null) → Math.round(null) = 0, which was
+      // poisoning DailyStats.avgProductivityScore with zeros and showing
+      // "Productivity Score 0%" on the weekly report.
+      const hasScore = typeof productivityScore === 'number';
+      const newAvg = hasScore
+        ? nextWeightedAverage(
+            existingStats?.avgProductivityScore ?? null,
+            existingStats?.sessionsCompleted ?? 0,
+            productivityScore
+          )
+        : existingStats?.avgProductivityScore ?? null;
 
       await prisma.dailyStats.upsert({
         where: { userId_date: { userId, date: today } },
         update: {
           totalFocusMinutes: { increment: actualDuration },
           sessionsCompleted: { increment: 1 },
-          ...(productivityScore !== undefined && { avgProductivityScore: newAvg }),
+          ...(hasScore && { avgProductivityScore: newAvg }),
         },
         create: {
           userId,
           date: today,
           totalFocusMinutes: actualDuration,
           sessionsCompleted: 1,
-          avgProductivityScore: productivityScore ?? 0,
+          avgProductivityScore: hasScore ? productivityScore : null,
         },
       });
     }

--- a/web-app/src/lib/productivity.ts
+++ b/web-app/src/lib/productivity.ts
@@ -1,7 +1,7 @@
 // Productivity scoring algorithm
 // Score is 0-100 based on focus time, completion rate, and session quality
 
-interface SessionForScoring {
+export interface SessionForScoring {
   plannedDuration: number;
   actualDuration: number | null;
   completed: boolean;

--- a/web-app/src/lib/reports.ts
+++ b/web-app/src/lib/reports.ts
@@ -1,3 +1,5 @@
+import { calculateProductivityScore, type SessionForScoring } from './productivity';
+
 export interface WeekStat {
   weekLabel: string;
   weekStart: string;
@@ -20,6 +22,17 @@ interface DailyStatInput {
   totalFocusMinutes: number;
   avgProductivityScore: number | null;
   sessionsCompleted: number;
+}
+
+/**
+ * Subset of Session fields needed to derive a per-week productivity score.
+ * Loose shape so callers don't have to import the full Prisma type.
+ */
+interface SessionInput {
+  endTime: Date | string;
+  plannedDuration: number;
+  actualDuration: number | null;
+  completed: boolean;
 }
 
 function toLocalDateOnly(date: Date): Date {
@@ -57,7 +70,19 @@ function toYMD(date: Date): string {
  * This ensures `dayAgo(0..6)` always maps to the same bucket regardless
  * of the current day of week.
  */
-export function getWeeklyStats(dailyStats: DailyStatInput[], numWeeks = 8): WeeklyStatsResult {
+export function getWeeklyStats(
+  dailyStats: DailyStatInput[],
+  numWeeks = 8,
+  /**
+   * Optional Session rows for the same range. When supplied, per-week
+   * productivity score is derived from completion + duration-match via
+   * `calculateProductivityScore` instead of read from
+   * DailyStats.avgProductivityScore. Pass `[]` (the default) to fall back
+   * to the daily-stats column — used by tests and by callers who don't
+   * have session data on hand.
+   */
+  sessions: SessionInput[] = [],
+): WeeklyStatsResult {
   type Bucket = { focusMinutes: number; scoreSum: number; scoreCount: number; sessions: number; weekStartDay: number };
 
   const todayDay = daysSinceEpochLocal(toLocalDateOnly(new Date()));
@@ -86,6 +111,40 @@ export function getWeeklyStats(dailyStats: DailyStatInput[], numWeeks = 8): Week
     buckets.set(bucketIndex, existing);
   }
 
+  // Bucket sessions per week using the same anchoring as the daily stats.
+  // We feed each bucket's session list to calculateProductivityScore to
+  // derive the week's score from completion + duration-match — the same
+  // signal `/api/analytics` uses, and one that doesn't depend on the user
+  // explicitly rating their sessions (which the desktop never collects).
+  const sessionsByBucket = new Map<number, SessionForScoring[]>();
+  for (const s of sessions) {
+    if (!s.endTime) continue;
+    const d = toLocalDateOnly(new Date(s.endTime));
+    const daysAgo = todayDay - daysSinceEpochLocal(d);
+    if (daysAgo < 0) continue;
+    const bucketIndex = Math.floor(daysAgo / 7);
+    if (bucketIndex >= numWeeks) continue;
+    const arr = sessionsByBucket.get(bucketIndex) ?? [];
+    arr.push({
+      plannedDuration: s.plannedDuration,
+      actualDuration: s.actualDuration,
+      completed: s.completed,
+    });
+    sessionsByBucket.set(bucketIndex, arr);
+  }
+
+  // Per-bucket derived score. Empty buckets stay 0 (consistent with the old
+  // behavior when scoreCount was 0).
+  const derivedScoreByBucket = new Map<number, number>();
+  for (const [idx, ss] of sessionsByBucket) {
+    derivedScoreByBucket.set(idx, ss.length > 0 ? calculateProductivityScore(ss) : 0);
+  }
+
+  // If sessions[] is supplied, ensure every bucket index that has daily
+  // stats but no sessions still resolves to 0 explicitly (so the score
+  // doesn't fall through to the legacy DailyStats path).
+  const useDerivedScores = sessions.length > 0;
+
   // Sort by bucketIndex descending (oldest first for chart order)
   const sortedIndices = [...buckets.keys()].sort((a, b) => b - a); // oldest (highest index) first
 
@@ -95,11 +154,14 @@ export function getWeeklyStats(dailyStats: DailyStatInput[], numWeeks = 8): Week
     const weekStartDayNum = todayDay - idx * 7 - 6;
     const weekStartDate = dayNumToLocalDate(weekStartDayNum, todayDay);
     const weekStart = toYMD(weekStartDate);
+    const score = useDerivedScores
+      ? (derivedScoreByBucket.get(idx) ?? 0)
+      : (agg.scoreCount > 0 ? Math.round(agg.scoreSum / agg.scoreCount) : 0);
     return {
       weekLabel: weekStartDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
       weekStart,
       totalFocusHours: Math.round((agg.focusMinutes / 60) * 10) / 10,
-      avgProductivityScore: agg.scoreCount > 0 ? Math.round(agg.scoreSum / agg.scoreCount) : 0,
+      avgProductivityScore: score,
       sessionsCompleted: agg.sessions,
     };
   });
@@ -112,8 +174,12 @@ export function getWeeklyStats(dailyStats: DailyStatInput[], numWeeks = 8): Week
 
   const currentFocusHours = Math.round((currentAgg.focusMinutes / 60) * 10) / 10;
   const previousFocusHours = Math.round((previousAgg.focusMinutes / 60) * 10) / 10;
-  const currentScore = currentAgg.scoreCount > 0 ? Math.round(currentAgg.scoreSum / currentAgg.scoreCount) : 0;
-  const previousScore = previousAgg.scoreCount > 0 ? Math.round(previousAgg.scoreSum / previousAgg.scoreCount) : 0;
+  const currentScore = useDerivedScores
+    ? (derivedScoreByBucket.get(0) ?? 0)
+    : (currentAgg.scoreCount > 0 ? Math.round(currentAgg.scoreSum / currentAgg.scoreCount) : 0);
+  const previousScore = useDerivedScores
+    ? (derivedScoreByBucket.get(1) ?? 0)
+    : (previousAgg.scoreCount > 0 ? Math.round(previousAgg.scoreSum / previousAgg.scoreCount) : 0);
   const currentSessions = currentAgg.sessions;
   const previousSessions = previousAgg.sessions;
 


### PR DESCRIPTION
## Summary

The Weekly Performance Report shows "Productivity Score 0%" forever because two bugs compound:

1. **Server poisons the column.** Desktop sends `productivityScore: null` on session-end (it doesn't collect an explicit rating). The PATCH handler's check `productivityScore !== undefined` is true for null, so it runs `nextWeightedAverage(null)` → `Math.round(null)` = 0. DailyStats.avgProductivityScore gets stamped 0 every session.
2. **Report reads only the column.** Even with #1 fixed, no one rates sessions, so the column stays null/0 forever and the report still shows 0%.

## What changed

- **`PATCH /api/sessions/[id]`** ([route.ts](web-app/src/app/api/sessions/%5Bid%5D/route.ts)): tighten check to `typeof productivityScore === 'number'`. Null no longer writes 0; new rows store null when no rating supplied.
- **`/api/reports/weekly` + `lib/reports.getWeeklyStats`** ([route.ts](web-app/src/app/api/reports/weekly/route.ts), [reports.ts](web-app/src/lib/reports.ts)): now also receives Session rows for the date range and derives per-week productivity from completion + duration match via the existing `calculateProductivityScore` helper (the same scoring `/api/analytics` already uses). Backward-compatible: when `sessions[]` is empty (existing tests, callers without session data), falls back to the legacy DailyStats column path.
- **`lib/productivity`**: export the `SessionForScoring` interface so `reports.ts` can type its session bucket.

## Estimated impact

Dev account had 24 completed sessions in the last 7 days. Quick approximation says the derived score will be ~95% — finally a useful number instead of 0%.

## Why no backfill

The poisoned zeros in `DailyStats.avgProductivityScore` are now ignored by the report (which derives from Sessions). Other readers of the column (cron weekly digest, leaderboard) can be migrated in follow-ups; for now they still see the noisy zeros, which is no worse than before.

## Verification

- ✓ `npm run typecheck` clean
- ✓ `vitest run reports.test productivity.test` — 30/30 pass

## Test plan

- [ ] CI green
- [ ] Refresh `flowshield.app/reports/weekly` after merge → Productivity Score shows real % (expect ~95)
- [ ] Open dev console, end a session via desktop without rating → check DailyStats.avgProductivityScore stays null (or previous value), not 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)