### PR TITLE
chore(desktop-v3): migrate tauri-plugin-shell to tauri-plugin-opener

### DIFF
--- a/desktop-app-v3/package.json
+++ b/desktop-app-v3/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-notification": "^2.0.0",
-    "@tauri-apps/plugin-shell": "^2.0.1",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "@tauri-apps/plugin-store": "^2.1.0",
     "pusher-js": "^8.5.0",
     "react": "^19.0.0",

--- a/desktop-app-v3/src-tauri/Cargo.toml
+++ b/desktop-app-v3/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri              = { version = "2", features = ["tray-icon"] }
 tauri-plugin-store = "2"
-tauri-plugin-shell = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"
 

--- a/desktop-app-v3/src-tauri/capabilities/default.json
+++ b/desktop-app-v3/src-tauri/capabilities/default.json
@@ -8,7 +8,7 @@
     "core:window:allow-close",
     "core:window:allow-minimize",
     "store:default",
-    "shell:allow-open",
+    "opener:allow-open-url",
     "notification:default",
     "autostart:default"
   ]

--- a/desktop-app-v3/src-tauri/src/lib.rs
+++ b/desktop-app-v3/src-tauri/src/lib.rs
@@ -135,7 +135,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
-        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,

--- a/desktop-app-v3/src-tauri/src/tray.rs
+++ b/desktop-app-v3/src-tauri/src/tray.rs
@@ -22,7 +22,7 @@ use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconEvent;
 use tauri::{App, AppHandle, Manager};
-use tauri_plugin_shell::ShellExt;
+use tauri_plugin_opener::OpenerExt;
 
 const TRAY_ID: &str = "main";
 const SHOW_ID: &str = "show";
@@ -81,7 +81,7 @@ fn open_update_url(app: &AppHandle) {
         tracing::warn!("update menu clicked but no UpdateInfo cached — ignoring");
         return;
     };
-    if let Err(e) = app.shell().open(&url, None) {
+    if let Err(e) = app.opener().open_url(&url, None::<&str>) {
         tracing::warn!(error = %e, %url, "failed to open update URL");
     }
 }

--- a/desktop-app-v3/src/components/UpdateBanner.tsx
+++ b/desktop-app-v3/src/components/UpdateBanner.tsx
@@ -1,4 +1,4 @@
-import { open } from '@tauri-apps/plugin-shell';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from './Button';
 import { useUpdateStore, selectShowBanner } from '../lib/update';
 
@@ -22,7 +22,7 @@ export function UpdateBanner() {
 
   const handleDownload = async () => {
     try {
-      await open(info.release_url);
+      await openUrl(info.release_url);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn('[update] open url failed', err);


### PR DESCRIPTION
Clears the **last** build warning (`tauri_plugin_shell::Shell::open` is deprecated). Warnings now **zero** (down from 22 at the start of this work).

`tauri-plugin-shell` was used in two places to open the release URL in the default browser — the tray "update available" handler (Rust) and the UpdateBanner download button (frontend). Both migrated to `tauri-plugin-opener`:

- **Rust** — swap dependency + `tauri_plugin_opener::init()`; `tray.rs` uses `app.opener().open_url(&url, None::<&str>)`.
- **Frontend** — swap the JS dep; `UpdateBanner.tsx` uses `openUrl` from `@tauri-apps/plugin-opener`.
- **Capability** — `shell:allow-open` → `opener:allow-open-url`. The frontend `openUrl` goes through IPC, so this permission is required (the Rust-side call doesn't need it, but the JS one does).

## Verification

- `cargo build --release --lib` → **zero warnings** (was 1 after the prior dead-code cleanup).
- `cargo test --lib` → **117 passing, 0 failed**.
- `tsc --noEmit` → clean.
- `tauri-plugin-opener` v2.5.4 resolves; the `opener:allow-open-url` capability validates against the plugin ACL at build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)