### PR TITLE
feat(web,docs): publish desktop v3 cross-platform info on homepage + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 **FlowShield** is a full-stack productivity ecosystem that helps knowledge workers, developers, and students build deep focus habits. It combines structured Pomodoro-style sessions with automatic activity tracking, AI-powered coaching, team accountability, and detailed billing analytics — across web, desktop, mobile, and browser extension.
 
-**Current versions:** Web v2.0.0 · Desktop v2.3.0
+**Current versions:** Web v2.0.0 · Desktop v2.3.0 (Windows, stable) · Desktop v3.3.0-alpha.0 (cross-platform alpha — Linux & macOS)
 
 ---
 
@@ -99,8 +99,10 @@ The primary product. Deployed on Netlify at [flowshield.app](https://flowshield.
 - Server-side caching via Upstash Redis (5-min TTL)
 - Error tracking via Sentry
 
-### Desktop App (`desktop-app/`)
-.NET 8.0 · C# · WinForms/WPF · SQLite (SQLCipher encrypted) · **Current: v2.3.0**
+### Desktop App — v2 Windows (`desktop-app/`)
+.NET 8.0 · C# · WinForms/WPF · SQLite (SQLCipher encrypted) · **Current: v2.3.0** · **[Install from Microsoft Store](https://apps.microsoft.com/detail/9MX8Q3FQ136L)**
+
+The polished, signed Windows release. Use this on Windows.
 
 - Background activity tracker monitoring active window/process
 - Deep Work Mode: hosts-file-based website and app blocking
@@ -110,6 +112,21 @@ The primary product. Deployed on Netlify at [flowshield.app](https://flowshield.
 - Auto-updater checks GitHub Releases on startup
 - DPAPI-based encrypted key storage · Serilog structured logging · Sentry .NET
 - Inno Setup installer → `FlowShield-Setup-vX.Y.Z.exe`
+
+### Desktop App — v3 cross-platform alpha (`desktop-app-v3/`)
+Tauri 2 · Rust · React 19 · TypeScript · SQLite · **Current: v3.3.0-alpha.0** · macOS · Linux
+
+The cross-platform rewrite. Native client for Linux and macOS users; Windows users should stay on v2 until v3 reaches parity.
+
+- **macOS:** universal `.dmg` (Intel + Apple Silicon) on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest). Unsigned/unnotarized for now — first launch needs right-click → Open → "Open Anyway" in System Settings → Privacy & Security.
+- **Linux:** `.AppImage`, `.deb`, and `.rpm` on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest), GPG-signed. Verify with `gpg --verify SHA256SUMS.asc`.
+- **Arch Linux:** [`flowshield-bin`](https://aur.archlinux.org/packages/flowshield-bin) on AUR — `yay -S flowshield-bin` (auto-published from each tag).
+- Native system tray with focus-session progress ring overlay
+- Activity tracker via cross-platform foreground-window query
+- Deep Work Mode: hosts-file blocking via `pkexec` (Linux) / `osascript` (macOS) elevation prompt
+- Real-time cross-device session sync via Pusher (`session-update` events)
+- In-app update notifications: GitHub Releases poll every 12h, channel-aware UX (loud banner for direct downloads, quiet tray badge for AUR / future Flatpak)
+- Tag-driven release pipeline: GitHub Actions builds + signs + publishes to GitHub Releases + auto-pushes to AUR on every `v3.*` tag
 
 ### Browser Extension (`browser-extension/`)
 Chrome Manifest V3 · Firefox Manifest V2 · **[Install from Chrome Web Store](https://chromewebstore.google.com/detail/flowshield/pjjmmmefbcmcckgmdoceapgbdnjbffdg)**
@@ -144,7 +161,7 @@ npm run dev                  # http://localhost:3000
 
 See [web-app/SETUP_GUIDE.md](web-app/SETUP_GUIDE.md) for all environment variables.
 
-### Desktop App
+### Desktop App — v2 (Windows, .NET)
 
 ```bash
 cd desktop-app
@@ -153,6 +170,35 @@ dotnet run -c Release
 ```
 
 The app will prompt you to log in with your FlowShield account on first run.
+
+### Desktop App — v3 (Tauri, cross-platform)
+
+End-user install (Linux / macOS):
+
+```bash
+# Linux (Debian/Ubuntu)
+sudo apt install ./FlowShield_3.3.0-alpha.0_amd64.deb
+
+# Linux (Fedora/RHEL)
+sudo dnf install ./FlowShield-3.3.0-alpha.0-1.x86_64.rpm
+
+# Linux (Arch — auto-publishes from each tag)
+yay -S flowshield-bin
+
+# macOS — right-click the .dmg → Open → "Open Anyway" in System Settings (unsigned for now)
+open FlowShield_3.3.0-alpha.0_universal.dmg
+```
+
+Dev build (any OS):
+
+```bash
+cd desktop-app-v3
+npm install
+npm run tauri:dev          # hot-reload dev mode
+npm run tauri:build        # produces installers under src-tauri/target/release/bundle/
+```
+
+System deps for Linux dev: `webkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `libssl-dev`, `libxss-dev`, `patchelf`. Tag-driven CI handles building + signing + publishing for releases — see [`.github/workflows/desktop-v3-release.yml`](.github/workflows/desktop-v3-release.yml).
 
 ### Browser Extension
 

--- a/web-app/src/components/landing/CrossPlatform.tsx
+++ b/web-app/src/components/landing/CrossPlatform.tsx
@@ -5,6 +5,15 @@ type Cta =
   | { label: string; href: string; external?: boolean; disabled?: false }
   | { label: string; disabled: true };
 
+type DownloadOption = {
+  /** 1-line label shown inside the pill (e.g. "macOS") */
+  label: string;
+  href: string;
+  external?: boolean;
+  /** Full description for screen readers — pills carry only an OS name visually */
+  ariaLabel?: string;
+};
+
 type Platform = {
   name: string;
   description: string;
@@ -16,6 +25,13 @@ type Platform = {
     external?: boolean;
     note?: string;
   };
+  /** When set, renders a row of compact OS-specific download pills below the
+   *  primary CTA, separated by a small editorial rule. Use this for surfaces
+   *  with multiple parallel distribution channels (Desktop = MS Store +
+   *  GitHub Releases per OS + AUR). */
+  downloadOptions?: DownloadOption[];
+  /** Caveat shown beneath the OS pills (e.g. "Linux & macOS are alpha"). */
+  alphaNote?: string;
 };
 
 const platforms: Platform[] = [
@@ -31,7 +47,7 @@ const platforms: Platform[] = [
   },
   {
     name: 'Desktop App',
-    description: 'Windows activity tracking, deep work mode, distraction blocking, and offline sync.',
+    description: 'Native client for Windows, macOS, and Linux. Activity tracking, deep work mode, hosts-file blocking, and offline sync.',
     icon: (
       <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
@@ -42,12 +58,27 @@ const platforms: Platform[] = [
       href: 'https://apps.microsoft.com/detail/9MX8Q3FQ136L',
       external: true,
     },
-    secondary: {
-      label: 'Nightly .exe on GitHub',
-      href: 'https://github.com/asifthewebguy/FlowShield/releases/latest',
-      external: true,
-      note: 'Self-signed — Windows SmartScreen will warn. Click "More info" → "Run anyway" to install.',
-    },
+    downloadOptions: [
+      {
+        label: 'macOS',
+        href: 'https://github.com/asifthewebguy/FlowShield/releases/latest',
+        external: true,
+        ariaLabel: 'Download FlowShield for macOS — universal .dmg from GitHub Releases',
+      },
+      {
+        label: 'Linux',
+        href: 'https://github.com/asifthewebguy/FlowShield/releases/latest',
+        external: true,
+        ariaLabel: 'Download FlowShield for Linux — .deb, .rpm, or .AppImage from GitHub Releases',
+      },
+      {
+        label: 'Arch',
+        href: 'https://aur.archlinux.org/packages/flowshield-bin',
+        external: true,
+        ariaLabel: 'Install FlowShield on Arch Linux from AUR — yay -S flowshield-bin',
+      },
+    ],
+    alphaNote: 'Linux & macOS are 3.x alpha builds — Windows is the polished release.',
   },
   {
     name: 'Browser Extension',
@@ -131,6 +162,40 @@ export default function CrossPlatform() {
               <p className="text-xs text-gray-400 mb-5 flex-grow">{p.description}</p>
 
               <PrimaryButton cta={p.primary} />
+
+              {p.downloadOptions && p.downloadOptions.length > 0 && (
+                <>
+                  {/* Editorial divider — caps-tracked separator between the
+                      hero CTA and the secondary OS-specific downloads. Reads
+                      as "Microsoft Store is the polished path; here are the
+                      others." */}
+                  <div className="mt-4 flex items-center gap-2" aria-hidden="true">
+                    <div className="flex-1 h-px bg-surface-3" />
+                    <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+                      or download for
+                    </span>
+                    <div className="flex-1 h-px bg-surface-3" />
+                  </div>
+                  <div className="mt-3 grid grid-cols-3 gap-1.5">
+                    {p.downloadOptions.map((opt) => (
+                      <a
+                        key={opt.label}
+                        href={opt.href}
+                        target={opt.external ? '_blank' : undefined}
+                        rel={opt.external ? 'noopener noreferrer' : undefined}
+                        aria-label={opt.ariaLabel ?? opt.label}
+                        className="text-[11px] font-medium text-gray-300 bg-surface-3/40 hover:bg-primary-900/40 hover:text-primary-300 border border-surface-3 hover:border-primary-700/60 rounded-md px-2 py-1.5 text-center transition-colors"
+                      >
+                        {opt.label}
+                      </a>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {p.alphaNote && (
+                <p className="mt-3 text-[10px] leading-snug text-gray-500 text-center">{p.alphaNote}</p>
+              )}
 
               {p.secondary && (
                 <div className="mt-3 text-center">


### PR DESCRIPTION
## Summary

Both the public landing page and the README still claimed FlowShield Desktop was Windows-only (.NET v2.3.0). Now that the v3 Tauri rewrite is shipping signed Linux + universal macOS builds + auto-publishing to AUR, both surfaces need to advertise it.

## Homepage — `CrossPlatform.tsx`

The Desktop card now renders as: hero CTA → editorial divider → 3 OS pills → tiny alpha disclaimer.

\`\`\`
[icon]  Desktop App
        Native client for Windows, macOS, and Linux. Activity tracking,
        deep work mode, hosts-file blocking, and offline sync.

        [ Get on Microsoft Store ]                    ← primary, Windows-stable

        ─────────  OR DOWNLOAD FOR  ─────────         ← editorial rule

        [ macOS ]   [ Linux ]   [ Arch ]              ← OS pills

        Linux & macOS are 3.x alpha builds — Windows is the polished release.
\`\`\`

Design notes:
- Hero CTA dominates; pills read as deliberate secondary downloads, not a tacked-on list.
- Editorial caps-tracked divider (\"OR DOWNLOAD FOR\") communicates the relationship between primary and secondary paths.
- Pills use existing \`surface-3\` + \`primary-700/60\` hover tokens — no new design tokens introduced.
- Each pill has a descriptive ARIA label (e.g. \"Download FlowShield for macOS — universal .dmg from GitHub Releases\").
- Type system: new \`DownloadOption\` type + optional \`downloadOptions\` / \`alphaNote\` fields on \`Platform\`. Backward-compatible — Web/Browser/Mobile cards unaffected.

## README

- **Header:** \"Current versions\" line now lists Web v2.0.0 · Desktop v2.3.0 (Windows, stable) · Desktop v3.3.0-alpha.0 (cross-platform alpha — Linux & macOS).
- **Platforms:** existing Desktop section split into:
  - \`### Desktop App — v2 Windows\` (MS Store CTA, .NET stack as before)
  - \`### Desktop App — v3 cross-platform alpha\` (Tauri/Rust stack, GitHub Releases per OS, AUR \`flowshield-bin\`, in-app update notifications, tag-driven CI)
- **Quick Start:** matching split — v2 \`dotnet run\` + new v3 install commands per OS (apt / dnf / yay / open .dmg) plus the dev build flow.

## Verification

- ✓ \`tsc --noEmit\` clean
- ✓ \`eslint src/components/landing/CrossPlatform.tsx\` clean

## Test plan

- [ ] CI green
- [ ] After merge → visit flowshield.app, scroll to \"One Account. Every Device.\" section → Desktop card renders the new pills + divider
- [ ] Click each pill → opens correct destination in new tab
- [ ] Resize to mobile width → 4-card grid collapses gracefully; the Desktop card's pill row stays in 3 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)