### PR TITLE
fix(desktop-v3): wrap LLM prompt in Phi-3 chat template (stop briefing ramble)

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/candle_llm.rs
+++ b/desktop-app-v3/src-tauri/src/ai/candle_llm.rs
@@ -136,9 +136,12 @@ impl CandleLlmRuntime {
             ));
         }
 
+        // Wrap in the Phi-3 instruct chat template so the model answers as the
+        // assistant and stops at <|end|> (raw prompts ramble — see phi3_chat_wrap).
+        let wrapped = phi3_chat_wrap(prompt);
         let encoding = self
             .tokenizer
-            .encode(prompt, true)
+            .encode(wrapped, true)
             .map_err(|e| AiError::Tokenize(format!("encode prompt: {e}")))?;
 
         let mut tokens: Vec<u32> = encoding.get_ids().to_vec();
@@ -221,11 +224,33 @@ fn simple_hash_u64(s: &str) -> u64 {
     h
 }
 
+/// Wrap a raw prompt in the Phi-3 instruct chat template. Phi-3-mini-4k is an
+/// instruct model trained on `<|user|>…<|end|>\n<|assistant|>`; fed a raw
+/// completion prompt it never enters an assistant turn, so it never emits the
+/// `<|end|>` stop token and rambles past the answer (hallucinating extra
+/// instruction blocks). Wrapping makes it answer as the assistant and stop
+/// cleanly at `<|end|>`. The `<|…|>` markers are Phi-3 special tokens, encoded
+/// to their special-token IDs by the tokenizer.
+fn phi3_chat_wrap(prompt: &str) -> String {
+    format!("<|user|>\n{prompt}<|end|>\n<|assistant|>\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+    #[test]
+    fn phi3_chat_wrap_uses_instruct_template() {
+        // The instruct model must receive the prompt inside its chat template
+        // so it answers as the assistant and emits <|end|> (instead of running
+        // in completion mode and rambling past the answer).
+        assert_eq!(
+            phi3_chat_wrap("Summarize my day."),
+            "<|user|>\nSummarize my day.<|end|>\n<|assistant|>\n"
+        );
+    }
 
     #[test]
     fn model_id_matches_registry() {


### PR DESCRIPTION
### Symptom
The briefing output leaked hallucinated instruction text after the real briefing — a fake "You are TimeMaster…" persona, "Instruction 2 (More Difficult)", "USER DATA: [Day] Fri".

### Root cause
`generate_sync` (candle_llm.rs) fed the raw prompt to Phi-3-mini-4k-**instruct** with no chat template. The instruct model never enters an assistant turn → never emits its `<|end|>` stop token → the EOS check never fires → it runs to `max_tokens` in completion mode, rambling past the answer and inventing new instruction blocks. (The prompt template itself is clean — the leak is hallucinated continuation, not echoed prompt.)

### Fix
Wrap the prompt in `<|user|>\n{prompt}<|end|>\n<|assistant|>\n` before encoding. The model answers as the assistant and stops cleanly at `<|end|>`. Applied in the runtime, so briefing **and** reflection both benefit. The `<|…|>` markers are Phi-3 special tokens (candle already resolves `<|end|>` via `token_to_id`).

### Tests
- New unit test `phi3_chat_wrap_uses_instruct_template` (guards the template format). Full suite: **124 passed**, clean build.
- Behavioral proof (no ramble) needs the real model — verify by generating a briefing on a build of this branch (the gated `briefing_pipeline_with_real_models` test covers it in CI-with-models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)