### PR TITLE
Security audit remediation: auth, rate-limiting, injection, headers

### DIFF
--- a/web-app/SECURITY_AUDIT.md
+++ b/web-app/SECURITY_AUDIT.md
@@ -1,0 +1,124 @@
+# FlowShield Web App — Security Audit
+
+**Date:** 2026-06-27 · **Scope:** `web-app/` (Next.js 16, Prisma/Postgres, custom JWT, Netlify)
+**Method:** 4 parallel reviewers — auth/authz, injection/input, secrets/config/headers, rate-limit/abuse.
+Findings deduplicated and prioritized. Line numbers are from the audited tree; re-check before editing.
+
+---
+
+## TL;DR — fix in this order
+
+1. **Rotate live credentials** (Neon DB password, Upstash token, Google AI key) + `chmod 600` the env files. They sat in world-readable files on disk.
+2. **Replace the in-memory rate limiter with Upstash Redis.** It is a no-op on serverless today — every brute-force/abuse limit silently fails open. Single highest-leverage fix (covers 6+ endpoints).
+3. **Stop leaking `hashedPassword` + reset tokens** from `/api/user/profile`.
+4. **Timing-safe `CRON_SECRET` compare**, JWT algorithm pinning, OAuth `state`, input validation on the unvalidated POST routes.
+
+---
+
+## CRITICAL
+
+### C1 — In-memory rate limiter is a no-op on serverless (auth brute-force, cost abuse)
+`src/lib/rate-limit.ts:10` — module-level `Map`. Netlify spawns fresh instances → counter resets to 0 per cold start. Every limit (login 10/15m, signup, forgot/reset-password, resend-verify, team-join) fails open.
+Compounded by `src/lib/rate-limit.ts:50-56`: `getClientIp` trusts raw `X-Forwarded-For` first element → attacker spoofs a new IP per request, bypassing the limiter even if it worked.
+**Fix:** `@upstash/ratelimit` (Redis already wired at `src/lib/redis.ts`). Key authenticated endpoints by userId; for unauth use Netlify's `x-nf-client-connection-ip` (or last XFF element). Removing the Map fixes C1 + the spoof at once.
+
+### C2 — Live credentials in world-readable env files
+`.env` and `.env.local` are `-rwxrwxrwx`. Gitignored and **not** in git history (verified) — exposure is local-disk only, but any process/user on the box can read them. Contains real Neon `DATABASE_URL`, `JWT_SECRET`, `NEXTAUTH_SECRET`, `UPSTASH_REDIS_REST_TOKEN`, `GOOGLE_AI_API_KEY`.
+**Fix:** `chmod 600 web-app/.env web-app/.env.local`. **Rotate** the Neon password, Upstash token, Google AI key (they were exposed); rotate `JWT_SECRET`/`NEXTAUTH_SECRET` if the box is shared/CI-accessible.
+
+### C3 — `/api/user/profile` returns full User row (hashedPassword + reset tokens)
+`src/app/api/user/profile/route.ts:32` — `findUnique({ include: { preferences:true }})` with no `select` → returns `hashedPassword`, `verificationToken`, `passwordResetToken`, `passwordResetExpires` to the client. Login route strips these; profile route does not.
+**Fix:** explicit `select` of safe fields only.
+
+### C4 — `CRON_SECRET` compared with `!==` (timing side-channel)
+`src/app/api/cron/weekly-digest/route.ts:18`, `src/app/api/cron/expire-subscriptions/route.ts:32`. String `===` is not constant-time → char-by-char enumeration over many requests.
+**Fix:** `crypto.timingSafeEqual` with length pre-check.
+
+### C5 — Admin announcement email: no schema, raw HTML to all users
+`src/app/api/admin/email/announce/route.ts:12-19` — body is a type assertion (`as`), no Zod, `html` forwarded unsanitized to bulk `sendEmail`. Compromised/insider admin → phishing/XSS HTML to every user.
+**Fix:** Zod-validate + sanitize (`sanitize-html`) before send. (Bounded to admin auth, but highest blast radius — treat as Critical.)
+
+---
+
+## HIGH
+
+### H1 — JWT verified without algorithm pinning
+`src/lib/jwt.ts:41,62`, `src/app/api/coach/advice/route.ts:23` — `verify(token, secret)` with no `{ algorithms:['HS256'] }`. Latent alg-confusion / `alg:none` risk on any lib downgrade/fork. Also pin on `sign` (`login/route.ts:70`, `google/callback/route.ts:101`).
+
+### H2 — JWT passed in URL query string (`?token=`)
+`src/app/api/coach/advice/route.ts:17-28` — SSE can't set Authorization header, so full JWT lands in browser history, access logs, CDN/proxy logs. Token valid up to 30 days.
+**Fix:** short-lived (≤2 min) SSE-scoped exchange token via POST, or httpOnly cookie the EventSource inherits.
+
+### H3 — OAuth callback has no `state` (login CSRF)
+`src/app/api/auth/google/route.ts:14-26` — no `state` param → attacker can force-login a victim into the attacker's account.
+**Fix:** generate `state`, store in Redis/signed cookie, verify in callback before code exchange.
+
+### H4 — SSRF via unvalidated push subscription endpoint
+`src/app/api/push/subscribe/route.ts:13-40` — arbitrary `endpoint` URL stored, later called by `webpush.sendNotification` in `/api/push/send`. Authenticated attacker points it at internal hosts / metadata endpoints.
+**Fix:** allowlist known push domains (google/mozilla/windows/apple); reject RFC-1918 / localhost.
+
+### H5 — Mass-assignment / no validation on `POST /api/sessions`
+`src/app/api/sessions/route.ts:17-25` — `CreateSessionSchema` exists in `src/lib/schemas.ts:20` but is never used. `plannedDuration`/`sessionType`/`projectId` go raw to Prisma → 500s + stack traces on bad input.
+**Fix:** `CreateSessionSchema.safeParse(body)`.
+
+### H6 — `/api/activity/sync`: unbounded array + unvalidated fields (DoS, leaderboard fraud)
+`src/app/api/activity/sync/route.ts:19-68` — no `length` cap, no field validation, no rate limit. One request with 100k rows → mass `createMany`, table bloat. `durationSeconds` unchecked → submit `999999999` to top the leaderboard (`src/app/api/leaderboard/route.ts`).
+**Fix:** Zod `z.array().max(500)`; clamp `durationSeconds` to a per-entry/per-day ceiling; truncate strings; rate-limit by userId.
+
+### H7 — No CSP header
+`next.config.ts:4-29` — has X-Frame-Options/HSTS/etc but no `Content-Security-Policy`. Any injected/3rd-party script runs unrestricted.
+**Fix:** add CSP (`default-src 'self'`; allow pusher/upstash/sentry in `connect-src`; `frame-ancestors 'none'`). Drop legacy `X-XSS-Protection`.
+
+### H8 — `/api/health` leaks DB error message, unauthenticated
+`src/app/api/health/route.ts:18-25` — returns `error.message` → can expose DB host/SSL details.
+**Fix:** return generic status; no `error.message`.
+
+### H9 — FREE-tier coach quota race (LLM cost abuse)
+`src/app/api/coach/advice/route.ts:60-269` — `lastCoachCallAt` written only after stream completes; N concurrent requests all pass the quota check → N parallel Gemini streams.
+**Fix:** Redis `SET NX EX` lock per userId before the call; add per-user req rate limit.
+
+### H10 — Stored XSS in email templates
+`src/app/api/admin/settings/route.ts` + `src/lib/settings.ts:97` (`applyTemplate` literal replace, no escaping) + `src/app/api/auth/signup/route.ts:90`. Admin-stored `email.welcome.body`/`digest.body` emitted as raw HTML to every signup; user `name` interpolated unescaped.
+**Fix:** sanitize stored bodies; HTML-escape all template vars.
+
+### H11 — `netlify.toml` catch-all SPA redirect shadows Next.js routes
+`netlify.toml:15-18` — `from "/*" to "/index.html" 200`. Wrong for App Router + `@netlify/plugin-nextjs`; API routes can return the HTML shell with 200.
+**Fix:** remove the `[[redirects]]` block.
+
+---
+
+## MEDIUM
+
+| ID | File | Issue | Fix |
+|----|------|-------|-----|
+| M1 | `api/devices/route.ts:61-68` | IDOR — POST reassigns an existing `deviceId` to caller without ownership check (device hijack) | check `existingDevice.userId === userId` first |
+| M2 | `api/sessions/[id]/toggle-pause/route.ts:19-65` | Read-then-write race doubles pause adjustment | wrap in `$transaction` |
+| M3 | `api/auth/signup/route.ts:39` | Account enumeration — 409 on existing email (login/forgot correctly generic) | generic response |
+| M4 | `api/sessions/route.ts:83` | `limit` query unclamped → `take: huge`/`NaN` | `Math.min(Math.max(n,1),200)` |
+| M5 | `api/teams/route.ts:48` | No cap on teams created per user | per-owner count cap |
+| M6 | `api/push/subscribe` | No per-user subscription cap → fan-out amplification in `/send` | cap (~10) |
+| M7 | `api/coach/advice/route.ts:203` | Prompt injection via user-controlled category strings | normalize categories to allowlist before prompt |
+| M8 | `api/leaderboard/route.ts:73-86` | Leaks every top-10 user's DB UUID to peers | drop `userId`, keep only `isCurrentUser` |
+| M9 | `api/auth/signup/route.ts:103` | User name/email interpolated unescaped into admin-notify HTML | HTML-escape or text-only |
+| M10 | `api/goals/route.ts:23` | Raw `goalType` query → Prisma 500 on bad enum | validate against enum |
+| M11 | `push/send`, `lib/pushNotify.ts` | Server uses `NEXT_PUBLIC_` VAPID key | split server/client env vars |
+| M12 | `netlify.toml:9` | `PUSHER_KEY` missing from `SECRETS_SCAN_OMIT_KEYS` (per own gotchas rule) | `"NEXTAUTH_URL,PUSHER_KEY"` |
+
+## LOW
+
+| ID | File | Issue |
+|----|------|-------|
+| L1 | `api/auth/login/route.ts:73` | 30-day `rememberMe` JWT not revoked on password change/reset (no tokenVersion/blocklist) |
+| L2 | `api/auth/reset-password/route.ts:17` | 10/hr limit vs forgot's 3/hr (tokens are 256-bit, low real risk) |
+| L3 | `api/export/route.ts:61-74` | CSV cells not RFC-4180 escaped → malformed CSV / formula injection if user strings added |
+| L4 | `api/auth/login/route.ts:59` | Email verification off by default (`REQUIRE_EMAIL_VERIFICATION`) |
+| L5 | `api/sessions/route.ts:88` | Unvalidated `date` query → `new Date()` → 500 |
+
+---
+
+## Clean (checked, no issue)
+- No raw SQL injection — all `$queryRaw` use tagged templates (parameterized).
+- No `dangerouslySetInnerHTML`; no dynamic `fetch()` to user URLs (except H4 push path).
+- Session/teams/admin IDOR — ownership + `UserRole==ADMIN` checks present (except M1 devices).
+- bcrypt cost=12; verification/reset tokens 32-byte crypto-random.
+- No filesystem ops with user input; no user-controlled RegExp.

