### PR TITLE
fix(desktop-v3): add nvrtc to CUDA toolkit sub-packages

### DIFF
--- a/.github/workflows/desktop-v3-release.yml
+++ b/.github/workflows/desktop-v3-release.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           cuda: '12.6.2'
           method: 'network'
-          sub-packages: '["nvcc", "cudart", "cudart-dev"]'
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev"]'
           non-cuda-sub-packages: '["libcublas", "libcublas-dev", "libcurand", "libcurand-dev"]'
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Second iteration of the Phase B cuda toolkit tuning (Task 3). Toolkit install + candle CUDA compile now succeed; the final link failed:

```
rust-lld: error: unable to find library -lnvrtc
```

candle's cuda backend links `-lnvrtc`. Added `nvrtc` + `nvrtc-dev` to `sub-packages` (cuda-nvrtc-12-6 / cuda-nvrtc-dev-12-6; the -dev provides the link symlink). The link line's full cuda set (`-lcuda -lnvrtc -lcurand -lcublas -lcublasLt -lcudart`) is now fully satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)