### PR TITLE
feat(desktop-v3): CUDA Linux AppImage release asset (GPU Phase B)

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -245,7 +245,7 @@ jobs:
 
   sign-and-release:
     name: Sign + publish to GitHub Releases
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-macos, build-linux-cuda]
     runs-on: ubuntu-22.04
     steps:
       - name: Download Linux bundles
@@ -258,6 +258,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: macos-bundles
+          path: release-artifacts
+
+      - name: Download cuda bundle (best-effort)
+        uses: actions/download-artifact@v4
+        # The cuda job is non-blocking; if it failed/skipped, its artifact won't
+        # exist. warn (not error) so the release still ships the CPU bundles.
+        continue-on-error: true
+        with:
+          name: linux-cuda-bundle
           path: release-artifacts
 
       - name: Generate SHA256SUMS

--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -142,6 +142,107 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-linux-cuda:
+    name: Build CUDA Linux AppImage
+    # Non-blocking: a failure here (fragile GPU toolchain) must never block the
+    # CPU release. The release ships without the cuda asset instead.
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxss-dev \
+            patchelf \
+            file
+
+      - name: Install CUDA toolkit 12.6
+        # Network method installs only the sub-packages we need (nvcc to compile
+        # candle-kernels; cudart/cublas/curand + their -dev headers/symlinks that
+        # candle-core's cuda backend links). Exports CUDA_PATH as an env var (not a step
+        # output), so reference $CUDA_PATH at the shell level.
+        uses: Jimver/cuda-toolkit@v0.2.19
+        id: cuda-toolkit
+        with:
+          cuda: '12.6.2'
+          method: 'network'
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "cublas", "cublas-dev", "curand", "curand-dev"]'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop-app-v3/src-tauri
+          # Distinct key so the cuda build's artifacts don't trample the CPU cache.
+          key: linux-cuda
+
+      - name: Install JS deps
+        working-directory: desktop-app-v3
+        run: npm ci || npm install
+
+      - name: Build CUDA AppImage
+        working-directory: desktop-app-v3
+        env:
+          CUDA_COMPUTE_CAP: '75'
+        # linuxdeploy bundles the binary's NEEDED libs; point the loader at the
+        # toolkit lib dir so libcudart/libcublas/libcurand get pulled into the
+        # AppImage. The Jimver action exports CUDA_PATH as an env var (not a step
+        # output), so reference $CUDA_PATH at the shell level.
+        run: |
+          export LD_LIBRARY_PATH="$CUDA_PATH/lib64:${LD_LIBRARY_PATH:-}"
+          npm run tauri:build -- --features cuda --bundles appimage
+
+      - name: Stage + rename cuda AppImage
+        run: |
+          set -euo pipefail
+          SRC=$(ls desktop-app-v3/src-tauri/target/release/bundle/appimage/FlowShield_*_amd64.AppImage)
+          mkdir -p release-artifacts
+          BASE=$(basename "${SRC%_amd64.AppImage}")
+          DEST="release-artifacts/${BASE}_amd64-cuda.AppImage"
+          mv "$SRC" "$DEST"
+          echo "--- staged ---"
+          ls -la release-artifacts/
+
+      - name: Assert CUDA runtime libs are bundled
+        # The one novel risk: a "cuda" AppImage that silently bundled no CUDA
+        # runtime would fall back to CPU on the user's machine. Extract the
+        # AppImage (no FUSE needed) and fail THIS job (not the release) if
+        # libcudart isn't inside it.
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(ls release-artifacts/FlowShield_*_amd64-cuda.AppImage)
+          chmod +x "$APPIMAGE"
+          "$APPIMAGE" --appimage-extract >/dev/null
+          if ls squashfs-root/usr/lib/libcudart.so* >/dev/null 2>&1; then
+            echo "::notice::libcudart bundled: $(ls squashfs-root/usr/lib/libcudart.so*)"
+          else
+            echo "::error::libcudart.so not bundled in the cuda AppImage — aborting cuda job."
+            exit 1
+          fi
+          rm -rf squashfs-root
+
+      - name: Upload cuda artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-cuda-bundle
+          path: release-artifacts/FlowShield_*_amd64-cuda.AppImage
+          if-no-files-found: error
+          retention-days: 7
+
   sign-and-release:
     name: Sign + publish to GitHub Releases
     needs: [build-linux, build-macos]

