### PR TITLE
fix(desktop-v3): security hardening (model verify fail-closed, https-only update URL, env gitignore)

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/model_download.rs
+++ b/desktop-app-v3/src-tauri/src/ai/model_download.rs
@@ -102,14 +102,15 @@ pub async fn sha256_file(path: &Path) -> Result<String, AiError> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-/// Verify a downloaded file against an expected hash. Empty-string `expected`
-/// is treated as "skip verification" — used during Plans 1.3/1.4 development
-/// when real hashes haven't been published yet. Production callers should
-/// refuse to mark a file usable when the registry hash is empty.
+/// Verify a downloaded file against an expected hash. Fails closed: an empty
+/// `expected` is rejected rather than skipped, so a missing registry hash can
+/// never let an unverified (potentially tampered) model file be used. Every
+/// `registry` entry carries a real hash — see `all_registry_files_have_sha256`.
 pub async fn verify_sha256(path: &Path, expected: &str) -> Result<(), AiError> {
     if expected.is_empty() {
-        tracing::warn!(?path, "sha256 verify skipped: empty expected hash (placeholder)");
-        return Ok(());
+        return Err(AiError::ModelDownload(format!(
+            "refusing to use {path:?}: registry has no sha256 to verify against"
+        )));
     }
     let actual = sha256_file(path).await?;
     if actual.eq_ignore_ascii_case(expected) {
@@ -454,9 +455,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verify_sha256_skips_when_expected_empty() {
+    async fn verify_sha256_fails_closed_when_expected_empty() {
+        // Fail-closed: a missing registry hash must reject the file, not skip.
         let f = write_temp_file(b"hello world");
-        verify_sha256(f.path(), "").await.unwrap();
+        assert!(verify_sha256(f.path(), "").await.is_err());
     }
 
     #[tokio::test]

--- a/desktop-app-v3/src-tauri/src/ai/registry.rs
+++ b/desktop-app-v3/src-tauri/src/ai/registry.rs
@@ -107,4 +107,17 @@ mod tests {
         let unique: std::collections::HashSet<&&str> = names.iter().collect();
         assert_eq!(names.len(), unique.len(), "duplicate local_filename in registry");
     }
+
+    #[test]
+    fn all_registry_files_have_sha256() {
+        // verify_sha256 fails closed on an empty hash; this guards against
+        // shipping a registry entry that would be rejected at download time.
+        for f in all_files() {
+            assert!(
+                !f.sha256.is_empty(),
+                "missing sha256 for {}",
+                f.local_filename
+            );
+        }
+    }
 }

--- a/desktop-app-v3/src-tauri/src/tray.rs
+++ b/desktop-app-v3/src-tauri/src/tray.rs
@@ -81,6 +81,12 @@ fn open_update_url(app: &AppHandle) {
         tracing::warn!("update menu clicked but no UpdateInfo cached — ignoring");
         return;
     };
+    // Defense-in-depth: only ever hand an https URL to the OS opener, even
+    // though release_url comes from our own GitHub releases API over TLS.
+    if !url.starts_with("https://") {
+        tracing::warn!(%url, "refusing to open non-https update URL");
+        return;
+    }
     if let Err(e) = app.opener().open_url(&url, None::<&str>) {
         tracing::warn!(error = %e, %url, "failed to open update URL");
     }

--- a/desktop-app-v3/src/components/UpdateBanner.tsx
+++ b/desktop-app-v3/src/components/UpdateBanner.tsx
@@ -22,6 +22,12 @@ export function UpdateBanner() {
 
   const handleDownload = async () => {
     try {
+      // Defense-in-depth: only open https update URLs.
+      if (!info.release_url.startsWith('https://')) {
+        // eslint-disable-next-line no-console
+        console.warn('[update] refusing non-https url', info.release_url);
+        return;
+      }
       await openUrl(info.release_url);
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -17,6 +17,7 @@
 .DS_Store
 *.pem
 .env
+.env*.local
 .env.production
 
 next-env.d.ts


### PR DESCRIPTION
Three defense-in-depth items from a security review of the desktop-v3 AI work. **None are exploitable today** — all are fail-safe hardening.

## 1. Model download verification fails closed
`verify_sha256` previously *skipped* verification (warn + `Ok`) when the registry hash was empty. Every current registry entry has a real hash, so there was no live gap — but a future blank entry would silently use an **unverified (potentially tampered) model file**. Now it returns `Err` on empty, and a new `all_registry_files_have_sha256` guard test asserts every `LLM_FILES`/`EMBEDDER_FILES` entry carries a hash.

## 2. Update URL restricted to https
The "download update" action handed `release_url` straight to the OS opener (`tray.rs`, `UpdateBanner.tsx`). The source is our GitHub Releases API over TLS (trusted), but if that response were ever spoofed, a non-`https` scheme would reach the system opener. Both call sites now require `https://` first.

## 3. `web-app/.env.local` git-ignored
`web-app/.gitignore` ignored `.env`/`.env.production` but **not** `.env.local` (which holds DATABASE_URL etc.) — currently untracked but unprotected against an accidental `git add`. Added `.env*.local`.

## Review scope (clean)

The rest of the AI surface checked out: SQL is parameterized (no SQLi), LLM/user text renders via React (no `dangerouslySetInnerHTML` → XSS-safe), Tauri capabilities are minimal (`opener:allow-open-url` etc.), no hardcoded secrets, no sensitive data logged.

## Tests

`cargo test --lib` → **121 passing, 0 failed** (flipped the empty-hash test to assert `Err`; added the registry guard); `tsc --noEmit` clean; zero warnings. `git check-ignore web-app/.env.local` now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)