### PR TITLE
docs(desktop-v3): per-platform install guides for macOS + Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ The polished, signed Windows release. Use this on Windows.
 ### Desktop App — v3 cross-platform alpha (`desktop-app-v3/`)
 Tauri 2 · Rust · React 19 · TypeScript · SQLite · **Current: v3.3.0-alpha.0** · macOS · Linux
 
-The cross-platform rewrite. Native client for Linux and macOS users; Windows users should stay on v2 until v3 reaches parity.
+The cross-platform rewrite. Native client for Linux and macOS users; Windows users should stay on v2 until v3 reaches parity. Full install walkthroughs: [macOS](desktop-app-v3/INSTALL_MACOS.md) · [Linux](desktop-app-v3/INSTALL_LINUX.md).
 
-- **macOS:** universal `.dmg` (Intel + Apple Silicon) on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest). Unsigned/unnotarized for now — first launch needs right-click → Open → "Open Anyway" in System Settings → Privacy & Security.
-- **Linux:** `.AppImage`, `.deb`, and `.rpm` on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest), GPG-signed. Verify with `gpg --verify SHA256SUMS.asc`.
+- **macOS:** universal `.dmg` (Intel + Apple Silicon) on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest). Unsigned/unnotarized for now — first launch needs right-click → Open → "Open Anyway" in System Settings → Privacy & Security. See [`INSTALL_MACOS.md`](desktop-app-v3/INSTALL_MACOS.md) for the Gatekeeper bypass + permissions walkthrough.
+- **Linux:** `.AppImage`, `.deb`, and `.rpm` on each [GitHub Release](https://github.com/asifthewebguy/FlowShield/releases/latest), GPG-signed. Verify with `gpg --verify SHA256SUMS.asc`. See [`INSTALL_LINUX.md`](desktop-app-v3/INSTALL_LINUX.md) for per-distro install + Wayland/tray troubleshooting.
 - **Arch Linux:** [`flowshield-bin`](https://aur.archlinux.org/packages/flowshield-bin) on AUR — `yay -S flowshield-bin` (auto-published from each tag).
 - Native system tray with focus-session progress ring overlay
 - Activity tracker via cross-platform foreground-window query
@@ -173,7 +173,9 @@ The app will prompt you to log in with your FlowShield account on first run.
 
 ### Desktop App — v3 (Tauri, cross-platform)
 
-End-user install (Linux / macOS):
+End-user install (Linux / macOS) — quick reference. **Full walkthroughs (verification, permissions, troubleshooting, uninstall):**
+- macOS: [`desktop-app-v3/INSTALL_MACOS.md`](desktop-app-v3/INSTALL_MACOS.md)
+- Linux: [`desktop-app-v3/INSTALL_LINUX.md`](desktop-app-v3/INSTALL_LINUX.md)
 
 ```bash
 # Linux (Debian/Ubuntu)

--- a/desktop-app-v3/INSTALL_LINUX.md
+++ b/desktop-app-v3/INSTALL_LINUX.md
@@ -1,0 +1,280 @@
+# Installing FlowShield on Linux
+
+FlowShield Desktop v3 ships four ways on Linux — pick whichever your
+distro prefers:
+
+| Format | Best for | Install path |
+|---|---|---|
+| **AUR** (`flowshield-bin`) | Arch, Manjaro, EndeavourOS | `yay -S flowshield-bin` (auto-updates) |
+| **`.rpm`** | Fedora, RHEL, openSUSE | `sudo dnf install ./FlowShield-X.Y.Z.rpm` |
+| **`.deb`** | Debian, Ubuntu, Pop!_OS, Mint | `sudo apt install ./FlowShield_X.Y.Z.deb` |
+| **`.AppImage`** | Any distro (no install required) | `chmod +x ./FlowShield_X.Y.Z.AppImage && ./FlowShield...` |
+
+> **Architecture:** all packages are `amd64` / `x86_64`. ARM Linux isn't
+> supported yet.
+
+> **Display server:** X11, GNOME Wayland (XWayland fallback), and KDE
+> Wayland are all supported. Pure Wayland with no XWayland is degraded —
+> idle/AFK detection won't work because the underlying API needs X.
+
+---
+
+## Quick install
+
+### Arch / Manjaro (recommended for Arch users)
+
+```bash
+yay -S flowshield-bin
+# or: paru -S flowshield-bin
+```
+
+That's it. Future updates flow through `yay -Syu` like any other AUR
+package — no manual re-downloads.
+
+### Fedora / RHEL / openSUSE
+
+```bash
+cd ~/Downloads
+gh release download v3.3.0-alpha.0 --repo asifthewebguy/FlowShield \
+  --pattern '*.rpm' --pattern '*.rpm.asc' \
+  --pattern 'SHA256SUMS' --pattern 'SHA256SUMS.asc'
+sudo dnf install ./FlowShield-3.3.0-alpha.0-1.x86_64.rpm
+```
+
+If you don't have the GitHub CLI installed, just download the `.rpm`
+straight from <https://github.com/asifthewebguy/FlowShield/releases/latest>.
+
+### Debian / Ubuntu / Pop!_OS / Mint
+
+```bash
+cd ~/Downloads
+gh release download v3.3.0-alpha.0 --repo asifthewebguy/FlowShield \
+  --pattern '*_amd64.deb' --pattern '*_amd64.deb.asc' \
+  --pattern 'SHA256SUMS' --pattern 'SHA256SUMS.asc'
+sudo apt install ./FlowShield_3.3.0-alpha.0_amd64.deb
+```
+
+### AppImage (any distro, no install)
+
+```bash
+cd ~/Downloads
+gh release download v3.3.0-alpha.0 --repo asifthewebguy/FlowShield \
+  --pattern '*.AppImage' --pattern '*.AppImage.asc' \
+  --pattern 'SHA256SUMS' --pattern 'SHA256SUMS.asc'
+chmod +x FlowShield_3.3.0-alpha.0_amd64.AppImage
+./FlowShield_3.3.0-alpha.0_amd64.AppImage
+```
+
+To get a desktop entry (so FlowShield shows up in your app menu), drop the
+AppImage into `~/Apps/` and use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)
+or run `--appimage-integrate` once.
+
+---
+
+## Verify integrity *(optional but recommended)*
+
+We GPG-sign every release. Verify before installing:
+
+```bash
+cd ~/Downloads
+
+# 1. Confirm SHA256SUMS is signed by us
+gpg --verify SHA256SUMS.asc
+#  → Good signature from "FlowShield <noreply@flowshield.app>"
+
+# 2. Confirm your downloaded file matches the published checksum
+sha256sum -c SHA256SUMS --ignore-missing
+#  → FlowShield_3.3.0-alpha.0_amd64.AppImage: OK
+```
+
+You can also verify a single package directly:
+
+```bash
+gpg --verify FlowShield-3.3.0-alpha.0-1.x86_64.rpm.asc \
+            FlowShield-3.3.0-alpha.0-1.x86_64.rpm
+```
+
+---
+
+## After install
+
+You'll find FlowShield in:
+
+- **System tray** — an icon next to your clock (uses `AppIndicator` /
+  `StatusNotifier`). On GNOME Wayland you may need the
+  [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/)
+  extension; KDE/XFCE/Cinnamon work out of the box.
+- **App menu** — searchable as "FlowShield"
+- **CLI** — the binary is installed at `/usr/bin/flowshield-desktop`
+- **Autostart** — FlowShield enables auto-start on first launch via a
+  `.desktop` file in `~/.config/autostart/`. Delete that file if you
+  don't want it.
+
+### Permissions you may be prompted for
+
+| Prompt | When | Why |
+|---|---|---|
+| **Notification permission** | First launch | Session-end + break reminders |
+| **Polkit (`pkexec`)** — admin password | First Deep Work toggle | Edit `/etc/hosts` to block distraction sites |
+
+Activity tracking (foreground-window queries) is unprivileged on X11 and
+on XWayland — no permission prompt needed.
+
+---
+
+## Updating
+
+### AUR users
+Updates flow through your normal `yay -Syu` — there's nothing to do
+manually. The `publish-to-aur` CI job pushes a new `pkgver` to AUR within
+~10 minutes of every GitHub release.
+
+### Direct-download users (.rpm / .deb / .AppImage)
+The app polls GitHub Releases every 12 hours. When a newer `v3.*` release
+exists, you'll see a banner at the top of the dashboard with a **Download**
+button — click it, then re-run the install command for your distro:
+
+```bash
+# Fedora / RHEL
+sudo dnf upgrade ./FlowShield-X.Y.Z-1.x86_64.rpm
+
+# Debian / Ubuntu
+sudo apt install ./FlowShield_X.Y.Z_amd64.deb   # 'install' upgrades in place
+
+# AppImage
+chmod +x ./FlowShield_X.Y.Z_amd64.AppImage      # replace the old file
+```
+
+---
+
+## Uninstalling
+
+### AUR
+
+```bash
+sudo pacman -Rns flowshield-bin
+```
+
+### .rpm
+
+```bash
+sudo dnf remove flow-shield   # note: the package name uses a hyphen
+```
+
+### .deb
+
+```bash
+sudo apt remove flow-shield
+sudo apt purge flow-shield   # also removes user-system config
+```
+
+### AppImage
+
+Delete the AppImage file. To remove local data:
+
+```bash
+rm -rf ~/.local/share/app.flowshield.desktop
+rm -rf ~/.config/app.flowshield.desktop
+rm -f  ~/.config/autostart/FlowShield.desktop
+```
+
+---
+
+## Troubleshooting
+
+### Window is blank / flickers on Wayland
+
+We disable WebKitGTK's DMA-BUF renderer at startup specifically because
+of this (see [PR #55](https://github.com/asifthewebguy/FlowShield/pull/55)).
+If you still see flicker on a recent kernel + Mesa, set the env var
+manually:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 flowshield-desktop
+```
+
+If it works with that, file an issue with your distro + Mesa version.
+
+### Tray icon doesn't appear (GNOME Wayland)
+
+GNOME removed legacy tray support. Install the
+[AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/)
+extension and re-launch FlowShield.
+
+### Close button stops working after the second click
+
+Fixed in v3.2.1 — on Linux, FlowShield minimizes the window instead of
+fully hiding it on close (libdecor's CSD bindings break on hide/show
+cycles). If you're still seeing it, you're on an older build — upgrade.
+
+### Activity tracker is silent
+
+Most likely you're on **pure Wayland** with no XWayland. The
+`active-win-pos-rs` crate we use for foreground-window queries currently
+has no Wayland-native backend. Workarounds:
+- Switch to an Xorg session at login
+- Use a desktop environment that defaults to XWayland (most do)
+
+### `pkexec` prompt never appears for Deep Work
+
+Confirm `polkit` is installed and your user is in the `wheel` (Fedora) or
+`sudo` (Debian/Ubuntu) group. On minimal installs:
+
+```bash
+# Fedora
+sudo dnf install polkit polkit-gnome   # gnome-authentication-agent
+
+# Debian/Ubuntu
+sudo apt install policykit-1 policykit-1-gnome
+```
+
+Then log out + in.
+
+### "No public key" when verifying GPG
+
+You haven't imported our public key yet. Grab it from the project's GitHub
+profile or pull from a keyserver:
+
+```bash
+gpg --keyserver keyserver.ubuntu.com --recv-keys F015C2B094B233F5
+```
+
+(Replace the key id with whatever's listed on the project's
+[Releases page](https://github.com/asifthewebguy/FlowShield/releases) under
+"Verifying releases.")
+
+---
+
+## Building from source
+
+If you'd rather compile yourself:
+
+```bash
+# System dependencies (Fedora)
+sudo dnf install webkit2gtk4.1-devel libappindicator-gtk3-devel \
+                 librsvg2-devel openssl-devel libXScrnSaver-devel \
+                 patchelf file rust nodejs
+
+# System dependencies (Debian/Ubuntu)
+sudo apt install libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+                 librsvg2-dev libssl-dev libxss-dev patchelf file \
+                 rustc cargo nodejs npm
+
+# Build
+git clone https://github.com/asifthewebguy/FlowShield.git
+cd FlowShield/desktop-app-v3
+npm install
+npm run tauri:build
+# Output: src-tauri/target/release/bundle/{deb,rpm,appimage}/
+```
+
+For dev mode with hot reload: `npm run tauri:dev`.
+
+---
+
+## Help / feedback
+
+- File a bug or feature request: <https://github.com/asifthewebguy/FlowShield/issues>
+- Source: <https://github.com/asifthewebguy/FlowShield>
+- Web dashboard: <https://flowshield.app>
+- AUR package page: <https://aur.archlinux.org/packages/flowshield-bin>

--- a/desktop-app-v3/INSTALL_MACOS.md
+++ b/desktop-app-v3/INSTALL_MACOS.md
@@ -1,0 +1,209 @@
+# Installing FlowShield on macOS
+
+FlowShield Desktop v3 ships as a **universal `.dmg`** that runs natively on
+Intel and Apple Silicon Macs. It's currently an unsigned/unnotarized alpha,
+so the first launch needs a one-time Gatekeeper bypass — about 30 seconds
+of clicks.
+
+> **macOS version:** 12 (Monterey) or newer recommended.
+> **Both architectures supported** by the same file: Intel (x86_64) and Apple Silicon (arm64).
+
+---
+
+## TL;DR
+
+```bash
+# 1. Download the latest .dmg from GitHub Releases
+open "https://github.com/asifthewebguy/FlowShield/releases/latest"
+
+# 2. Mount + drag FlowShield.app to /Applications
+
+# 3. Strip the quarantine attribute so Gatekeeper trusts it
+xattr -d com.apple.quarantine /Applications/FlowShield.app
+
+# 4. Launch
+open /Applications/FlowShield.app
+```
+
+---
+
+## Step-by-step
+
+### 1. Download
+
+Visit <https://github.com/asifthewebguy/FlowShield/releases/latest> and grab:
+
+- `FlowShield_X.Y.Z_universal.dmg` — the installer (~80 MB)
+- *(Optional)* `SHA256SUMS` and `SHA256SUMS.asc` — for integrity verification
+
+You can also click the **macOS** pill on the [flowshield.app](https://flowshield.app)
+homepage, which links to the same Releases page.
+
+### 2. Verify integrity *(optional but recommended)*
+
+```bash
+cd ~/Downloads
+
+# Confirm the SHA256SUMS file was signed by us (key fingerprint should match
+# the one published on the project's GitHub profile / README)
+gpg --verify SHA256SUMS.asc
+
+# Confirm the .dmg matches the published checksum
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+If `gpg --verify` says **"Good signature"** and `shasum -c` says **"OK"**,
+you have an authentic copy.
+
+### 3. Install
+
+```bash
+open ~/Downloads/FlowShield_*_universal.dmg
+```
+
+The DMG window opens. Drag **FlowShield.app** to your `/Applications`
+folder, then close + eject the DMG.
+
+### 4. First launch (Gatekeeper bypass)
+
+FlowShield isn't notarized yet (we're working on it — see [Why isn't it
+notarized?](#why-isnt-it-notarized) below). macOS will block the first
+launch by default. Pick one of these two paths:
+
+#### Path A — Terminal (one command, fastest)
+
+```bash
+xattr -d com.apple.quarantine /Applications/FlowShield.app
+open /Applications/FlowShield.app
+```
+
+That's it. The app launches normally and stays trusted on every future
+launch.
+
+#### Path B — System Settings (click-only)
+
+1. Open **Finder → Applications**, **right-click** (or Control-click)
+   `FlowShield.app` → **Open**.
+2. macOS shows *"Apple could not verify FlowShield is free of malware"*
+   with no Open button (this is normal for macOS 15 Sequoia and newer).
+   Click **Done**.
+3. Open **System Settings → Privacy & Security**, scroll down to the
+   **Security** section. You'll see a banner:
+   > "FlowShield" was blocked to protect your Mac.
+4. Click **Open Anyway**, confirm with Touch ID or your password.
+5. The app launches and is trusted from now on.
+
+---
+
+## After install
+
+You'll find FlowShield in:
+
+- **Menu bar:** an icon at the top-right (an `NSStatusItem`). During an
+  active focus session, the icon morphs into a progress ring + countdown.
+- **Applications folder:** `/Applications/FlowShield.app`
+- **Login items:** FlowShield enables "Open at Login" on first launch so it
+  resumes after a reboot. Toggle it off in **System Settings → General →
+  Login Items** if you don't want this.
+
+### macOS permissions you'll be prompted for
+
+| Prompt | When | Why |
+|---|---|---|
+| **Notifications** | First launch | Session-end + break reminders |
+| **Accessibility** | First focus session | Read foreground app names for activity tracking |
+| **Administrator password** | First Deep Work toggle | Edit `/etc/hosts` to block distraction sites (via `osascript` elevation) |
+
+All three are optional — declining only disables the matching feature.
+
+---
+
+## Updating
+
+The app polls GitHub Releases every 12 hours. When a newer `v3.*` release
+exists, you'll see a banner at the top of the dashboard with a **Download**
+button — click it to open the new Release page in your browser, then
+repeat the install steps above with the new `.dmg`.
+
+You can also check manually: just download the latest `.dmg` from
+[Releases](https://github.com/asifthewebguy/FlowShield/releases/latest)
+and drag the new `FlowShield.app` over the existing one in `/Applications`.
+
+---
+
+## Uninstalling
+
+```bash
+# Quit FlowShield first (menu bar → Quit, or `pkill FlowShield`)
+rm -rf /Applications/FlowShield.app
+rm -rf ~/Library/Application\ Support/app.flowshield.desktop
+rm -rf ~/Library/Caches/app.flowshield.desktop
+rm -rf ~/Library/Preferences/app.flowshield.desktop.plist
+```
+
+The first line removes the app; the rest clean up local data (encrypted
+session cache, preferences, offline-sync queue).
+
+---
+
+## Troubleshooting
+
+### *"FlowShield is damaged and can't be opened"*
+
+This means the quarantine attribute is set but the bypass hasn't been
+applied yet. Run:
+
+```bash
+xattr -d com.apple.quarantine /Applications/FlowShield.app
+```
+
+If that fails with "No such xattr", try:
+
+```bash
+xattr -cr /Applications/FlowShield.app   # clears all extended attributes
+```
+
+### Menu-bar icon doesn't appear
+
+macOS sometimes hides menu-bar items when there isn't enough horizontal
+space. Try:
+
+- Quit some other menu-bar app temporarily to free space, OR
+- Use [Bartender](https://www.macbartender.com/) / [Hidden Bar](https://github.com/dwarvesf/hidden) to manage menu-bar overflow.
+
+### Activity tracker isn't recording
+
+Open **System Settings → Privacy & Security → Accessibility** and confirm
+**FlowShield** is enabled. Without this permission the tracker can't read
+foreground app names.
+
+### Deep Work mode does nothing
+
+Open **System Settings → Privacy & Security → Full Disk Access** and add
+**FlowShield**. Editing `/etc/hosts` requires it on macOS 13+.
+
+If the elevation prompt never appears at all, try toggling Deep Work off
+then on again — `osascript` occasionally fails to bring its prompt to the
+foreground on the first try.
+
+---
+
+## Why isn't it notarized?
+
+Apple notarization requires an **Apple Developer Program** membership
+(US$99/year). FlowShield is open-source and self-funded; we're rolling out
+a notarized build once the v3 alpha stabilizes and we can justify the
+recurring cost.
+
+Until then, the one-time `xattr -d com.apple.quarantine` bypass is
+equivalent in safety to opening any unsigned binary you trust the source
+of — the SHA256 + GPG verification steps above let you confirm the binary
+came from us.
+
+---
+
+## Help / feedback
+
+- File a bug or feature request: <https://github.com/asifthewebguy/FlowShield/issues>
+- Source: <https://github.com/asifthewebguy/FlowShield>
+- Web dashboard: <https://flowshield.app>


### PR DESCRIPTION
## Summary

Adds two end-user install guides for the v3 cross-platform desktop client and links them from the project README.

## New files

- **[`desktop-app-v3/INSTALL_MACOS.md`](desktop-app-v3/INSTALL_MACOS.md)** — Gatekeeper bypass (Terminal + GUI paths), GPG/SHA256 verification, post-install permissions (Notifications / Accessibility / Admin for Deep Work), updating, uninstalling, troubleshooting, and a note on why notarization is deferred.
- **[`desktop-app-v3/INSTALL_LINUX.md`](desktop-app-v3/INSTALL_LINUX.md)** — Format-selection table, per-distro quick install (Arch / Fedora / Debian / Ubuntu / AppImage), GPG verification, post-install (tray on GNOME Wayland, autostart, polkit for Deep Work), per-format upgrade + uninstall, troubleshooting (WebKitGTK Wayland flicker, missing GNOME tray, libdecor close-button, pure-Wayland tracker silence, polkit missing, GPG key import), and build-from-source.

## README links

\`README.md\` now links both files from two complementary locations:

1. **Platforms → Desktop v3 cross-platform alpha** — section intro + per-OS bullets each link the matching \`INSTALL_*.md\`.
2. **Quick Start → Desktop v3 (Tauri, cross-platform)** — bold callout above the command block pointing to both files.

## Test plan

- [ ] CI green (no code changed)
- [ ] On GitHub, the README renders with working links to both INSTALL_*.md files
- [ ] Each INSTALL_*.md renders cleanly (tables, code blocks, headings) on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)