--- a/web-app/netlify.toml
+++ b/web-app/netlify.toml
@@ -6,12 +6,11 @@
 [build.environment]
   NODE_VERSION = "20"
   SECRETS_SCAN_OMIT_PATHS = "DEPLOYMENT.md,.env.production.example"
-  SECRETS_SCAN_OMIT_KEYS = "NEXTAUTH_URL"
+  SECRETS_SCAN_OMIT_KEYS = "NEXTAUTH_URL,PUSHER_KEY"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+# No catch-all SPA redirect: @netlify/plugin-nextjs owns App Router routing.
+# A `/* -> /index.html 200` rule would shadow API routes (return the HTML shell
+# with 200 instead of JSON), silently breaking auth/error handling.

--- a/web-app/next.config.ts
+++ b/web-app/next.config.ts
@@ -1,7 +1,32 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
+// Content-Security-Policy (enforcing). Allowances:
+//   - script/style 'unsafe-inline': Next.js App Router injects inline hydration
+//     scripts and styled-jsx without nonces; required until nonce-based CSP.
+//   - 'unsafe-eval': some bundled deps (source-map/Sentry) need it in the client.
+//   - js.pusher.com: Pusher client SDK; *.pusher.com + wss for its connections.
+//   - *.sentry.io: Sentry browser SDK error ingestion.
+//   - img https: + data:: Google avatar URLs and inline data images.
+// If a feature breaks, check the browser console for the blocked directive.
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.pusher.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.pusher.com wss://*.pusher.com https://*.sentry.io",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ');
+
 const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: csp,