--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -227,8 +227,12 @@ jobs:
           APPIMAGE=$(ls release-artifacts/FlowShield_*_amd64-cuda.AppImage)
           chmod +x "$APPIMAGE"
           "$APPIMAGE" --appimage-extract >/dev/null
-          if ls squashfs-root/usr/lib/libcudart.so* >/dev/null 2>&1; then
-            echo "::notice::libcudart bundled: $(ls squashfs-root/usr/lib/libcudart.so*)"
+          # linuxdeploy may place the lib under usr/lib/ OR the multiarch
+          # usr/lib/x86_64-linux-gnu/ — search the whole tree so a bundled lib
+          # in either location isn't a false-negative.
+          FOUND=$(find squashfs-root -name 'libcudart.so*' | head -1)
+          if [ -n "$FOUND" ]; then
+            echo "::notice::libcudart bundled: $FOUND"
           else
             echo "::error::libcudart.so not bundled in the cuda AppImage — aborting cuda job."
             exit 1

--- a/docs/superpowers/plans/2026-06-25-gpu-acceleration-phase-b.md
+++ b/docs/superpowers/plans/2026-06-25-gpu-acceleration-phase-b.md
@@ -1,0 +1,285 @@
+# GPU Acceleration — Phase B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Task 3 is a manual, release-pipeline spike — run it directly (not via a subagent).**
+
+**Goal:** Make `desktop-v3-release.yml` build and publish a self-contained, CUDA-accelerated Linux **AppImage** alongside the existing CPU bundles, without ever blocking the CPU release.
+
+**Architecture:** A new non-blocking `build-linux-cuda` job mirrors `build-linux` but installs the CUDA 12.6 toolkit and builds with `--features cuda --bundles appimage`. linuxdeploy bundles the CUDA runtime `.so`s into the AppImage (only the NVIDIA driver stays external). The job renames its output with a `-cuda` suffix, asserts the runtime libs are bundled, and uploads a separate artifact that `sign-and-release` signs and publishes.
+
+**Tech Stack:** GitHub Actions, Tauri 2 CLI, candle 0.8.4 `cuda` feature (from Phase A), `Jimver/cuda-toolkit` action, linuxdeploy/AppImage.
+
+## Global Constraints
+
+- Only file touched: `.github/workflows/desktop-v3-release.yml`. No application code changes (Phase A already shipped the `cuda` feature + `select_device()`).
+- The cuda job is **non-blocking**: `continue-on-error: true`. A cuda failure must never fail the release — CPU deb/rpm/AppImage + macOS dmg always ship.
+- cuda variant is **AppImage only**. Do not produce deb/rpm for it.
+- Build target floor: `CUDA_COMPUTE_CAP=75` (Turing). CUDA toolkit `12.6` (matches the validated candle 0.8.4 / cudarc 0.13.9 pairing).
+- Asset name: `FlowShield_${VERSION}_amd64-cuda.AppImage` — distinct from the CPU `FlowShield_${VERSION}_amd64.AppImage`.
+- `publish-to-aur` must stay CPU-only: it downloads only the `linux-bundles` artifact, never the cuda artifact. Do not add the cuda artifact to its downloads.
+- Runner `ubuntu-22.04` (default gcc 11 satisfies nvcc 12.6 — no conda/`NVCC_CCBIN` workaround; that was Fedora-43-only).
+
+## Reference — current workflow shape
+
+`.github/workflows/desktop-v3-release.yml` jobs (line anchors):
+- `build-linux` (lines 25–89): ubuntu-22.04 → apt deps → node 20 → rust stable → `Swatinem/rust-cache@v2` (workspace `desktop-app-v3/src-tauri`) → `npm ci || npm install` → `npm run tauri:build` → stage deb/rpm/AppImage → `upload-artifact` name `linux-bundles`.
+- `build-macos` (lines 91–143).
+- `sign-and-release` (lines 145–230): `needs: [build-linux, build-macos]` → download `linux-bundles` + `macos-bundles` into `release-artifacts` → `sha256sum * > SHA256SUMS` → GPG import/sign (`for f in *.deb *.rpm *.AppImage *.dmg`) → `softprops/action-gh-release@v2` publishes `release-artifacts/*`.
+- `publish-to-aur` (lines 232–304): `needs: sign-and-release` → downloads only `linux-bundles` → renders PKGBUILD from the CPU `FlowShield_*_amd64.AppImage`.
+
+`desktop-app-v3/package.json`: `"tauri:build": "tauri build"`. So `npm run tauri:build -- <args>` forwards `<args>` to `tauri build`.
+
+The CPU AppImage path after `npm run tauri:build`:
+`desktop-app-v3/src-tauri/target/release/bundle/appimage/FlowShield_<version>_amd64.AppImage`.
+
+### Validation tooling (used by every task)
+
+No `actionlint`/`yamllint` installed. Validate edited YAML two ways:
+
+1. Parse check (always available):
+   `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/desktop-v3-release.yml')); print('yaml ok')"`
+2. Expression/context lint via a one-shot `actionlint` binary (downloads ~2 MB to the repo-ignored scratch dir, no system install):
+   ```bash
+   bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) >/dev/null
+   ./actionlint .github/workflows/desktop-v3-release.yml && rm -f actionlint
+   ```
+   Expected: no output = clean. If `curl` is unavailable, the parse check in (1) is the floor.
+
+---
+
+### Task 1: Add the non-blocking `build-linux-cuda` job
+
+**Files:**
+- Modify: `.github/workflows/desktop-v3-release.yml` (insert a new job immediately before `sign-and-release`, i.e. before line 145 `  sign-and-release:`)
+
+**Interfaces:**
+- Produces: an uploaded artifact named `linux-cuda-bundle` containing one file, `FlowShield_<version>_amd64-cuda.AppImage`. Task 2 consumes this artifact name.
+
+- [ ] **Step 1: Insert the `build-linux-cuda` job**
+
+In `.github/workflows/desktop-v3-release.yml`, insert the following job between the end of `build-macos` (line 143) and the start of `sign-and-release` (line 145). Keep two-space indentation consistent with the other jobs.
+
+```yaml
+  build-linux-cuda:
+    name: Build CUDA Linux AppImage
+    # Non-blocking: a failure here (fragile GPU toolchain) must never block the
+    # CPU release. The release ships without the cuda asset instead.
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxss-dev \
+            patchelf \
+            file
+
+      - name: Install CUDA toolkit 12.6
+        # Network method installs only the sub-packages we need (nvcc to compile
+        # candle-kernels; cudart/cublas/curand + their -dev headers/symlinks that
+        # candle-core's cuda backend links). Exports CUDA_PATH and adds nvcc to PATH.
+        uses: Jimver/cuda-toolkit@v0.2.19
+        id: cuda-toolkit
+        with:
+          cuda: '12.6.2'
+          method: 'network'
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "cublas", "cublas-dev", "curand", "curand-dev"]'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop-app-v3/src-tauri
+          # Distinct key so the cuda build's artifacts don't trample the CPU cache.
+          key: linux-cuda
+
+      - name: Install JS deps
+        working-directory: desktop-app-v3
+        run: npm ci || npm install
+
+      - name: Build CUDA AppImage
+        working-directory: desktop-app-v3
+        env:
+          CUDA_COMPUTE_CAP: '75'
+        # linuxdeploy bundles the binary's NEEDED libs; point the loader at the
+        # toolkit lib dir so libcudart/libcublas/libcurand get pulled into the
+        # AppImage. The Jimver action exports CUDA_PATH as an env var (not a step
+        # output), so reference $CUDA_PATH at the shell level.
+        run: |
+          export LD_LIBRARY_PATH="$CUDA_PATH/lib64:${LD_LIBRARY_PATH:-}"
+          npm run tauri:build -- --features cuda --bundles appimage
+
+      - name: Stage + rename cuda AppImage
+        run: |
+          set -euo pipefail
+          SRC=$(ls desktop-app-v3/src-tauri/target/release/bundle/appimage/FlowShield_*_amd64.AppImage)
+          mkdir -p release-artifacts
+          BASE=$(basename "${SRC%_amd64.AppImage}")
+          DEST="release-artifacts/${BASE}_amd64-cuda.AppImage"
+          mv "$SRC" "$DEST"
+          echo "--- staged ---"
+          ls -la release-artifacts/
+
+      - name: Assert CUDA runtime libs are bundled
+        # The one novel risk: a "cuda" AppImage that silently bundled no CUDA
+        # runtime would fall back to CPU on the user's machine. Extract the
+        # AppImage (no FUSE needed) and fail THIS job (not the release) if
+        # libcudart isn't inside it.
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(ls release-artifacts/FlowShield_*_amd64-cuda.AppImage)
+          chmod +x "$APPIMAGE"
+          "$APPIMAGE" --appimage-extract >/dev/null
+          if ls squashfs-root/usr/lib/libcudart.so* >/dev/null 2>&1; then
+            echo "::notice::libcudart bundled: $(ls squashfs-root/usr/lib/libcudart.so*)"
+          else
+            echo "::error::libcudart.so not bundled in the cuda AppImage — aborting cuda job."
+            exit 1
+          fi
+          rm -rf squashfs-root
+
+      - name: Upload cuda artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-cuda-bundle
+          path: release-artifacts/FlowShield_*_amd64-cuda.AppImage
+          if-no-files-found: error
+          retention-days: 7
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/desktop-v3-release.yml')); print('yaml ok')"
+bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) >/dev/null && ./actionlint .github/workflows/desktop-v3-release.yml && rm -f actionlint
+```
+Expected: `yaml ok`, then no actionlint output (clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/desktop-v3-release.yml
+git commit -m "feat(desktop-v3): build non-blocking CUDA Linux AppImage in release CI"
+```
+
+---
+
+### Task 2: Wire the cuda artifact into `sign-and-release`
+
+**Files:**
+- Modify: `.github/workflows/desktop-v3-release.yml` — `sign-and-release` job: `needs` line (147) + add a gated download step after the existing `Download macOS bundles` step (after line 160).
+
+**Interfaces:**
+- Consumes: the `linux-cuda-bundle` artifact from Task 1.
+- Produces: nothing new for later tasks — the existing sign loop (`for f in *.AppImage`), `SHA256SUMS`, and `softprops/action-gh-release` (`release-artifacts/*`) already pick up any `.AppImage` in `release-artifacts`.
+
+- [ ] **Step 1: Add `build-linux-cuda` to `needs`**
+
+In `.github/workflows/desktop-v3-release.yml`, change the `sign-and-release` `needs` line (147) from:
+```yaml
+    needs: [build-linux, build-macos]
+```
+to:
+```yaml
+    needs: [build-linux, build-macos, build-linux-cuda]
+```
+Because `build-linux-cuda` has `continue-on-error: true`, a cuda failure still reports success to `needs` — so adding it here makes `sign-and-release` wait for the artifact to be ready **without** letting a cuda failure block the release.
+
+- [ ] **Step 2: Add a gated download of the cuda artifact**
+
+Immediately after the existing `Download macOS bundles` step (ends line 160), insert:
+```yaml
+      - name: Download cuda bundle (best-effort)
+        uses: actions/download-artifact@v4
+        # The cuda job is non-blocking; if it failed/skipped, its artifact won't
+        # exist. warn (not error) so the release still ships the CPU bundles.
+        continue-on-error: true
+        with:
+          name: linux-cuda-bundle
+          path: release-artifacts
+```
+No other change is needed in `sign-and-release`: the later `sha256sum *`, the GPG `for f in *.deb *.rpm *.AppImage *.dmg` loop, and `action-gh-release`'s `release-artifacts/*` already include whatever AppImage landed in `release-artifacts`.
+
+- [ ] **Step 3: Confirm AUR stays CPU-only (no change, verify)**
+
+Read the `publish-to-aur` job (lines 232–304). Confirm it still downloads only `name: linux-bundles` and globs `FlowShield_*_amd64.AppImage`. Note the CPU file is `FlowShield_<v>_amd64.AppImage` and the cuda file is `FlowShield_<v>_amd64-cuda.AppImage`; the AUR job never downloads the `linux-cuda-bundle` artifact, so the cuda asset cannot reach AUR. Make no edits — this step is a verification only.
+
+- [ ] **Step 4: Validate the workflow YAML**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/desktop-v3-release.yml')); print('yaml ok')"
+bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) >/dev/null && ./actionlint .github/workflows/desktop-v3-release.yml && rm -f actionlint
+```
+Expected: `yaml ok`, then clean actionlint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/desktop-v3-release.yml
+git commit -m "feat(desktop-v3): publish cuda AppImage via sign-and-release (gated, non-blocking)"
+```
+
+---
+
+### Task 3: Release-pipeline validation (MANUAL — gating)
+
+**This is not a subagent task.** It exercises the real release workflow and the GPU on the developer's machine. It validates Tasks 1–2 end-to-end and gates any follow-up (Phase C).
+
+- [ ] **Step 1: Trigger a test run of the workflow**
+
+The cuda job's toolkit sub-package names and link deps can only be confirmed against a real run (GHA runners build differently than the local Fedora box). After Tasks 1–2 are merged to `main`, trigger the workflow against the latest existing `v3.*` tag:
+```bash
+gh workflow run "Desktop v3 Release" -f tag=<latest v3.* tag, e.g. v3.9.1-alpha.0>
+gh run watch
+```
+Watch the `build-linux-cuda` job. Expected: CUDA toolkit installs, `candle-kernels` + candle compile with `--features cuda`, AppImage builds, the "Assert CUDA runtime libs are bundled" step prints `libcudart bundled`, and the artifact uploads.
+
+**If the build fails on a missing CUDA lib at link time** (e.g. `cannot find -lcublasLt`): add the missing `-dev` sub-package (e.g. `cublasLt`) to the `sub-packages` list in Task 1's job, or switch that step to `method: 'local'` (full toolkit) if several are missing. Re-run. This is the expected iteration point — record what was needed.
+
+- [ ] **Step 2: Confirm the asset published**
+
+After the run, confirm the Release for that tag now lists `FlowShield_<v>_amd64-cuda.AppImage` (plus its `.asc` if GPG is provisioned) alongside the CPU bundles, and that `SHA256SUMS` includes it. Confirm the CPU `.deb`/`.rpm`/`.AppImage` + macOS `.dmg` are still present (non-blocking did not drop them).
+
+- [ ] **Step 3: GPU smoke-test on the RTX 3060 (Fedora)**
+
+Download the published `-cuda` AppImage on the developer's Fedora box (driver 580):
+```bash
+chmod +x FlowShield_*_amd64-cuda.AppImage
+# Clear today's cached briefing first so Generate triggers a fresh run:
+#   sqlite3 ~/.local/share/app.flowshield.desktop/local.sqlite "DELETE FROM ai_briefings WHERE date='<today YYYY-MM-DD>';"
+./FlowShield_*_amd64-cuda.AppImage
+```
+Launch, ensure Local AI is `ready`, click **Generate today's briefing**, and confirm:
+- the log shows `AI compute device: CUDA(0)` (not `CPU`),
+- `nvtop` shows a GPU0 utilization spike + VRAM rise,
+- the briefing completes as full text.
+
+This re-runs the Phase A spike check against the **shipped artifact** — proving the bundled CUDA runtime works on a clean machine with only the driver present.
+
+- [ ] **Step 4: Record the result**
+
+Note: did the cuda job build cleanly in CI? Which sub-packages were actually required? Did the bundled AppImage run on the GPU on Fedora? This result gates Phase C (the CPU/GPU selector) — a selector is only worth building once a GPU build verifiably ships and runs.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** self-contained AppImage ✓ (Task 1 build + bundle-assert); AppImage-only ✓ (`--bundles appimage`); sm_75 floor ✓ (`CUDA_COMPUTE_CAP=75`); CUDA 12.6 ✓ (Jimver `12.6.2`); non-blocking ✓ (`continue-on-error` + `needs` semantics + warn download); Jimver/ubuntu-22.04 ✓; `-cuda` naming + no SHA/AUR collision ✓ (Task 1 rename, Task 2 Step 3 verify); sign/release integration ✓ (Task 2); in-CI structural check + manual GPU smoke ✓ (Task 1 assert step + Task 3).
+- **Placeholder scan:** none — every YAML block is complete and ready to paste; the one empirical unknown (exact toolkit sub-packages) is handled by an explicit iterate-on-CI-log loop in Task 3 Step 1, not a placeholder.
+- **Type consistency:** artifact name `linux-cuda-bundle` and file pattern `FlowShield_*_amd64-cuda.AppImage` are used identically in Task 1 (produce) and Task 2 (consume); `id: cuda-toolkit` matches the `steps.cuda-toolkit.outputs.CUDA_PATH` reference.
+- **Deferred:** Windows/macOS cuda, deb/rpm cuda, the CPU/GPU selector (Phase C), multi-arch cubins.

--- a/docs/superpowers/specs/2026-06-25-gpu-acceleration-phase-b-design.md
+++ b/docs/superpowers/specs/2026-06-25-gpu-acceleration-phase-b-design.md
@@ -1,0 +1,128 @@
+# GPU Acceleration — Phase B (CUDA Linux AppImage Release Asset) Design
+
+**Date:** 2026-06-25
+**Status:** Approved design — pending implementation plan
+**Component:** `desktop-app-v3` / `.github/workflows/desktop-v3-release.yml`
+
+## Context
+
+Phase A (PR #94, merged) made the on-device AI device-agnostic: an off-by-default
+`cuda` cargo feature + `select_device()` (CPU default, CUDA(0) when a `cuda` build
+initializes, CPU fallback otherwise). A local spike proved a `cuda` build runs Phi-3
+q4 inference on the RTX 3060, fast. **Phase B ships that capability**: the release
+pipeline builds a second, CUDA-accelerated Linux asset so NVIDIA users can opt into
+GPU inference. It does **not** add a CPU/GPU UI selector (Phase C).
+
+## Phasing (this spec = Phase B only)
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| A | `cuda` feature, `select_device()`, wire into loaders, local spike | done (PR #94) |
+| **B** | CI builds a self-contained `-cuda` Linux **AppImage** release asset | this spec |
+| C | CPU/GPU selector on the AI settings page, persisted, read by `select_device` | later |
+
+## Decisions (locked during brainstorming)
+
+1. **Self-contained AppImage.** The asset bundles the CUDA runtime libs so the only
+   external dependency is the NVIDIA driver. AppImage is the only release format that
+   bundles cleanly, so the cuda variant ships as **AppImage only**; the CPU build
+   keeps all three (deb/rpm/AppImage) + macOS.
+2. **GPU floor = Turing `sm_75`** (`CUDA_COMPUTE_CAP=75`). candle ships PTX kernels
+   that JIT at load, so sm_75 covers RTX 20/30/40-series and newer (the 3060
+   included); Pascal/GTX-10 and older are dropped.
+3. **Non-blocking.** A cuda-job failure must never block the release — CPU bundles +
+   macOS always ship; the release simply omits the cuda asset.
+4. **CI toolkit via `Jimver/cuda-toolkit` action on ubuntu-22.04.** Default gcc 11 on
+   22.04 satisfies nvcc 12.6 — none of the conda/g++ workarounds the local Fedora 43
+   box needed (those were a Fedora-gcc-15 + system-CUDA-13 problem, absent on 22.04).
+
+## Architecture
+
+One new job, `build-linux-cuda`, added to `desktop-v3-release.yml`. It mirrors the
+existing `build-linux` job (same `ubuntu-22.04` runner, system deps, node, rust
+setup) and adds the CUDA toolkit + the `cuda` feature. It produces one self-contained
+AppImage and uploads it as a separate artifact. The existing `sign-and-release` job
+consumes it alongside the other bundles. No other workflow or any application code is
+touched; the default (CPU) build path is unchanged.
+
+### Build distro ≠ run distro
+
+The ubuntu-22.04 runner is only the build machine. The shipped AppImage is
+distro-agnostic: built against glibc 2.35, it runs on any Linux with glibc ≥ 2.35
+(Fedora, Arch, etc.) — the same portability the existing CPU AppImage already relies
+on. CUDA-wise, the only host requirement is an NVIDIA driver new enough for CUDA 12.6
+(≥ 525); the CUDA runtime itself is bundled.
+
+## The `build-linux-cuda` job
+
+- `runs-on: ubuntu-22.04`; `continue-on-error: true` (non-blocking).
+- Same `apt` system deps, `actions/setup-node@v4` (node 20), `dtolnay/rust-toolchain@stable`,
+  `Swatinem/rust-cache@v2` as `build-linux`, but with a distinct cache `key: linux-cuda`
+  so the CPU and cuda caches don't trample each other.
+- `Jimver/cuda-toolkit@v0.2.x` with `cuda: '12.6.x'`, `method: network`, and a
+  `sub-packages`/`linux-local-args` selection that installs nvcc + the runtime libs
+  (cudart, cublas) — enough to compile candle-kernels and to bundle at link time.
+- Env for the build step:
+  - `CUDA_COMPUTE_CAP=75`
+  - `LD_LIBRARY_PATH` prepends the toolkit lib dir, so linuxdeploy resolves and
+    bundles the CUDA runtime `.so`s into the AppImage.
+- Build: `npm run tauri:build -- --features cuda --bundles appimage`
+  (AppImage only; the deb/rpm formats are not produced for the cuda variant).
+
+## AppImage bundling + naming
+
+- **Bundling:** linuxdeploy copies the binary's NEEDED libs into the AppImage. With
+  `LD_LIBRARY_PATH` pointing at the toolkit, `libcudart.so.12` / `libcublas.so.12` /
+  etc. are bundled. `libcuda.so.1` (the driver) is on linuxdeploy's standard exclude
+  list and stays external — correct, since it must come from the user's driver.
+- **Naming:** the stage step renames the output to
+  `FlowShield_${VERSION}_amd64-cuda.AppImage` — distinct from the CPU
+  `FlowShield_${VERSION}_amd64.AppImage`. No collision in `SHA256SUMS` or the Release
+  asset list; the `-cuda` suffix makes the GPU build self-describing.
+
+## Integration with `sign-and-release` and AUR
+
+- `sign-and-release` adds a download of the cuda artifact gated so a missing artifact
+  (cuda job failed/skipped) is a clean no-op — `if-no-files-found: warn`, not `error`.
+- The existing GPG sign loop (`for f in *.deb *.rpm *.AppImage *.dmg`) signs the cuda
+  AppImage automatically; `SHA256SUMS` includes it.
+- `publish-to-aur` is unaffected: it downloads only the `linux-bundles` (CPU) artifact
+  and globs `FlowShield_*_amd64.AppImage` (the CPU file), so the cuda asset can never
+  leak into the AUR `flowshield-bin` package.
+
+## Error handling
+
+- Cuda toolchain fragility is contained by `continue-on-error: true` + the `warn`
+  download gate: every failure mode (toolkit install, nvcc compile, link, bundle)
+  degrades to "release ships without the cuda asset," never to a blocked release.
+- The CPU asset remains the safe default for the ~99% of users without an NVIDIA GPU.
+
+## Testing / validation
+
+The one novel risk is whether linuxdeploy bundles the CUDA `.so`s correctly. GHA
+runners have no GPU, so runtime GPU verification is out of scope for CI; validation is
+structural:
+
+- **In-CI:** after the bundle step, extract/inspect the AppImage and assert
+  `libcudart.so.*` is present *inside* it (and that the main binary's `ldd`, resolved
+  against the AppImage's bundled lib dir, does not fall through to a host path for
+  cudart). Fail the cuda job (not the release) if the runtime lib is missing — a
+  silently-CPU-only "cuda" AppImage is worse than no cuda asset.
+- **Manual GPU smoke-test:** download the built `-cuda` AppImage on the developer's
+  Fedora + RTX 3060 box (driver 580), generate a briefing, confirm
+  `AI compute device: CUDA(0)` in the log and a GPU utilization spike — the same check
+  that closed the Phase A spike, now against the shipped artifact.
+
+## Out of scope (Phase B)
+
+- Windows cuda build (no Windows release exists yet).
+- macOS (no NVIDIA GPUs; Metal is a separate future track).
+- deb/rpm cuda variants (system-package CUDA-lib bundling is messy; AppImage only).
+- The CPU/GPU settings selector + persistence (Phase C).
+- Multi-arch native cubins / per-GPU optimization (single sm_75 PTX, JIT upward).
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/desktop-v3-release.yml` | add `build-linux-cuda` job; wire its artifact into `sign-and-release` (gated, non-blocking) |


### PR DESCRIPTION
## GPU Acceleration — Phase B

Builds and publishes a self-contained, CUDA-accelerated Linux **AppImage** alongside the existing CPU bundles. Follows Phase A (#94), which shipped the `cuda` feature + `select_device()`. Validated locally: Phi-3 q4 runs on the RTX 3060, fast.

### What changed (one file: `desktop-v3-release.yml`)
- **New `build-linux-cuda` job** — ubuntu-22.04, `continue-on-error: true` (non-blocking). Installs CUDA 12.6.2 (`Jimver/cuda-toolkit`), builds `tauri:build --features cuda --bundles appimage` with `CUDA_COMPUTE_CAP=75` (Turing floor → RTX 20/30/40 + newer via PTX JIT). Renames output to `FlowShield_*_amd64-cuda.AppImage`, asserts `libcudart` is bundled inside the AppImage, uploads `linux-cuda-bundle`.
- **`sign-and-release`** — waits on the cuda job (`needs`) and does a gated, best-effort download of its artifact; the existing GPG sign loop + `action-gh-release` publish it.

### Guarantees
- **Non-blocking:** any cuda-toolchain failure degrades to "release ships without the cuda asset" — CPU deb/rpm/AppImage + macOS dmg always ship.
- **Self-contained:** AppImage bundles the CUDA runtime; only external dep is the NVIDIA driver. Runs cross-distro (Fedora/Arch/etc.), not just Ubuntu.
- **AUR untouched:** `publish-to-aur` downloads only `linux-bundles`; the `-cuda` asset can't reach AUR.

### Scope
Phase B only. Out of scope: Windows/macOS cuda, deb/rpm cuda variants, CPU/GPU UI selector (Phase C).

### Validation
- YAML parse + `actionlint` clean.
- Per-task reviews: both spec ✅ / quality approved. Final whole-branch review: merge-ready (1 Important — libcudart multiarch path glob — fixed in `ecd3f6d`).
- **Pending (Task 3, manual, post-merge):** trigger a real release run to confirm the cuda job builds + bundles, then GPU smoke-test the published AppImage on the RTX 3060. Gates Phase C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)