### PR TITLE
fix(desktop-v3): sanitize reflection question output (shared first_paragraph)

### DIFF
--- a/desktop-app-v3/src-tauri/src/ai/briefing.rs
+++ b/desktop-app-v3/src-tauri/src/ai/briefing.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::ai::candle_embedder::CandleEmbedder;
 use crate::ai::candle_llm::CandleLlmRuntime;
 use crate::ai::embedder::Embedder;
-use crate::ai::prompts::{render_briefing_prompt, BriefingContext};
+use crate::ai::prompts::{first_paragraph, render_briefing_prompt, BriefingContext};
 use crate::ai::retriever::top_k_by_cosine;
 use crate::ai::runtime::LlmRuntime;
 use crate::error::AppError;
@@ -31,32 +31,6 @@ const BRIEFING_MAX_TOKENS: usize = 200;
 const RETRIEVAL_K: usize = 15;
 const RETRIEVAL_WINDOW_DAYS: i64 = 7;
 const MIN_OUTPUT_LEN: usize = 5;
-
-/// Keep only the briefing itself. Phi-3-mini-q4 reliably writes the 2-3
-/// sentence briefing first, then under thin/sparse data sometimes appends
-/// extra sections after a blank line — an "Explanation:" list, a restated
-/// "USER DATA:" echo of the prompt, a "Suggested action:" block. Return the
-/// first paragraph (everything before the first blank line); as a guard,
-/// also cut at any leaked prompt-structure marker in case an echo isn't
-/// preceded by a blank line. A real briefing never contains these markers.
-fn first_paragraph(text: &str) -> &str {
-    let t = text.trim_start();
-    let mut end = t.find("\n\n").unwrap_or(t.len());
-    for marker in [
-        "USER DATA",
-        "YESTERDAY'S REFLECTION",
-        "TODAY:",
-        "BRIEFING:",
-        "[Session]",
-        "[Day]",
-        "[Reflection]",
-    ] {
-        if let Some(i) = t.find(marker) {
-            end = end.min(i);
-        }
-    }
-    t[..end].trim_end()
-}
 
 /// RAII guard that flips the `in_flight` flag back to `false` on drop —
 /// even if the orchestrator panics.
@@ -218,31 +192,6 @@ mod tests {
         let db = store::open(&path).expect("open db");
         std::mem::forget(tmp);
         db
-    }
-
-    #[test]
-    fn first_paragraph_strips_appended_sections() {
-        // Real GPU leak: briefing, then an "Explanation:" list after a blank line.
-        let leaked = "In the past week you had 5 sessions. Today, limit app usage.\n\n\nExplanation:\n- focus time decreased\n- app usage increased";
-        assert_eq!(
-            first_paragraph(leaked),
-            "In the past week you had 5 sessions. Today, limit app usage."
-        );
-
-        // Real screenshot leak: briefing, then a "User Data:" echo of the chunks.
-        let leaked2 = "Your focus time decreased. Today, set a timer.\n\nUser Data:\n[Day] Sat. 3 sessions.";
-        assert_eq!(
-            first_paragraph(leaked2),
-            "Your focus time decreased. Today, set a timer."
-        );
-
-        // Defense-in-depth: an inline chunk echo with no blank line before it.
-        let leaked3 = "Focus dropped this week. [Session] Sat 10:00-10:15 echo.";
-        assert_eq!(first_paragraph(leaked3), "Focus dropped this week.");
-
-        // A clean single-paragraph briefing is returned unchanged.
-        let clean = "You had 5 sessions averaging 10 minutes. Today, take a break between blocks.";
-        assert_eq!(first_paragraph(clean), clean);
     }
 
     #[tokio::test]

--- a/desktop-app-v3/src-tauri/src/ai/prompts.rs
+++ b/desktop-app-v3/src-tauri/src/ai/prompts.rs
@@ -69,9 +69,60 @@ pub fn render_reflection_prompt(ctx: &ReflectionContext<'_>) -> String {
     REFLECTION_TEMPLATE.replace("{chunks}", &chunks_block)
 }
 
