### PR TITLE
fix(desktop-v3): LLM load doubled the model subdir in the path

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/candle_llm.rs
+++ b/desktop-app-v3/src-tauri/src/ai/candle_llm.rs
@@ -31,8 +31,8 @@ use crate::error::AiError;
 
 /// Filenames inside the model directory. Match the layout the Plan 1.2
 /// downloader writes to disk via `LLM_FILES` `local_filename` entries.
-const GGUF_FILE: &str = "phi-3-mini-4k-instruct/Phi-3-mini-4k-instruct-q4.gguf";
-const TOKENIZER_FILE: &str = "phi-3-mini-4k-instruct/tokenizer.json";
+const GGUF_FILE: &str = "Phi-3-mini-4k-instruct-q4.gguf";
+const TOKENIZER_FILE: &str = "tokenizer.json";
 
 /// Sampling temperature. 0.0 = greedy; we use a low non-zero temp for slight
 /// variation across days while staying mostly deterministic for the same
@@ -228,6 +228,18 @@ mod tests {
     #[test]
     fn model_id_matches_registry() {
         assert_eq!(LLM_ID, "phi-3-mini-4k-instruct-q4");
+    }
+
+    #[test]
+    fn model_filenames_are_bare_not_subdir_prefixed() {
+        // Callers pass the model subdir (e.g. `model_dir.join("phi-3-mini-4k-instruct")`),
+        // and `load` joins these constants onto it. They must be bare filenames —
+        // a subdir prefix here doubles the path (…/phi-3-mini-4k-instruct/phi-3-mini-4k-instruct/…).
+        assert!(!GGUF_FILE.contains('/'), "GGUF_FILE must be a bare filename: {GGUF_FILE}");
+        assert!(
+            !TOKENIZER_FILE.contains('/'),
+            "TOKENIZER_FILE must be a bare filename: {TOKENIZER_FILE}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Once enough session chunks accrued (≥5) and the briefing first fired, it failed with:

> ai: model not loaded: open …/models/phi-3-mini-4k-instruct/**phi-3-mini-4k-instruct**/Phi-3-mini-4k-instruct-q4.gguf: No such file or directory (os error 2)

The model subdir `phi-3-mini-4k-instruct/` appears **twice**.

## Root cause

`candle_llm.rs` embedded the subdir in its load constants:

```rust
const GGUF_FILE = "phi-3-mini-4k-instruct/Phi-3-mini-4k-instruct-q4.gguf";
const TOKENIZER_FILE = "phi-3-mini-4k-instruct/tokenizer.json";
```

But callers (`briefing.rs`, `reflection.rs`) already pass `model_dir.join("phi-3-mini-4k-instruct")` into `CandleLlmRuntime::load`, which then does `model_dir.join(GGUF_FILE)` → the subdir doubles. The downloaded file is one level deep (`models/phi-3-mini-4k-instruct/Phi-3…gguf`, confirmed on disk), so the load misses.

The **embedder** loader does this correctly — its constants are bare filenames (`"model.safetensors"`) and the caller adds the `bge-small-en-v1.5/` subdir. The LLM constants wrongly copied the registry's `local_filename` (which carries the subdir for the *downloader*) into the *loader*.

Latent since Phase 1.4 — only surfaced now because the briefing first generates at ≥5 session chunks. The real-load test is weights-gated (skipped without the model), so nothing exercised the path join.

## Fix

Make the LLM constants bare filenames, matching the embedder:

```rust
const GGUF_FILE = "Phi-3-mini-4k-instruct-q4.gguf";
const TOKENIZER_FILE = "tokenizer.json";
```

Adds a guard test (`model_filenames_are_bare_not_subdir_prefixed`) asserting neither constant contains `/` — fails on the old code, passes on the fix.

## Tests

`cargo test --lib` → **129 passing, 0 failed**; zero warnings. RED→GREEN on the new guard test confirmed. The loader now targets the exact on-disk path.

**Not yet verified:** actual briefing generation (LLM inference) end-to-end — needs the running app with the model present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)