### PR TITLE
fix(desktop-v3): strip appended sections from briefing output

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/briefing.rs
+++ b/desktop-app-v3/src-tauri/src/ai/briefing.rs
@@ -32,6 +32,32 @@ const RETRIEVAL_K: usize = 15;
 const RETRIEVAL_WINDOW_DAYS: i64 = 7;
 const MIN_OUTPUT_LEN: usize = 5;
 
+/// Keep only the briefing itself. Phi-3-mini-q4 reliably writes the 2-3
+/// sentence briefing first, then under thin/sparse data sometimes appends
+/// extra sections after a blank line — an "Explanation:" list, a restated
+/// "USER DATA:" echo of the prompt, a "Suggested action:" block. Return the
+/// first paragraph (everything before the first blank line); as a guard,
+/// also cut at any leaked prompt-structure marker in case an echo isn't
+/// preceded by a blank line. A real briefing never contains these markers.
+fn first_paragraph(text: &str) -> &str {
+    let t = text.trim_start();
+    let mut end = t.find("\n\n").unwrap_or(t.len());
+    for marker in [
+        "USER DATA",
+        "YESTERDAY'S REFLECTION",
+        "TODAY:",
+        "BRIEFING:",
+        "[Session]",
+        "[Day]",
+        "[Reflection]",
+    ] {
+        if let Some(i) = t.find(marker) {
+            end = end.min(i);
+        }
+    }
+    t[..end].trim_end()
+}
+
 /// RAII guard that flips the `in_flight` flag back to `false` on drop —
 /// even if the orchestrator panics.
 struct InFlightGuard<'a>(&'a AtomicBool);
@@ -120,9 +146,11 @@ where
         local_time: &local_time,
     });
 
-    // Phase 2: run the LLM (no lock held).
+    // Phase 2: run the LLM (no lock held). Keep only the first paragraph —
+    // the model sometimes appends an "Explanation:"/"USER DATA:" echo section
+    // after the briefing (see first_paragraph).
     let text = runtime.generate(&prompt, BRIEFING_MAX_TOKENS).await?;
-    let trimmed = text.trim();
+    let trimmed = first_paragraph(&text);
 
     if trimmed.len() < MIN_OUTPUT_LEN {
         tracing::warn!(
@@ -190,6 +218,31 @@ mod tests {
         let db = store::open(&path).expect("open db");
         std::mem::forget(tmp);
         db
+    }
+
+    #[test]
+    fn first_paragraph_strips_appended_sections() {
+        // Real GPU leak: briefing, then an "Explanation:" list after a blank line.
+        let leaked = "In the past week you had 5 sessions. Today, limit app usage.\n\n\nExplanation:\n- focus time decreased\n- app usage increased";
+        assert_eq!(
+            first_paragraph(leaked),
+            "In the past week you had 5 sessions. Today, limit app usage."
+        );
+
+        // Real screenshot leak: briefing, then a "User Data:" echo of the chunks.
+        let leaked2 = "Your focus time decreased. Today, set a timer.\n\nUser Data:\n[Day] Sat. 3 sessions.";
+        assert_eq!(
+            first_paragraph(leaked2),
+            "Your focus time decreased. Today, set a timer."
+        );
+
+        // Defense-in-depth: an inline chunk echo with no blank line before it.
+        let leaked3 = "Focus dropped this week. [Session] Sat 10:00-10:15 echo.";
+        assert_eq!(first_paragraph(leaked3), "Focus dropped this week.");
+
+        // A clean single-paragraph briefing is returned unchanged.
+        let clean = "You had 5 sessions averaging 10 minutes. Today, take a break between blocks.";
+        assert_eq!(first_paragraph(clean), clean);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Symptom
The briefing still leaked after the chat-template fix (#104) — a trailing block shown below the real briefing: an `Explanation:` list or a restated `User Data:` echo of the prompt chunks.

### Root cause (reproduced)
Ran the gated `briefing_pipeline_with_real_models` test against a **copy of the real corpus on GPU** (`--features cuda`):
- CPU + rich data → clean. CPU + thin data → clean. GPU + rich data → clean.
- **GPU + the real (thin/messy) corpus → leaked** ("...stay focused on your tasks.\n\n\nExplanation:\n- ...").

So Phi-3-mini-q4 writes the 2-3 sentence briefing first, then under sparse data **over-produces an extra section after a blank line**. The chat wrap stopped the persona hallucination but not this appendage. It's a fixed external model (weights unchangeable) and the appendage varies run-to-run (CUDA sampling) — so the robust fix is **output sanitization**.

### Fix
`first_paragraph()` keeps only the text before the first blank line, with a guard that also cuts at any leaked prompt-structure marker (`USER DATA`, `[Session]`, `[Day]`, `BRIEFING:`, …) — a real briefing never contains these. The prompt already asks for "2-3 sentences max" (one paragraph), so this enforces intent and drops every observed appendage.

### Verification
- Unit test with the **actual leaked outputs** as fixtures (`first_paragraph_strips_appended_sections`).
- End-to-end on **GPU + real data**: stored briefing is now a single clean paragraph ("Your focused sessions have decreased by 14 minutes... set a timer..."). Full suite **125 passed**, clean build.

Note: the reflection generator has the same over-production family (its stored questions are contaminated) — out of scope here, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)