+  },
   {
     key: 'X-Content-Type-Options',
     value: 'nosniff',
@@ -9,10 +34,6 @@ const securityHeaders = [
   {
     key: 'X-Frame-Options',
     value: 'DENY',
-  },
-  {
-    key: 'X-XSS-Protection',
-    value: '1; mode=block',
   },
   {
     key: 'Referrer-Policy',

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@sentry/nextjs": "^10.42.0",
+        "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.3",
         "bcryptjs": "^2.4.3",
         "date-fns": "^3.0.0",
@@ -23,6 +24,7 @@
         "react-dom": "^19.2.3",
         "recharts": "^2.10.3",
         "resend": "^6.6.0",
+        "sanitize-html": "^2.17.5",
         "swr": "^2.3.7",
         "web-push": "^3.6.7",
         "zod": "^4.3.6",
@@ -37,6 +39,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/sanitize-html": "^2.16.1",
         "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^5.1.4",
         "autoprefixer": "^10.4.16",
@@ -3765,6 +3768,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
@@ -4321,6 +4334,30 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
     },
     "node_modules/@upstash/redis": {
       "version": "1.36.3",
@@ -5707,6 +5744,12 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5736,6 +5779,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -5825,6 +5877,73 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -5885,6 +6004,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6128,7 +6259,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7249,6 +7379,25 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/http_ece": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
@@ -7628,6 +7777,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -8024,6 +8182,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/levn": {
@@ -8765,6 +8932,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8929,6 +9102,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8953,7 +9127,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9720,6 +9893,21 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@sentry/nextjs": "^10.42.0",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.3",
     "bcryptjs": "^2.4.3",
     "date-fns": "^3.0.0",
@@ -26,6 +27,7 @@
     "react-dom": "^19.2.3",
     "recharts": "^2.10.3",
     "resend": "^6.6.0",
+    "sanitize-html": "^2.17.5",
     "swr": "^2.3.7",
     "web-push": "^3.6.7",
     "zod": "^4.3.6",
@@ -40,6 +42,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/sanitize-html": "^2.16.1",
     "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.16",

--- a/web-app/src/app/api/activity/sync/route.ts
+++ b/web-app/src/app/api/activity/sync/route.ts
@@ -1,9 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { resolveCategory } from '@/lib/activity-sync';
+import { rateLimit } from '@/lib/rate-limit';
+
+const MAX_STRING = 2048;
+const MAX_DURATION = 86400; // 1 day in seconds
+
+const activityItemSchema = z.object({
+  timestamp: z.string().refine((v) => {
+    const d = new Date(v);
+    return !isNaN(d.getTime());
+  }, { message: 'timestamp must be a valid date string' }),
+  windowTitle: z.string().max(MAX_STRING).optional(),
+  processName: z.string().max(MAX_STRING).optional(),
+  applicationName: z.string().max(MAX_STRING).optional(),
+  domain: z.string().max(MAX_STRING).optional(),
+  url: z.string().max(MAX_STRING).optional(),
+  category: z.string().max(MAX_STRING).optional(),
+  durationSeconds: z
+    .number()
+    .int()
+    .finite()
+    .min(0)
+    .transform((v) => Math.min(v, MAX_DURATION)),
+  activityLevel: z.number().min(0).max(100).optional(),
+  sessionId: z.string().max(MAX_STRING).optional().nullable(),
+});
+
+const syncBodySchema = z.object({
+  activities: z.array(activityItemSchema).min(1).max(500),
+  source: z.string().max(64).optional(),
+});
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,18 +47,28 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { activities } = body;
-
-    if (!Array.isArray(activities) || activities.length === 0) {
+    // Per-user rate limit: 120 requests per minute
+    const rl = await rateLimit('activity-sync:' + userId, 120, 60 * 1000);
+    if (!rl.allowed) {
       return NextResponse.json(
-        { error: 'No activities provided' },
+        { error: 'Rate limit exceeded' },
+        { status: 429 }
+      );
+    }
+
+    const raw = await request.json();
+    const parsed = syncBodySchema.safeParse(raw);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? 'Invalid request body' },
         { status: 400 }
       );
     }
 
+    const { activities, source: rawSource } = parsed.data;
     // Source identifies the client sending data: desktop | browser | mobile
-    const source: string = (body.source as string) || 'desktop';
+    const source: string = rawSource || 'desktop';
 
     // Load CategoryRules once for the whole batch (browser source only)
     const categoryRules = source === 'browser'
@@ -38,7 +79,7 @@ export async function POST(request: NextRequest) {
       : [];
 
     // Store activities in database
-    const activityLogs = activities.map((activity: any) => ({
+    const activityLogs = activities.map((activity) => ({
       userId,
       timestamp: new Date(activity.timestamp),
       windowTitle: activity.windowTitle || activity.url || 'Unknown',

--- a/web-app/src/app/api/admin/email/announce/route.ts
+++ b/web-app/src/app/api/admin/email/announce/route.ts
@@ -1,7 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import sanitizeHtml from 'sanitize-html';
 import { prisma } from '@/lib/prisma';
 import { getAdminFromToken } from '@/lib/jwt';
 import { sendEmail } from '@/lib/email';
+
+const AnnounceSchema = z.object({
+  subject: z.string().min(1).max(200),
+  html: z.string().max(50000),
+  tier: z.enum(['FREE', 'PRO', 'TEAM']).optional(),
+});
+
+const EMAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'h1', 'h2', 'h3', 'h4', 'p', 'a', 'b', 'i', 'strong', 'em',
+    'ul', 'ol', 'li', 'br', 'span', 'div', 'img', 'hr',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  ],
+  allowedAttributes: {
+    'a': ['href'],
+    'img': ['src', 'alt', 'width', 'height'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemesByTag: {
+    img: ['http', 'https'],
+  },
+};
 
 export async function POST(request: NextRequest) {
   const adminId = getAdminFromToken(request);
@@ -9,15 +33,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const { subject, html, tier } = await request.json() as {
-    subject: string;
-    html: string;
-    tier?: 'FREE' | 'PRO' | 'TEAM';
-  };
-
-  if (!subject || !html) {
-    return NextResponse.json({ error: 'subject and html are required' }, { status: 400 });
+  const body = await request.json();
+  const parsed = AnnounceSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
   }
+
+  const { subject, tier } = parsed.data;
+  const html = sanitizeHtml(parsed.data.html, EMAIL_SANITIZE_OPTIONS);
 
   const users = await prisma.user.findMany({
     where: {

--- a/web-app/src/app/api/auth/forgot-password/route.ts
+++ b/web-app/src/app/api/auth/forgot-password/route.ts
@@ -18,7 +18,7 @@ const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
 export async function POST(request: NextRequest) {
   try {
     const ip = getClientIp(request);
-    const rl = rateLimit(`forgot-password:${ip}`, 3, 60 * 60 * 1000);
+    const rl = await rateLimit(`forgot-password:${ip}`, 3, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many password-reset requests. Please try again later.' },

--- a/web-app/src/app/api/auth/google/callback/route.ts
+++ b/web-app/src/app/api/auth/google/callback/route.ts
@@ -18,6 +18,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_cancelled`);
   }
 
+  const state = searchParams.get('state');
+  if (!state) {
+    return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_invalid_state`);
+  }
+
   try {
     const clientId = process.env.GOOGLE_CLIENT_ID;
     const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
@@ -27,6 +32,13 @@ export async function GET(request: NextRequest) {
       logger.error('Google OAuth env vars missing');
       return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_config`);
     }
+
+    // Validate and consume OAuth state (CSRF protection)
+    const storedState = await redis.get('oauth-state:' + state);
+    if (!storedState) {
+      return NextResponse.redirect(`${appUrl}/auth/login?error=oauth_invalid_state`);
+    }
+    await redis.del('oauth-state:' + state);
 
     // Exchange code for tokens
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
@@ -101,7 +113,7 @@ export async function GET(request: NextRequest) {
     const jwtToken = sign(
       { userId: user.id, email: user.email, role: user.role },
       getJwtSecret(),
-      { expiresIn: '7d' }
+      { expiresIn: '7d', algorithm: 'HS256' }
     );
 
     const isNewUser = !user.preferences?.workStyle;

--- a/web-app/src/app/api/auth/google/route.ts
+++ b/web-app/src/app/api/auth/google/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { redis } from '@/lib/redis';
 
 export async function GET() {
   const clientId = process.env.GOOGLE_CLIENT_ID;
@@ -11,6 +13,9 @@ export async function GET() {
   const redirectUri = `${appUrl}/api/auth/google/callback`;
   const scope = 'openid email profile';
 
+  const state = randomBytes(16).toString('hex');
+  await redis.set('oauth-state:' + state, '1', { ex: 600 });
+
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -18,6 +23,7 @@ export async function GET() {
     scope,
     access_type: 'offline',
     prompt: 'select_account',
+    state,
   });
 
   return NextResponse.redirect(

--- a/web-app/src/app/api/auth/login/route.test.ts
+++ b/web-app/src/app/api/auth/login/route.test.ts
@@ -88,7 +88,23 @@ describe('POST /api/auth/login — email-verified gate', () => {
     delete process.env.REQUIRE_EMAIL_VERIFICATION;
   });
 
-  it('allows unverified users when REQUIRE_EMAIL_VERIFICATION is unset (default off)', async () => {
+  it('blocks unverified users by default when REQUIRE_EMAIL_VERIFICATION is unset (default ON)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'USER',
+      hashedPassword: 'hashed',
+      emailVerified: null,
+      preferences: null,
+    });
+    const res = await POST(makeRequest({ email: 'user@example.com', password: 'password123' }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.code).toBe('EMAIL_NOT_VERIFIED');
+  });
+
+  it('allows unverified users only when verification is explicitly disabled (=false)', async () => {
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'false';
     mocks.findUnique.mockResolvedValueOnce({
       id: 'user-1',
       email: 'user@example.com',

--- a/web-app/src/app/api/auth/login/route.ts
+++ b/web-app/src/app/api/auth/login/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: NextRequest) {
   try {
     // Rate limit: 10 attempts per 15 minutes per IP
     const ip = getClientIp(request);
-    const rl = rateLimit(`login:${ip}`, 10, 15 * 60 * 1000);
+    const rl = await rateLimit(`login:${ip}`, 10, 15 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many login attempts. Please try again later.' },
@@ -29,10 +29,19 @@ export async function POST(request: NextRequest) {
     }
     const { email, password, rememberMe } = parsed.data;
 
-    // Find user
+    // Find user — explicit select to avoid leaking token/reset fields
     const user = await prisma.user.findUnique({
       where: { email },
-      include: {
+      select: {
+        id: true,
+        email: true,
+        hashedPassword: true,
+        name: true,
+        timezone: true,
+        role: true,
+        createdAt: true,
+        emailVerified: true,
+        subscriptionTier: true,
         preferences: true,
       },
     });
@@ -54,9 +63,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Email-verified gate (off by default until mobile + desktop clients
-    // ship error-code handling). Set REQUIRE_EMAIL_VERIFICATION=true to enable.
-    if (process.env.REQUIRE_EMAIL_VERIFICATION === 'true' && !user.emailVerified) {
+    // Email-verified gate (ON by default). Set REQUIRE_EMAIL_VERIFICATION=false to disable.
+    if (process.env.REQUIRE_EMAIL_VERIFICATION !== 'false' && !user.emailVerified) {
       return NextResponse.json(
         {
           error: 'Please verify your email before signing in.',
@@ -70,7 +78,7 @@ export async function POST(request: NextRequest) {
     const token = sign(
       { userId: user.id, email: user.email, role: user.role },
       getJwtSecret(),
-      { expiresIn: rememberMe ? '30d' : '7d' } // 30 days if rememberMe is true, else 7 days
+      { expiresIn: rememberMe ? '30d' : '7d', algorithm: 'HS256' } // 30 days if rememberMe is true, else 7 days
     );
 
     // Return user data (excluding password) and token

--- a/web-app/src/app/api/auth/resend-verification/route.ts
+++ b/web-app/src/app/api/auth/resend-verification/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const rl = rateLimit(`resend-verify:${userId}`, 3, 60 * 60 * 1000);
+    const rl = await rateLimit(`resend-verify:${userId}`, 3, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },

--- a/web-app/src/app/api/auth/reset-password/route.ts
+++ b/web-app/src/app/api/auth/reset-password/route.ts
@@ -14,7 +14,7 @@ import { ResetPasswordSchema } from '@/lib/schemas';
 export async function POST(request: NextRequest) {
   try {
     const ip = getClientIp(request);
-    const rl = rateLimit(`reset-password:${ip}`, 10, 60 * 60 * 1000);
+    const rl = await rateLimit(`reset-password:${ip}`, 3, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },

--- a/web-app/src/app/api/auth/signup/route.ts
+++ b/web-app/src/app/api/auth/signup/route.ts
@@ -6,13 +6,23 @@ import crypto from 'crypto';
 import { sendEmail } from '@/lib/email';
 import { rateLimit, getClientIp } from '@/lib/rate-limit';
 import { SignupSchema } from '@/lib/schemas';
-import { getSettings, applyTemplate } from '@/lib/settings';
+import { getSettings, applyTemplate, applyTemplatePlain } from '@/lib/settings';
+
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 export async function POST(request: NextRequest) {
   try {
     // Rate limit: 5 signups per hour per IP
     const ip = getClientIp(request);
-    const rl = rateLimit(`signup:${ip}`, 5, 60 * 60 * 1000);
+    const rl = await rateLimit(`signup:${ip}`, 5, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many signup attempts. Please try again later.' },
@@ -37,8 +47,8 @@ export async function POST(request: NextRequest) {
 
     if (existingUser) {
       return NextResponse.json(
-        { error: 'User with this email already exists' },
-        { status: 409 }
+        { message: 'If that email can be registered, check your inbox to continue.' },
+        { status: 200 }
       );
     }
 
@@ -90,7 +100,7 @@ export async function POST(request: NextRequest) {
     if (emailSettings.email.welcome.enabled) {
       await sendEmail({
         to: email,
-        subject: applyTemplate(emailSettings.email.welcome.subject, vars),
+        subject: applyTemplatePlain(emailSettings.email.welcome.subject, vars),
         html: applyTemplate(emailSettings.email.welcome.body, vars),
       });
     }
@@ -101,8 +111,8 @@ export async function POST(request: NextRequest) {
         subject: 'New User Registration - FlowShield',
         html: `
           <h1>New User Registered</h1>
-          <p>Email: ${email}</p>
-          <p>Name: ${name || 'N/A'}</p>
+          <p>Email: ${escapeHtml(email)}</p>
+          <p>Name: ${escapeHtml(name || 'N/A')}</p>
           <p>Time: ${new Date().toLocaleString()}</p>
         `,
       });

--- a/web-app/src/app/api/coach/advice/route.test.ts
+++ b/web-app/src/app/api/coach/advice/route.test.ts
@@ -6,23 +6,27 @@ process.env.GOOGLE_AI_API_KEY = 'test-gemini-key';
 const mocks = vi.hoisted(() => ({
   redisGet: vi.fn(),
   redisSetex: vi.fn(async (_key: string, _ttl: number, _text: string) => 'OK'),
+  redisSet: vi.fn(async () => 'OK' as 'OK' | null),
+  redisDel: vi.fn(async () => 1),
   generateContentStream: vi.fn(),
   userFindUnique: vi.fn(),
   sessionFindMany: vi.fn(),
   dailyStatsFindMany: vi.fn(),
   activityLogFindMany: vi.fn(),
+  rateLimitFn: vi.fn(async () => ({ allowed: true, remaining: 4, resetInMs: 0 })),
 }));
 
 vi.mock('@/lib/redis', () => ({
   redis: {
     get: mocks.redisGet,
     setex: mocks.redisSetex,
+    set: mocks.redisSet,
+    del: mocks.redisDel,
   },
 }));
 
 vi.mock('@/lib/jwt', () => ({
   getUserIdFromToken: vi.fn(() => 'user-1'),
-  getJwtSecret: vi.fn(() => 'test-secret'),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -45,6 +49,10 @@ vi.mock('@google/generative-ai', () => {
     },
   };
 });
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: mocks.rateLimitFn,
+}));
 
 const { redisGet, redisSetex, generateContentStream } = mocks;
 
@@ -83,6 +91,9 @@ describe('GET /api/coach/advice', () => {
     vi.clearAllMocks();
     redisGet.mockReset();
     redisSetex.mockClear();
+    mocks.redisSet.mockClear();
+    mocks.redisDel.mockClear();
+    mocks.rateLimitFn.mockClear();
     generateContentStream.mockReset();
   });
 
@@ -204,5 +215,31 @@ describe('GET /api/coach/advice', () => {
     expect(key).toMatch(/^coach:user-1:\d{4}-\d{2}-\d{2}$/);
     expect(ttl).toBe(DAILY_TTL_SECONDS);
     expect(payload).toBe('Pro advice here.');
+  });
+
+  it('returns 429 when per-user rate limit is exceeded', async () => {
+    mockUser('FREE');
+    redisGet.mockResolvedValueOnce(null);
+    mocks.rateLimitFn.mockResolvedValueOnce({ allowed: false, remaining: 0, resetInMs: 60000 });
+    const res = await GET(makeRequest('/api/coach/advice'));
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toBe('Too many requests');
+    expect(generateContentStream).not.toHaveBeenCalled();
+    expect(mocks.redisSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when a coaching request is already in progress (lock held)', async () => {
+    redisGet.mockResolvedValueOnce(null);
+    const now = new Date();
+    primePrisma({
+      sessions: [{ startTime: now, actualDuration: 45, completed: true }],
+    });
+    mocks.redisSet.mockResolvedValueOnce(null); // lock already held
+    const res = await GET(makeRequest('/api/coach/advice'));
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toBe('A coaching request is already in progress');
+    expect(generateContentStream).not.toHaveBeenCalled();
   });
 });

--- a/web-app/src/app/api/coach/advice/route.ts
+++ b/web-app/src/app/api/coach/advice/route.ts
@@ -1,31 +1,16 @@
 import { NextRequest } from 'next/server';
-import { verify } from 'jsonwebtoken';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken, getJwtSecret } from '@/lib/jwt';
+import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { redis } from '@/lib/redis';
+import { rateLimit } from '@/lib/rate-limit';
 import {
   coachCacheKey,
   coachCacheTtl,
   freeTierCanCall,
   nextFreeTierResetAt,
 } from '@/lib/coach-quota';
-
-// EventSource cannot set Authorization headers, so the client can pass the JWT
-// as ?token=... on this SSE endpoint. Fall back to that when the header is absent.
-function getUserIdFromRequestOrQuery(request: NextRequest): string | null {
-  const fromHeader = getUserIdFromToken(request);
-  if (fromHeader) return fromHeader;
-  const queryToken = new URL(request.url).searchParams.get('token');
-  if (!queryToken) return null;
-  try {
-    const decoded = verify(queryToken, getJwtSecret()) as { userId: string };
-    return decoded.userId;
-  } catch {
-    return null;
-  }
-}
 
 async function readCache(userId: string, tier: string): Promise<string | null> {
   try {
@@ -56,6 +41,13 @@ async function writeCache(userId: string, tier: string, text: string): Promise<v
  * Quota for FREE tier is durable: enforced via `User.lastCoachCallAt` in the
  * database, so a Redis outage cannot grant unlimited calls. Cache is purely a
  * perf layer.
+ *
+ * Auth: Authorization: Bearer <jwt> header only. Both web and desktop clients
+ * use fetch/HttpClient with the Authorization header — no ?token= fallback.
+ *
+ * Concurrency: a per-user Redis lock (coach-lock:<userId>, 60s TTL) prevents N
+ * concurrent requests from all passing freeTierCanCall and opening N Gemini streams.
+ * Per-user rate limit: 5 requests/min.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -69,7 +61,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const userId = getUserIdFromRequestOrQuery(request);
+    const userId = getUserIdFromToken(request);
 
     if (!userId) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -135,6 +127,16 @@ export async function GET(request: NextRequest) {
 
     if (cacheOnly) {
       return new Response(null, { status: 204 });
+    }
+
+    // Per-user rate limit: 5 requests/min to prevent burst abuse before we
+    // open a Gemini stream.
+    const rl = await rateLimit('coach:' + userId, 5, 60 * 1000);
+    if (!rl.allowed) {
+      return new Response(
+        JSON.stringify({ error: 'Too many requests' }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     // Gather last 7 days of activity context
@@ -222,16 +224,29 @@ Keep your response to 150–250 words. Do not include a greeting like "Hi [name]
 
 Based on this data, give ${userName} 2–3 specific, actionable coaching tips to improve their productivity this week. Reference their actual numbers.`;
 
+    // Distributed lock: prevents concurrent requests from opening N Gemini streams.
+    // Lock auto-expires in 60s if the stream never completes (e.g. client disconnect).
+    const lockKey = 'coach-lock:' + userId;
+    const locked = await redis.set(lockKey, '1', { nx: true, ex: 60 });
+    if (!locked) {
+      return new Response(
+        JSON.stringify({ error: 'A coaching request is already in progress' }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
     // Stream Gemini's response as SSE + accumulate for cache write.
     // We persist to cache + stamp lastCoachCallAt ONLY on a clean stream
     // completion, never on a mid-stream error — partial advice would burn
     // the FREE user's monthly call without giving them usable text.
-    const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_API_KEY);
-    const encoder = new TextEncoder();
-    let fullText = '';
+    let stream: ReadableStream;
+    try {
+      const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_API_KEY);
+      const encoder = new TextEncoder();
+      let fullText = '';
 
-    const stream = new ReadableStream({
-      async start(controller) {
+      stream = new ReadableStream({
+        async start(controller) {
         let streamErrored = false;
         try {
           const model = genAI.getGenerativeModel({
@@ -256,6 +271,7 @@ Based on this data, give ${userName} 2–3 specific, actionable coaching tips to
         } catch (err) {
           streamErrored = true;
           logger.error('Coach stream error:', err);
+          await redis.del(lockKey);
           const errData = JSON.stringify({ error: 'Stream failed' });
           controller.enqueue(encoder.encode(`data: ${errData}\n\n`));
           controller.close();
@@ -275,10 +291,16 @@ Based on this data, give ${userName} 2–3 specific, actionable coaching tips to
           }
         }
 
+        await redis.del(lockKey);
         controller.enqueue(encoder.encode('data: [DONE]\n\n'));
         controller.close();
       },
     });
+
+    } catch (err) {
+      await redis.del(lockKey);
+      throw err;
+    }
 
     return new Response(stream, {
       headers: {

--- a/web-app/src/app/api/cron/expire-subscriptions/route.ts
+++ b/web-app/src/app/api/cron/expire-subscriptions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { invalidateUserTierCache } from '@/lib/subscription';
+import { safeEqual } from '@/lib/timing-safe';
 
 /**
  * POST /api/cron/expire-subscriptions
@@ -29,7 +30,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (provided !== expected) {
+  if (!safeEqual(provided, expected)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/web-app/src/app/api/cron/weekly-digest/route.ts
+++ b/web-app/src/app/api/cron/weekly-digest/route.ts
@@ -4,6 +4,7 @@ import { sendEmail } from '@/lib/email';
 import { logger } from '@/lib/logger';
 import { generateInsights } from '@/lib/insights';
 import { getSettings } from '@/lib/settings';
+import { safeEqual } from '@/lib/timing-safe';
 
 /**
  * GET /api/cron/weekly-digest
@@ -15,7 +16,7 @@ export async function GET(request: NextRequest) {
   // Validate the cron secret. Header-only — query string would leak the
   // secret into server access logs and CDN logs.
   const secret = request.headers.get('x-cron-secret');
-  if (!process.env.CRON_SECRET || secret !== process.env.CRON_SECRET) {
+  if (!process.env.CRON_SECRET || !safeEqual(secret, process.env.CRON_SECRET)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/web-app/src/app/api/devices/route.ts
+++ b/web-app/src/app/api/devices/route.ts
@@ -59,6 +59,12 @@ export async function POST(request: NextRequest) {
 
     let device;
     if (existingDevice) {
+      if (existingDevice.userId !== userId) {
+        return NextResponse.json(
+          { error: 'Device not found' },
+          { status: 404 }
+        );
+      }
       // Update existing device
       device = await prisma.deviceConnection.update({
         where: { deviceId },

--- a/web-app/src/app/api/export/route.ts
+++ b/web-app/src/app/api/export/route.ts
@@ -3,6 +3,18 @@ import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
+/**
+ * RFC-4180-safe CSV cell: doubles internal quotes, wraps in quotes, and
+ * prefixes with a single quote if the value starts with a formula trigger
+ * character (= + - @ TAB CR) to prevent CSV injection in spreadsheet apps.
+ */
+function csvCell(value: unknown): string {
+  const str = String(value ?? '');
+  const escaped = str.replace(/"/g, '""');
+  const needsPrefix = /^[=+\-@\t\r]/.test(str);
+  return needsPrefix ? `"'${escaped}"` : `"${escaped}"`;
+}
+
 export async function GET(request: NextRequest) {
   try {
     const userId = getUserIdFromToken(request);
@@ -71,7 +83,7 @@ export async function GET(request: NextRequest) {
 
       const csvContent = [
         headers.join(','),
-        ...rows.map((row) => row.map((cell) => `"${cell}"`).join(',')),
+        ...rows.map((row) => row.map(csvCell).join(',')),
       ].join('\n');
 
       return new NextResponse(csvContent, {

--- a/web-app/src/app/api/goals/route.ts
+++ b/web-app/src/app/api/goals/route.ts
@@ -20,7 +20,11 @@ export async function GET(req: NextRequest) {
       active: true,
     };
 
+    const VALID_GOAL_TYPES = ['DAILY_TIME', 'WEEKLY_TIME', 'STREAK', 'PRODUCTIVITY_SCORE'] as const;
     if (type) {
+      if (!VALID_GOAL_TYPES.includes(type as typeof VALID_GOAL_TYPES[number])) {
+        return NextResponse.json({ error: 'Invalid goal type' }, { status: 400 });
+      }
       whereClause.goalType = type;
     }
 

--- a/web-app/src/app/api/health/route.ts
+++ b/web-app/src/app/api/health/route.ts
@@ -13,13 +13,14 @@ export async function GET() {
       database: 'connected',
       timestamp: new Date().toISOString(),
     });
-  } catch (error: any) {
+  } catch (error) {
+    // Log full detail server-side; never return error.message to the client
+    // (it can leak DB host / connection-string details).
     logger.error('Health check failed', error);
     return NextResponse.json(
       {
         status: 'error',
         database: 'disconnected',
-        error: error.message || 'Unknown error',
         timestamp: new Date().toISOString(),
       },
       { status: 500 }

--- a/web-app/src/app/api/leaderboard/route.ts
+++ b/web-app/src/app/api/leaderboard/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
         const cached = await redis.get<RawLeaderboardEntry[]>(cacheKey);
         if (cached) {
             return NextResponse.json({
-                leaderboard: cached.map(e => ({ ...e, isCurrentUser: e.userId === userId })),
+                leaderboard: cached.map(({ userId: uid, ...rest }) => ({ ...rest, isCurrentUser: uid === userId })),
             });
         }
 
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest) {
         await redis.set(cacheKey, rawEntries, { ex: CACHE_TTL });
 
         return NextResponse.json({
-            leaderboard: rawEntries.map(e => ({ ...e, isCurrentUser: e.userId === userId })),
+            leaderboard: rawEntries.map(({ userId: uid, ...rest }) => ({ ...rest, isCurrentUser: uid === userId })),
         });
 
     } catch (error) {

--- a/web-app/src/app/api/push/send/route.ts
+++ b/web-app/src/app/api/push/send/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
 
-        const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+        const publicKey = process.env.VAPID_PUBLIC_KEY || process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
         const privateKey = process.env.VAPID_PRIVATE_KEY;
 
         if (!publicKey || !privateKey) {

--- a/web-app/src/app/api/push/subscribe/route.ts
+++ b/web-app/src/app/api/push/subscribe/route.ts
@@ -2,6 +2,44 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
+import { rateLimit } from '@/lib/rate-limit';
+
+const ALLOWED_PUSH_SUFFIXES = [
+    '.googleapis.com',
+    '.google.com',
+    '.mozilla.com',
+    '.mozaws.net',
+    '.windows.com',
+    '.microsoft.com',
+    '.apple.com',
+];
+
+const PRIVATE_HOSTNAME_PATTERNS = [
+    'localhost',
+    '127.',
+    '10.',
+    '192.168.',
+    '169.254.',
+    '::1',
+];
+
+function isAllowedPushEndpoint(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    const hostname = parsed.hostname.toLowerCase();
+    if (
+        PRIVATE_HOSTNAME_PATTERNS.some((p) => hostname === p || hostname.startsWith(p)) ||
+        hostname.endsWith('.local')
+    ) {
+        return false;
+    }
+    return ALLOWED_PUSH_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
 
 export async function POST(req: NextRequest) {
     try {
@@ -10,10 +48,19 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
 
+        const rl = await rateLimit('push-sub:' + userId, 20, 60 * 60 * 1000);
+        if (!rl.allowed) {
+            return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+        }
+
         const subscription = await req.json();
 
         if (!subscription.endpoint || !subscription.keys) {
             return NextResponse.json({ error: 'Invalid subscription' }, { status: 400 });
+        }
+
+        if (!isAllowedPushEndpoint(subscription.endpoint)) {
+            return NextResponse.json({ error: 'Invalid push endpoint' }, { status: 400 });
         }
 
         // Upsert subscription
@@ -30,6 +77,11 @@ export async function POST(req: NextRequest) {
                 },
             });
         } else {
+            const count = await prisma.pushSubscription.count({ where: { userId } });
+            if (count >= 10) {
+                return NextResponse.json({ error: 'Subscription limit reached' }, { status: 400 });
+            }
+
             await prisma.pushSubscription.create({
                 data: {
                     userId,

--- a/web-app/src/app/api/sessions/[id]/toggle-pause/route.ts
+++ b/web-app/src/app/api/sessions/[id]/toggle-pause/route.ts
@@ -16,15 +16,15 @@ export async function POST(
         const { id } = await params;
         const { action } = await request.json(); // 'pause' or 'resume'
 
-        const session = await prisma.session.findUnique({
-            where: { id },
-        });
-
-        if (!session || session.userId !== userId) {
-            return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-        }
-
         if (action === 'pause') {
+            const session = await prisma.session.findUnique({
+                where: { id },
+            });
+
+            if (!session || session.userId !== userId) {
+                return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+            }
+
             if (session.isPaused) {
                 return NextResponse.json({ message: 'Session already paused' });
             }
@@ -37,32 +37,39 @@ export async function POST(
                 },
             });
         } else if (action === 'resume') {
-            if (!session.isPaused || !session.pausedAt) {
-                return NextResponse.json({ message: 'Session is not paused' });
-            }
+            const updatedSession = await prisma.$transaction(async (tx) => {
+                const session = await tx.session.findUnique({
+                    where: { id },
+                });
 
-            // Calculate how long it was paused
-            const now = new Date();
-            const pausedDurationMs = now.getTime() - new Date(session.pausedAt).getTime();
+                if (!session || session.userId !== userId) {
+                    throw Object.assign(new Error('Session not found'), { status: 404 });
+                }
 
-            // We need to push the startTime (or endTime if it existed?)
-            // Actually, simplest logic for a deadline-based timer:
-            // If we have a 'startTime' and 'plannedDuration', the 'endTime' is implied.
-            // If we pause, we stop the clock. When we resume, we must shift the 'startTime' forward by the pause duration
-            // so that (now - startTime) reflects only active time? 
-            // OR better: shift the implied end time.
-            // Let's shift the startTime forward, effectively "ignoring" the paused block.
+                if (!session.isPaused || !session.pausedAt) {
+                    throw Object.assign(new Error('Session is not paused'), { status: 409 });
+                }
 
-            const newStartTime = new Date(session.startTime.getTime() + pausedDurationMs);
+                // Calculate how long it was paused
+                const now = new Date();
+                const pausedDurationMs = now.getTime() - new Date(session.pausedAt).getTime();
 
-            await prisma.session.update({
-                where: { id },
-                data: {
-                    isPaused: false,
-                    pausedAt: null, // Clear it
-                    startTime: newStartTime,
-                },
+                // Shift startTime forward by the paused duration so the implied
+                // end time (startTime + plannedDuration) stays correct and only
+                // active time is counted.
+                const newStartTime = new Date(session.startTime.getTime() + pausedDurationMs);
+
+                return tx.session.update({
+                    where: { id },
+                    data: {
+                        isPaused: false,
+                        pausedAt: null,
+                        startTime: newStartTime,
+                    },
+                });
             });
+
+            return NextResponse.json({ session: updatedSession });
         } else {
             return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
         }
@@ -70,7 +77,13 @@ export async function POST(
         const updatedSession = await prisma.session.findUnique({ where: { id } });
         return NextResponse.json({ session: updatedSession });
 
-    } catch (error) {
+    } catch (error: any) {
+        if (error?.status === 404) {
+            return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+        }
+        if (error?.status === 409) {
+            return NextResponse.json({ message: 'Session is not paused' }, { status: 409 });
+        }
         logger.error('Toggle pause error:', error);
         return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }

--- a/web-app/src/app/api/sessions/route.ts
+++ b/web-app/src/app/api/sessions/route.ts
@@ -4,6 +4,7 @@ import { getUserIdFromToken } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { invalidateAnalyticsCache } from '@/lib/analytics-cache';
+import { CreateSessionSchema } from '@/lib/schemas';
 
 // Create a new session
 export async function POST(request: NextRequest) {
@@ -15,14 +16,14 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { plannedDuration, sessionType = 'WORK', projectId } = body;
-
-    if (!plannedDuration) {
+    const parsed = CreateSessionSchema.safeParse(body);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: 'plannedDuration is required' },
+        { error: 'Invalid input', details: parsed.error.flatten() },
         { status: 400 }
       );
     }
+    const { plannedDuration, sessionType, projectId } = parsed.data;
 
     // Race check: refuse to create a second active session for the same user.
     // A session is "active" when it hasn't been marked completed and has no
@@ -80,8 +81,12 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '50') || 50, 1), 200);
     const date = searchParams.get('date'); // YYYY-MM-DD format
+
+    if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return NextResponse.json({ error: 'Invalid date format, expected YYYY-MM-DD' }, { status: 400 });
+    }
 
     let where: any = { userId };
 

--- a/web-app/src/app/api/teams/join/route.ts
+++ b/web-app/src/app/api/teams/join/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const ip = getClientIp(request);
-    const rl = rateLimit(`team-join:${ip}`, 5, 60 * 60 * 1000);
+    const rl = await rateLimit(`team-join:${ip}`, 5, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many join attempts. Please try again later.' },

--- a/web-app/src/app/api/teams/route.ts
+++ b/web-app/src/app/api/teams/route.ts
@@ -55,6 +55,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Team name must be at least 2 characters' }, { status: 400 });
     }
 
+    const owned = await prisma.team.count({ where: { ownerId: userId } });
+    if (owned >= 5) {
+      return NextResponse.json({ error: 'Team limit reached (max 5)' }, { status: 429 });
+    }
+
     const team = await prisma.team.create({
       data: {
         name: name.trim(),

--- a/web-app/src/app/api/user/password/route.ts
+++ b/web-app/src/app/api/user/password/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const rl = rateLimit(`change-password:${userId}`, 10, 60 * 60 * 1000);
+    const rl = await rateLimit(`change-password:${userId}`, 10, 60 * 60 * 1000);
     if (!rl.allowed) {
       return NextResponse.json(
         { error: 'Too many password-change attempts. Please try again later.' },

--- a/web-app/src/app/api/user/profile/route.ts
+++ b/web-app/src/app/api/user/profile/route.ts
@@ -17,7 +17,15 @@ export async function GET(request: NextRequest) {
 
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      include: {
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        timezone: true,
+        role: true,
+        createdAt: true,
+        emailVerified: true,
+        subscriptionTier: true,
         preferences: true,
       },
     });
@@ -71,7 +79,15 @@ export async function PUT(request: NextRequest) {
           },
         }),
       },
-      include: {
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        timezone: true,
+        role: true,
+        createdAt: true,
+        emailVerified: true,
+        subscriptionTier: true,
         preferences: true,
       },
     });

--- a/web-app/src/lib/jwt.ts
+++ b/web-app/src/lib/jwt.ts
@@ -38,7 +38,9 @@ export function getUserIdFromToken(request: NextRequest): string | null {
     }
 
     const token = authHeader.substring(7);
-    const decoded = verify(token, getJwtSecret()) as { userId: string };
+    // Pin the algorithm — without this, jsonwebtoken accepts whatever `alg` the
+    // token header declares (alg-confusion / alg:none risk on any lib change).
+    const decoded = verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as { userId: string };
     return decoded.userId;
   } catch (error) {
     return null;
@@ -58,7 +60,7 @@ export function getAdminFromToken(request: NextRequest): string | null {
     }
 
     const token = authHeader.substring(7);
-    const decoded = verify(token, getJwtSecret()) as { userId: string; role?: string };
+    const decoded = verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as { userId: string; role?: string };
     if (decoded.role !== 'ADMIN') {
       return null;
     }

--- a/web-app/src/lib/pushNotify.ts
+++ b/web-app/src/lib/pushNotify.ts
@@ -6,7 +6,7 @@ let vapidConfigured = false;
 
 function configureVapid(): boolean {
   if (vapidConfigured) return true;
-  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  const publicKey = process.env.VAPID_PUBLIC_KEY || process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
   const privateKey = process.env.VAPID_PRIVATE_KEY;
   if (!publicKey || !privateKey) {
     logger.warn('VAPID keys are missing; skipping push send');

--- a/web-app/src/lib/rate-limit.test.ts
+++ b/web-app/src/lib/rate-limit.test.ts
@@ -1,93 +1,76 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock Redis client so no real connection is attempted.
+vi.mock('@/lib/redis', () => ({ redis: {}, CACHE_TTL: 300 }));
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+// Shared mock for Ratelimit#limit; every instance delegates to it.
+const limitMock = vi.fn();
+vi.mock('@upstash/ratelimit', () => {
+  class Ratelimit {
+    static slidingWindow() {
+      return {};
+    }
+    limit = limitMock;
+  }
+  return { Ratelimit };
+});
+
 import { rateLimit, getClientIp } from './rate-limit';
 
-// The rate limiter uses a module-level Map. We need to ensure tests don't
-// bleed into each other via shared state, so we use unique keys per test.
-let testId = 0;
-function uniqueKey(prefix = 'test') {
-  return `${prefix}:${++testId}:${Date.now()}`;
-}
+describe('rateLimit (Redis-backed)', () => {
+  beforeEach(() => {
+    limitMock.mockReset();
+  });
 
-describe('rateLimit', () => {
-  it('allows the first request under the limit', () => {
-    const result = rateLimit(uniqueKey(), 5, 60_000);
+  it('passes through an allowed result', async () => {
+    limitMock.mockResolvedValue({ success: true, remaining: 4, reset: Date.now() + 60_000 });
+    const result = await rateLimit('login:1.2.3.4', 5, 60_000);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(4);
+    expect(result.resetInMs).toBeGreaterThan(0);
   });
 
-  it('tracks remaining count correctly', () => {
-    const key = uniqueKey();
-    rateLimit(key, 5, 60_000);
-    rateLimit(key, 5, 60_000);
-    const result = rateLimit(key, 5, 60_000);
+  it('passes through a blocked result', async () => {
+    limitMock.mockResolvedValue({ success: false, remaining: 0, reset: Date.now() + 30_000 });
+    const result = await rateLimit('login:1.2.3.4', 5, 60_000);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it('clamps resetInMs to >= 0 when reset is in the past', async () => {
+    limitMock.mockResolvedValue({ success: false, remaining: 0, reset: Date.now() - 5_000 });
+    const result = await rateLimit('login:1.2.3.4', 5, 60_000);
+    expect(result.resetInMs).toBe(0);
+  });
+
+  it('fails open (allowed) when Redis throws', async () => {
+    limitMock.mockRejectedValue(new Error('redis down'));
+    const result = await rateLimit('login:1.2.3.4', 5, 60_000);
     expect(result.allowed).toBe(true);
-    expect(result.remaining).toBe(2);
-  });
-
-  it('blocks requests at the limit', () => {
-    const key = uniqueKey();
-    for (let i = 0; i < 3; i++) rateLimit(key, 3, 60_000);
-    const blocked = rateLimit(key, 3, 60_000);
-    expect(blocked.allowed).toBe(false);
-    expect(blocked.remaining).toBe(0);
-  });
-
-  it('returns resetInMs close to windowMs when blocked', () => {
-    const key = uniqueKey();
-    const windowMs = 60_000;
-    for (let i = 0; i < 2; i++) rateLimit(key, 2, windowMs);
-    const blocked = rateLimit(key, 2, windowMs);
-    expect(blocked.allowed).toBe(false);
-    // resetInMs should be approximately windowMs (within 100ms tolerance)
-    expect(blocked.resetInMs).toBeGreaterThan(windowMs - 200);
-    expect(blocked.resetInMs).toBeLessThanOrEqual(windowMs);
-  });
-
-  it('allows new requests after the window expires', async () => {
-    const key = uniqueKey();
-    const windowMs = 50; // 50ms window
-    rateLimit(key, 1, windowMs);
-    // First request fills the limit
-    expect(rateLimit(key, 1, windowMs).allowed).toBe(false);
-
-    // Wait for window to expire
-    await new Promise((r) => setTimeout(r, 60));
-    expect(rateLimit(key, 1, windowMs).allowed).toBe(true);
-  });
-
-  it('treats different keys independently', () => {
-    const key1 = uniqueKey('a');
-    const key2 = uniqueKey('b');
-    for (let i = 0; i < 3; i++) rateLimit(key1, 3, 60_000);
-    // key1 is at limit; key2 should still be fresh
-    expect(rateLimit(key1, 3, 60_000).allowed).toBe(false);
-    expect(rateLimit(key2, 3, 60_000).allowed).toBe(true);
-  });
-
-  it('allows a limit of 1 (single-request window)', () => {
-    const key = uniqueKey();
-    expect(rateLimit(key, 1, 60_000).allowed).toBe(true);
-    expect(rateLimit(key, 1, 60_000).allowed).toBe(false);
-  });
-
-  it('remaining is 0 when exactly at limit', () => {
-    const key = uniqueKey();
-    rateLimit(key, 2, 60_000);
-    const last = rateLimit(key, 2, 60_000);
-    expect(last.allowed).toBe(true);
-    expect(last.remaining).toBe(0);
+    expect(result.remaining).toBe(5);
   });
 });
 
 describe('getClientIp', () => {
-  it('extracts IP from x-forwarded-for header', () => {
+  it('prefers Netlify x-nf-client-connection-ip (unspoofable edge IP)', () => {
     const req = new Request('https://example.com', {
-      headers: { 'x-forwarded-for': '192.168.1.1, 10.0.0.1' },
+      headers: {
+        'x-nf-client-connection-ip': '203.0.113.9',
+        'x-forwarded-for': '1.2.3.4, 203.0.113.9',
+      },
     });
-    expect(getClientIp(req)).toBe('192.168.1.1');
+    expect(getClientIp(req)).toBe('203.0.113.9');
   });
 
-  it('falls back to x-real-ip when x-forwarded-for is absent', () => {
+  it('uses the LAST x-forwarded-for element (closest to trusted edge)', () => {
+    const req = new Request('https://example.com', {
+      headers: { 'x-forwarded-for': '1.2.3.4, 203.0.113.9' },
+    });
+    expect(getClientIp(req)).toBe('203.0.113.9');
+  });
+
+  it('falls back to x-real-ip when no forwarded headers exist', () => {
     const req = new Request('https://example.com', {
       headers: { 'x-real-ip': '10.0.0.5' },
     });
@@ -99,9 +82,9 @@ describe('getClientIp', () => {
     expect(getClientIp(req)).toBe('unknown');
   });
 
-  it('trims whitespace from x-forwarded-for', () => {
+  it('trims whitespace from forwarded values', () => {
     const req = new Request('https://example.com', {
-      headers: { 'x-forwarded-for': '  203.0.113.5  , 10.0.0.1' },
+      headers: { 'x-forwarded-for': '  1.2.3.4 ,  203.0.113.5  ' },
     });
     expect(getClientIp(req)).toBe('203.0.113.5');
   });

--- a/web-app/src/lib/rate-limit.ts
+++ b/web-app/src/lib/rate-limit.ts
@@ -1,13 +1,17 @@
 /**
- * In-memory sliding window rate limiter.
- * Note: resets per serverless invocation — effective for burst protection within one instance.
+ * Distributed sliding-window rate limiter backed by Upstash Redis.
+ *
+ * Replaces the previous in-memory Map, which reset on every serverless cold
+ * start (so limits silently failed open). State now lives in Redis and is
+ * shared across all serverless instances.
+ *
+ * Fail-open: if Redis is unreachable we allow the request (and log) rather than
+ * lock every user out of auth on a Redis outage. Availability > strictness here.
  */
 
-interface RateLimitEntry {
-  timestamps: number[];
-}
-
-const store = new Map<string, RateLimitEntry>();
+import { Ratelimit, type Duration } from '@upstash/ratelimit';
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
 
 export interface RateLimitResult {
   allowed: boolean;
@@ -15,42 +19,67 @@ export interface RateLimitResult {
   resetInMs: number;
 }
 
+// One Ratelimit instance per (limit, windowMs) config; cached so we don't
+// rebuild on every call. Keyed by `${limit}:${windowMs}`.
+const limiters = new Map<string, Ratelimit>();
+
+function getLimiter(limit: number, windowMs: number): Ratelimit {
+  const cacheKey = `${limit}:${windowMs}`;
+  let limiter = limiters.get(cacheKey);
+  if (!limiter) {
+    limiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(limit, `${windowMs} ms` as Duration),
+      analytics: false,
+      prefix: 'rl',
+    });
+    limiters.set(cacheKey, limiter);
+  }
+  return limiter;
+}
+
 /**
- * @param key      Unique key (e.g. "login:127.0.0.1")
+ * @param key      Unique key (e.g. "login:127.0.0.1" or "coach:<userId>")
  * @param limit    Max requests allowed in the window
  * @param windowMs Window size in milliseconds
  */
-export function rateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
-  const now = Date.now();
-  const windowStart = now - windowMs;
-
-  const entry = store.get(key) ?? { timestamps: [] };
-
-  // Remove timestamps outside the window
-  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
-
-  if (entry.timestamps.length >= limit) {
-    const oldest = entry.timestamps[0];
-    const resetInMs = oldest + windowMs - now;
-    store.set(key, entry);
-    return { allowed: false, remaining: 0, resetInMs };
+export async function rateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): Promise<RateLimitResult> {
+  try {
+    const { success, remaining, reset } = await getLimiter(limit, windowMs).limit(key);
+    return {
+      allowed: success,
+      remaining,
+      resetInMs: Math.max(0, reset - Date.now()),
+    };
+  } catch (error) {
+    // Redis unreachable — fail open so auth isn't bricked, but record it.
+    logger.error('Rate limiter unavailable (failing open)', error);
+    return { allowed: true, remaining: limit, resetInMs: windowMs };
   }
-
-  entry.timestamps.push(now);
-  store.set(key, entry);
-
-  return {
-    allowed: true,
-    remaining: limit - entry.timestamps.length,
-    resetInMs: windowMs,
-  };
 }
 
-/** Extract client IP from Next.js request headers */
+/**
+ * Extract the client IP from request headers.
+ *
+ * On Netlify, `x-nf-client-connection-ip` is injected by the platform and is
+ * NOT attacker-controllable — prefer it. The `x-forwarded-for` first element is
+ * client-supplied (a request can arrive with a forged XFF that Netlify then
+ * prepends its real value to), so it is only a last-resort fallback and we read
+ * the LAST element, which is closest to the trusted edge.
+ */
 export function getClientIp(request: Request): string {
-  return (
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
-    request.headers.get('x-real-ip') ??
-    'unknown'
-  );
+  const nf = request.headers.get('x-nf-client-connection-ip');
+  if (nf) return nf.trim();
+
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) {
+    const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
+    if (parts.length > 0) return parts[parts.length - 1];
+  }
+
+  return request.headers.get('x-real-ip')?.trim() ?? 'unknown';
 }

--- a/web-app/src/lib/settings.ts
+++ b/web-app/src/lib/settings.ts
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import { prisma } from './prisma';
 import { buildWelcomeEmail } from './email-templates';
 
@@ -37,6 +38,42 @@ const DEFAULTS: AppSettings = {
   },
 };
 
+// Email-safe sanitize-html allowlist. Used when persisting admin-controlled
+// email body fields so that stored HTML is clean before it ever reaches users.
+const EMAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'h1', 'h2', 'h3', 'h4', 'p', 'a', 'b', 'i', 'strong', 'em',
+    'ul', 'ol', 'li', 'br', 'span', 'div', 'img', 'hr',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  ],
+  allowedAttributes: {
+    'a': ['href'],
+    'img': ['src', 'alt', 'width', 'height'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemesByTag: {
+    img: ['http', 'https'],
+  },
+};
+
+// HTML-escape a plain-text value before interpolating it into an HTML template.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Normalise a plain-text string for use as an email subject.
+ * Strips CR/LF (SMTP header injection) and any angle-bracket tags (stray markup).
+ */
+function plainText(s: string): string {
+  return s.replace(/[\r\n]+/g, ' ').replace(/<[^>]*>/g, '');
+}
+
 /**
  * Load all app settings from the DB, falling back to defaults for missing keys.
  */
@@ -74,13 +111,33 @@ export async function getSettings(): Promise<AppSettings> {
 
 /**
  * Save a flat map of key→value pairs to the DB (upsert).
+ * Email body fields are sanitized with an email-safe allowlist before persistence
+ * so admin-controlled HTML never reaches users unsanitized.
  */
 export async function saveSettings(
   updates: Record<string, unknown>,
   updatedBy: string
 ): Promise<void> {
+  const sanitized = Object.fromEntries(
+    Object.entries(updates).map(([key, value]) => {
+      if (
+        (key === 'email.welcome.body' || key === 'email.digest.body') &&
+        typeof value === 'string'
+      ) {
+        return [key, sanitizeHtml(value, EMAIL_SANITIZE_OPTIONS)];
+      }
+      if (
+        (key === 'email.welcome.subject' || key === 'email.verification.subject' || key === 'email.digest.subject') &&
+        typeof value === 'string'
+      ) {
+        return [key, plainText(value)];
+      }
+      return [key, value];
+    })
+  );
+
   await Promise.all(
-    Object.entries(updates).map(([key, value]) =>
+    Object.entries(sanitized).map(([key, value]) =>
       prisma.appSetting.upsert({
         where: { key },
         update: { value: value as never, updatedBy },
@@ -93,8 +150,23 @@ export async function saveSettings(
 /**
  * Apply template variables to an email body string.
  * Replaces {{name}}, {{appUrl}}, etc.
+ * Variable VALUES are HTML-escaped to prevent injection from user-controlled data.
  */
 export function applyTemplate(
+  template: string,
+  vars: Record<string, string>
+): string {
+  return Object.entries(vars).reduce(
+    (str, [k, v]) => str.replaceAll(`{{${k}}}`, escapeHtml(v)),
+    template
+  );
+}
+
+/**
+ * Apply template variables to a plain-text string (e.g. email subjects).
+ * Unlike applyTemplate, values are NOT HTML-escaped so subjects render correctly.
+ */
+export function applyTemplatePlain(
   template: string,
   vars: Record<string, string>
 ): string {

--- a/web-app/src/lib/timing-safe.ts
+++ b/web-app/src/lib/timing-safe.ts
@@ -1,0 +1,14 @@
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Constant-time string comparison. Use for secrets (cron tokens, signatures)
+ * so an attacker can't enumerate the value via response-timing differences.
+ * Returns false on length mismatch without leaking the comparison early.
+ */
+export function safeEqual(a: string | undefined | null, b: string | undefined | null): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}


### PR DESCRIPTION
Remediates the web-app security audit (see `web-app/SECURITY_AUDIT.md`). 28 findings fixed across auth, rate-limiting, input validation, injection/XSS, authz, and config.

## Highlights
- **Rate limiter** — replaced per-instance in-memory Map (a no-op on Netlify serverless) with Upstash Redis sliding window; hardened `getClientIp` against `X-Forwarded-For` spoofing. Applied limits to coach (per-user + concurrency lock), activity/sync, push/subscribe, teams.
- **JWT** — pinned `algorithms:['HS256']` on verify+sign; removed `?token=` query auth from coach SSE (clients use the `Authorization` header).
- **Data exposure** — explicit Prisma `select` on `/user/profile` and `/auth/login` (stop returning `hashedPassword` + reset/verification tokens); health route no longer leaks DB error messages; leaderboard drops user UUIDs.
- **Input validation** — Zod on sessions POST and activity/sync (array cap, clamp `durationSeconds`); SSRF allowlist on push endpoints; goals enum; sessions limit/date clamps.
- **Injection/XSS** — sanitize-html on admin announce + stored email templates; escaped template vars; RFC-4180 + formula-injection-safe CSV export.
- **Authz/race** — devices IDOR ownership check; toggle-pause wrapped in a transaction; teams creation cap.
- **Config** — timing-safe `CRON_SECRET` compare; enforce CSP (drop legacy `X-XSS-Protection`); removed catch-all SPA redirect; added `PUSHER_KEY` to `SECRETS_SCAN_OMIT_KEYS`; split server VAPID env var.
- **Auth UX** — signup no longer leaks account existence; email verification enforced by default.

## Verification
- `npm run lint` — clean
- `npm test` — 251/251 pass
- `npm run build` — success
- Implemented per-file by parallel subagents, then an adversarial whole-branch security review; all 6 review findings fixed (incl. a login token leak the original audit missed).

## Required before/after merge (out-of-band)
- **Rotate** Neon DB password, Upstash token, Google AI key — they were in a world-readable env file (perms fixed to `600`).
- Set `VAPID_PUBLIC_KEY` (server copy). Optionally `REQUIRE_EMAIL_VERIFICATION=false` if not ready to enforce verification.

## Deferred
- **Token revocation (`tokenVersion`)** — doing it correctly makes auth async across ~41 routes (Promise-truthiness bypass risk). Tracked for a focused follow-up via a single `middleware.ts` chokepoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)