+/// Keep only the first paragraph of an LLM completion. Phi-3-mini-q4 reliably
+/// produces the intended answer first (a 2-3 sentence briefing, or a single
+/// reflection question), then under thin/sparse data sometimes appends extra
+/// sections after a blank line — an "Explanation:" list, a restated "USER
+/// DATA:" echo of the prompt chunks, a "Solution N:" follow-up. Return the text
+/// before the first blank line; as a guard, also cut at any leaked
+/// prompt-structure marker in case an echo isn't preceded by a blank line. A
+/// real answer never contains these markers.
+pub(crate) fn first_paragraph(text: &str) -> &str {
+    let t = text.trim_start();
+    let mut end = t.find("\n\n").unwrap_or(t.len());
+    for marker in [
+        "USER DATA",
+        "YESTERDAY'S REFLECTION",
+        "TODAY'S DATA",
+        "TODAY:",
+        "BRIEFING:",
+        "QUESTION:",
+        "[Session]",
+        "[Day]",
+        "[Reflection]",
+    ] {
+        if let Some(i) = t.find(marker) {
+            end = end.min(i);
+        }
+    }
+    t[..end].trim_end()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn first_paragraph_strips_appended_sections() {
+        // Real GPU briefing leak: an "Explanation:" list after a blank line.
+        let leaked = "In the past week you had 5 sessions. Today, limit app usage.\n\n\nExplanation:\n- focus time decreased";
+        assert_eq!(
+            first_paragraph(leaked),
+            "In the past week you had 5 sessions. Today, limit app usage."
+        );
+        // Real reflection leak: question then a "Solution 1:" follow-up.
+        let q = "What caused the Thursday session to end 25 minutes early?\n\n\nSolution 1:\nWhat led to the 15-minute session ending early?";
+        assert_eq!(
+            first_paragraph(q),
+            "What caused the Thursday session to end 25 minutes early?"
+        );
+        // Inline chunk echo with no blank line (defense-in-depth guard).
+        let inline = "Focus dropped this week. [Session] Sat 10:00-10:15 echo.";
+        assert_eq!(first_paragraph(inline), "Focus dropped this week.");
+        // Clean single-paragraph output is unchanged.
+        let clean = "You had 5 sessions averaging 10 minutes. Today, take a break.";
+        assert_eq!(first_paragraph(clean), clean);
+    }
 
     #[test]
     fn briefing_template_substitutes_all_placeholders() {

--- a/desktop-app-v3/src-tauri/src/ai/reflection.rs
+++ b/desktop-app-v3/src-tauri/src/ai/reflection.rs
@@ -3,7 +3,7 @@
 //! pending ai_reflections row (answer = "") for the user to answer.
 
 use crate::ai::candle_llm::CandleLlmRuntime;
-use crate::ai::prompts::{render_reflection_prompt, ReflectionContext};
+use crate::ai::prompts::{first_paragraph, render_reflection_prompt, ReflectionContext};
 use crate::ai::runtime::LlmRuntime;
 use crate::error::{AiError, AppError};
 use crate::store::ai::{self as store_ai, ChunkSource, ModelStatus, Reflection};
@@ -35,7 +35,9 @@ pub async fn build_question<L: LlmRuntime + ?Sized>(
 ) -> Result<String, AiError> {
     let prompt = render_reflection_prompt(&ReflectionContext { chunks: session_texts });
     let raw = llm.generate(&prompt, REFLECTION_MAX_TOKENS).await?;
-    Ok(raw.trim().to_string())
+    // Keep only the question — the model sometimes appends a "Solution N:"
+    // follow-up after a blank line (see first_paragraph).
+    Ok(first_paragraph(&raw).to_string())
 }
 
 /// Build a *pending* reflection row (answer empty) for `date`.
@@ -157,6 +159,19 @@ mod tests {
         let texts = vec!["[Session] Tue 2026-06-23 09:00-09:20 (60min planned, 20min actual).".to_string()];
         let q = build_question(&llm, &texts).await.unwrap();
         assert_eq!(q, "What blocked your 9am session?");
+    }
+
+    #[tokio::test]
+    async fn build_question_strips_appended_solution_block() {
+        // The model sometimes appends a "Solution N:" follow-up after the
+        // question — first_paragraph keeps only the question.
+        let llm = MockLlmRuntime {
+            canned_response: "What caused the early finish?\n\n\nSolution 1:\nWhat led to it?".to_string(),
+            id: "mock-llm-v0",
+        };
+        let texts = vec!["[Session] Tue 2026-06-23 09:00-09:20 (60min planned, 20min actual).".to_string()];
+        let q = build_question(&llm, &texts).await.unwrap();
+        assert_eq!(q, "What caused the early finish?");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #106. The reflection generator has the **same over-production leak** as the briefing — Phi-3-q4 writes the question, then appends a `Solution N:` follow-up after a blank line, stored as the question (visible as contaminated reflection rows like `"What caused...?\n\n\nSolution 1:\nWhat led to..."`).

### Change
- Move `first_paragraph` to the shared `prompts` module (`pub(crate)`).
- Apply it in **both** briefing generation (unchanged behavior — same fn, now shared) and reflection's `build_question`.
- Reflection questions are now truncated to the question itself.

### Tests
- `prompts::first_paragraph_strips_appended_sections` (briefing + reflection leak fixtures).
- `reflection::build_question_strips_appended_solution_block`.
- Full suite **126 passed**, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)