### PR TITLE
chore(desktop-v3): remove unused LLM_ID import in briefing.rs

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/briefing.rs
+++ b/desktop-app-v3/src-tauri/src/ai/briefing.rs
@@ -21,7 +21,6 @@ use crate::ai::candle_embedder::CandleEmbedder;
 use crate::ai::candle_llm::CandleLlmRuntime;
 use crate::ai::embedder::Embedder;
 use crate::ai::prompts::{render_briefing_prompt, BriefingContext};
-use crate::ai::registry::LLM_ID;
 use crate::ai::retriever::top_k_by_cosine;
 use crate::ai::runtime::LlmRuntime;
 use crate::error::AppError;


### PR DESCRIPTION
Removes the dead `use crate::ai::registry::LLM_ID;` import in `briefing.rs`, flagged by the release build's `unused_imports` warning. No behavior change — `cargo build --lib` clean, warning gone.

Other pre-existing warnings (scaffolding for upcoming AI phases, `shell().open` deprecation) intentionally left for their owning work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)