### PR TITLE
fix(desktop-v3): correct CUDA toolkit sub-package names (cublas/curand)

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -166,16 +166,19 @@ jobs:
             file
 
       - name: Install CUDA toolkit 12.6
-        # Network method installs only the sub-packages we need (nvcc to compile
-        # candle-kernels; cudart/cublas/curand + their -dev headers/symlinks that
-        # candle-core's cuda backend links). Exports CUDA_PATH as an env var (not a step
-        # output), so reference $CUDA_PATH at the shell level.
+        # Installs only what candle's cuda backend needs: nvcc (compile
+        # candle-kernels) + cudart. cublas/curand are named libcublas-/libcurand-
+        # in NVIDIA's apt repo (not cuda-*), so they go in non-cuda-sub-packages —
+        # Jimver maps sub-packages -> cuda-<name>-12-6 and
+        # non-cuda-sub-packages -> <name>-12-6. Exports CUDA_PATH as an env var
+        # (not a step output), so reference $CUDA_PATH at the shell level.
         uses: Jimver/cuda-toolkit@v0.2.19
         id: cuda-toolkit
         with:
           cuda: '12.6.2'
           method: 'network'
-          sub-packages: '["nvcc", "cudart", "cudart-dev", "cublas", "cublas-dev", "curand", "curand-dev"]'
+          sub-packages: '["nvcc", "cudart", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcublas", "libcublas-dev", "libcurand", "libcurand-dev"]'
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
The GPU Phase B cuda release job (first real run, tag v3.10.0-alpha.0) failed at the CUDA toolkit install step:

```
E: Unable to locate package cuda-cublas-12-6
E: Unable to locate package cuda-curand-12-6  (+ -dev)
```

`Jimver/cuda-toolkit` maps `sub-packages` → `cuda-<name>-12-6`. That's correct for nvcc/cudart, but **cublas/curand are `libcublas-12-6` / `libcurand-12-6`** in NVIDIA's apt repo (not `cuda-*`). Moved them to `non-cuda-sub-packages` (mapped to `<name>-12-6`); nvcc + cudart stay in `sub-packages`.

Non-blocking held: the CPU bundles + macOS shipped fine; only the cuda asset was missing. This was the expected iteration point called out in the Phase B plan (Task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)