### PR TITLE
fix(desktop-v3): use dedicated HTTP client for model download

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/model_download.rs
+++ b/desktop-app-v3/src-tauri/src/ai/model_download.rs
@@ -251,6 +251,21 @@ pub fn models_dir(handle: &AppHandle) -> Result<PathBuf, AiError> {
     Ok(dir)
 }
 
+/// HTTP client purpose-built for large model downloads. The shared app client
+/// (`AppState::http`) carries a 20s *total* request timeout — correct for JSON
+/// API calls, fatal for a multi-GB GGUF that legitimately streams for minutes.
+/// This client sets NO total timeout. Stalls are still bounded: `read_timeout`
+/// aborts when the stream delivers no bytes for 60s, and `connect_timeout`
+/// fails fast when HuggingFace is unreachable.
+pub fn download_client() -> Result<reqwest::Client, AiError> {
+    reqwest::Client::builder()
+        .user_agent(concat!("FlowShield-Desktop/", env!("CARGO_PKG_VERSION"), " (rust)"))
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .read_timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| AiError::ModelDownload(format!("build download client: {e}")))
+}
+
 /// Download every file in the registry into `app_data_dir/models/`. Updates
 /// `ai_model_state.status` from Downloading → Ready (or → Error). Emits
 /// `ai-model-progress` per chunk and `ai-model-status-changed` on transition.
@@ -526,5 +541,50 @@ mod tests {
 
         let final_bytes = tokio::fs::read(&target).await.unwrap();
         assert_eq!(final_bytes, full);
+    }
+
+    #[tokio::test]
+    async fn download_client_tolerates_slow_body() {
+        // Regression: the model download once reused the shared app client,
+        // whose 20s *total* request timeout aborted multi-GB downloads.
+        // `download_client()` must carry no short total timeout. A 100ms-total
+        // client fails on a 300ms-delayed body; download_client() streams it.
+        use std::time::Duration;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/m"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(b"hello world".to_vec())
+                    .set_delay(Duration::from_millis(300)),
+            )
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/m", server.uri());
+
+        // Sanity: a tiny total-timeout client (like the old shared client)
+        // DOES abort on this slow body.
+        let strict = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        assert!(
+            strict.get(&url).send().await.is_err(),
+            "100ms total-timeout client should abort on a 300ms-delayed body"
+        );
+
+        // The download client tolerates the slow body and reads it fully.
+        let dl = download_client().unwrap();
+        let resp = dl
+            .get(&url)
+            .send()
+            .await
+            .expect("download client must not time out on a slow body");
+        let body = resp.bytes().await.unwrap();
+        assert_eq!(&body[..], b"hello world");
     }
 }

