### PR TITLE
chore(desktop-v3): clear 4 dead-code warnings

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/candle_embedder.rs
+++ b/desktop-app-v3/src-tauri/src/ai/candle_embedder.rs
@@ -19,7 +19,6 @@ use candle_transformers::models::bert::{BertModel, Config, DTYPE};
 use tokenizers::Tokenizer;
 
 use crate::ai::embedder::{Embedder, EMBEDDING_DIM};
-use crate::ai::registry::EMBEDDER_ID;
 use crate::error::AiError;
 
 /// Filenames inside the model directory. Match the layout the Plan 1.2
@@ -200,10 +199,6 @@ impl Embedder for CandleEmbedder {
         // tracker poll loop, etc).
         tokio::task::block_in_place(|| self.embed_sync(text))
     }
-
-    fn embedder_id(&self) -> &str {
-        EMBEDDER_ID
-    }
 }
 
 #[cfg(test)]
@@ -211,16 +206,6 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    /// embedder_id must match registry constant — Plan 1.5 keys cache lookups
-    /// off this string and a drift would silently invalidate every chunk's
-    /// embedding when re-loaded.
-    #[test]
-    fn embedder_id_matches_registry() {
-        // We can't construct CandleEmbedder without weights, but the
-        // associated constant is reachable.
-        assert_eq!(EMBEDDER_ID, "bge-small-en-v1.5");
-    }
 
     /// `load` must surface a typed `AiError::ModelLoad` (not panic) when the
     /// model directory is missing files. Plan 1.5's settings page renders

--- a/desktop-app-v3/src-tauri/src/ai/embedder.rs
+++ b/desktop-app-v3/src-tauri/src/ai/embedder.rs
@@ -18,35 +18,21 @@ pub trait Embedder: Send + Sync {
     /// produces a different dimensionality (which would be a configuration
     /// bug, not a runtime error).
     async fn embed(&self, text: &str) -> Result<Vec<f32>, AiError>;
-
-    /// Batch variant — implementations are encouraged to fuse forward passes.
-    /// Default impl just calls `embed` in a loop, but real implementations
-    /// override for ~10x throughput on large batches.
-    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AiError> {
-        let mut out = Vec::with_capacity(texts.len());
-        for t in texts {
-            out.push(self.embed(t).await?);
-        }
-        Ok(out)
-    }
-
-    /// Identifier baked into `ai_chunks.embedded_at` semantics. When this
-    /// changes (rare — a real embedder swap), every chunk needs re-indexing.
-    fn embedder_id(&self) -> &str;
 }
 
 /// Deterministic mock — hashes input text into a 384-dim unit vector. Used
 /// by every substrate test that needs an embedder without loading BGE-small.
-pub struct MockEmbedder {
-    pub id: &'static str,
-}
+#[cfg(test)]
+pub struct MockEmbedder;
 
+#[cfg(test)]
 impl Default for MockEmbedder {
     fn default() -> Self {
-        Self { id: "mock-embedder-v0" }
+        MockEmbedder
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl Embedder for MockEmbedder {
     async fn embed(&self, text: &str) -> Result<Vec<f32>, AiError> {
@@ -63,9 +49,6 @@ impl Embedder for MockEmbedder {
             *x /= norm;
         }
         Ok(v)
-    }
-    fn embedder_id(&self) -> &str {
-        self.id
     }
 }
 
@@ -96,13 +79,5 @@ mod tests {
         let a = m.embed("apple").await.unwrap();
         let b = m.embed("zebra").await.unwrap();
         assert_ne!(a, b);
-    }
-
-    #[tokio::test]
-    async fn batch_default_works() {
-        let m = MockEmbedder::default();
-        let out = m.embed_batch(&["a".into(), "b".into()]).await.unwrap();
-        assert_eq!(out.len(), 2);
-        assert_eq!(out[0].len(), EMBEDDING_DIM);
     }
 }

--- a/desktop-app-v3/src-tauri/src/ai/runtime.rs
+++ b/desktop-app-v3/src-tauri/src/ai/runtime.rs
@@ -21,11 +21,13 @@ pub trait LlmRuntime: Send + Sync {
 
 /// In-memory mock returning canned strings. Used by every substrate test
 /// that exercises orchestration without the real model.
+#[cfg(test)]
 pub struct MockLlmRuntime {
     pub canned_response: String,
     pub id: &'static str,
 }
 
+#[cfg(test)]
 impl Default for MockLlmRuntime {
     fn default() -> Self {
         Self {
@@ -35,6 +37,7 @@ impl Default for MockLlmRuntime {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl LlmRuntime for MockLlmRuntime {
     async fn generate(&self, _prompt: &str, _max_tokens: usize) -> Result<String, AiError> {

--- a/desktop-app-v3/src-tauri/src/commands/ai.rs
+++ b/desktop-app-v3/src-tauri/src/commands/ai.rs
@@ -103,7 +103,6 @@ pub enum BriefingState {
     Generating,
     EmptyState,
     Hidden,
-    Error { message: String },
 }
 
 #[tauri::command]


### PR DESCRIPTION
Clears 4 of the 5 release-build warnings (down from 22 before the corpus work).

- **Gate test mocks** — `MockEmbedder` + `MockLlmRuntime` behind `#[cfg(test)]`. They're used only by tests, so release builds flagged them "never constructed."
- **Remove dead `Embedder` trait surface** — `embed_batch` (unused default method) and `embedder_id` (no production caller; cache-key wiring never happened). Drops the now-orphaned `CandleEmbedder`/`MockEmbedder` impls, the two tests that exercised them, and the orphaned `EMBEDDER_ID` import.
- **Remove `BriefingState::Error`** — never constructed; briefing errors flow via the `ai-briefing-error` event, and the frontend's `error` state is driven by that event, not this command's return.

`model_id` (LlmRuntime) is kept — it's production-used by `CandleLlmRuntime`.

**Deferred:** the `tray.rs:84` `shell().open` deprecation — it needs the `tauri-plugin-opener` dependency + plugin init, so it gets its own PR.

## Tests

`cargo test --lib` → **117 passing, 0 failed** (down 2 from removing the obsolete `batch_default_works` + `embedder_id_matches_registry` tests). Release `cargo build` now emits only the single deferred deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)