--- a/desktop-app-v3/src-tauri/src/commands/ai.rs
+++ b/desktop-app-v3/src-tauri/src/commands/ai.rs
@@ -38,7 +38,9 @@ pub async fn ai_model_download_start(
         .get()
         .cloned()
         .ok_or_else(|| AppError::Storage("local DB not initialized".into()))?;
-    let http = state.http.clone();
+    // Use a download-specific client: the shared `state.http` carries a 20s
+    // total-request timeout that would abort a multi-GB model download.
+    let http = model_download::download_client()?;
     let handle_for_task = handle.clone();
 
     tauri::async_runtime::spawn(async move {

--- a/desktop-app-v3/src/lib/ai.ts
+++ b/desktop-app-v3/src/lib/ai.ts
@@ -19,9 +19,15 @@ export interface AiSettings {
   indexed_chunk_count: number;
 }
 
+export interface DownloadProgress {
+  downloaded: number;
+  total: number;
+}
+
 interface AiStore {
   briefing: BriefingState;
   settings: AiSettings | null;
+  downloadProgress: DownloadProgress | null;
   refreshBriefing: () => Promise<void>;
   refreshSettings: () => Promise<void>;
   setLabsEnabled: (enabled: boolean) => Promise<void>;
@@ -31,6 +37,7 @@ interface AiStore {
 export const useAIStore = create<AiStore>((set, get) => ({
   briefing: { status: 'hidden' },
   settings: null,
+  downloadProgress: null,
 
   refreshBriefing: async () => {
     try {
@@ -70,10 +77,32 @@ export const useAIStore = create<AiStore>((set, get) => ({
       set({ briefing: { status: 'error', message: String(evt.payload) } });
     });
 
+    // Live model-download feedback. Backend emits `ai-model-progress` per
+    // ~1MB chunk and `ai-model-status-changed` on every status transition.
+    const unModelProgress = await listen<{
+      overall_bytes_downloaded: number;
+      overall_bytes_total: number;
+    }>('ai-model-progress', (evt) => {
+      set({
+        downloadProgress: {
+          downloaded: evt.payload.overall_bytes_downloaded,
+          total: evt.payload.overall_bytes_total,
+        },
+      });
+    });
+    const unModelStatus = await listen<string>('ai-model-status-changed', async (evt) => {
+      await get().refreshSettings();
+      if (evt.payload !== 'downloading') {
+        set({ downloadProgress: null });
+      }
+    });
+
     return () => {
       unReady();
       unGenerating();
       unError();
+      unModelProgress();
+      unModelStatus();
     };
   },
 }));

--- a/desktop-app-v3/src/routes/SettingsAiPage.tsx
+++ b/desktop-app-v3/src/routes/SettingsAiPage.tsx
@@ -13,6 +13,7 @@ import { Button } from '../components/Button';
 export function SettingsAiPage() {
   const navigate = useNavigate();
   const settings = useAIStore((s) => s.settings);
+  const downloadProgress = useAIStore((s) => s.downloadProgress);
   const refreshSettings = useAIStore((s) => s.refreshSettings);
   const setLabsEnabled = useAIStore((s) => s.setLabsEnabled);
 
@@ -88,6 +89,20 @@ export function SettingsAiPage() {
         <div>Status: <span className="font-mono">{settings.status}</span></div>
         <div>Disk usage: {diskMB} MB</div>
         <div>Indexed chunks: {settings.indexed_chunk_count}</div>
+        {settings.status === 'downloading' && downloadProgress && downloadProgress.total > 0 && (
+          <div className="space-y-1 pt-1">
+            <div className="h-2 w-full overflow-hidden rounded bg-gray-200">
+              <div
+                className="h-full bg-primary-500 transition-all"
+                style={{ width: `${Math.min(100, (downloadProgress.downloaded / downloadProgress.total) * 100)}%` }}
+              />
+            </div>
+            <div className="font-mono text-xs text-gray-500">
+              {(downloadProgress.downloaded / (1024 * 1024)).toFixed(0)} /{' '}
+              {(downloadProgress.total / (1024 * 1024)).toFixed(0)} MB
+            </div>
+          </div>
+        )}
       </section>
 
       <section className="space-y-2">


### PR DESCRIPTION
## Problem

Enabling Local AI and clicking **Re-download** did nothing visible — status stuck, then silently failed. Root cause: the model download reused the shared app `reqwest::Client`, which carries a **20s total-request timeout**. That deadline is correct for JSON API calls but fatal for the 2.4 GB Phi-3 GGUF — every download aborted with a timeout, flipping status to `Error`, while the non-polling settings page still displayed `downloading`.

## Fix

**Backend**
- New `download_client()` in `model_download.rs` — **no total timeout**, but `connect_timeout(30s)` (fail fast if HuggingFace unreachable) + `read_timeout(60s)` (abort on a stalled stream, not on total duration).
- `ai_model_download_start` builds this client instead of cloning `state.http`. Shared client keeps its 20s timeout for API calls.

**Frontend**
- AI store listens to `ai-model-progress` and `ai-model-status-changed` (already emitted by backend) and tracks `downloadProgress`.
- Settings page shows a live progress bar + MB counter while downloading and refreshes status/disk on transitions — no more silent "nothing happens".

## Tests

- Regression test `download_client_tolerates_slow_body`: a 100ms total-timeout client aborts a 300ms-delayed body; `download_client()` streams it fully. (`cargo test ai::model_download` — 11 pass.)
- `tsc --noEmit` clean.

## Manual verification

Ran `tauri dev`, clicked Re-download → full bundle downloaded, **Status: ready, Disk usage: 2412.2 MB**. Confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)