### PR TITLE
Surface EMAIL_NOT_VERIFIED on login (desktop, extension, mobile)

### DIFF
--- a/browser-extension/chrome/popup/popup.js
+++ b/browser-extension/chrome/popup/popup.js
@@ -94,7 +94,9 @@ formLogin.addEventListener('submit', async (e) => {
     const data = await res.json();
 
     if (!res.ok) {
-      showError(data.error || 'Login failed');
+      showError(data.code === 'EMAIL_NOT_VERIFIED'
+        ? 'Please verify your email. Check your inbox for the verification link.'
+        : (data.error || 'Login failed'));
       return;
     }
 

--- a/browser-extension/firefox/popup/popup.js
+++ b/browser-extension/firefox/popup/popup.js
@@ -124,7 +124,12 @@ formLogin.addEventListener('submit', async e => {
     });
 
     const data = await res.json();
-    if (!res.ok) { showError(data.error || 'Login failed'); return; }
+    if (!res.ok) {
+      showError(data.code === 'EMAIL_NOT_VERIFIED'
+        ? 'Please verify your email. Check your inbox for the verification link.'
+        : (data.error || 'Login failed'));
+      return;
+    }
 
     await browser.storage.local.set({ token: data.token, user: JSON.stringify(data.user) });
     await writeTokenToPage(data.token);

--- a/desktop-app/UI/LoginForm.cs
+++ b/desktop-app/UI/LoginForm.cs
@@ -171,7 +171,10 @@ namespace FlowShield.Desktop.UI
                 }
                 else
                 {
-                    _statusLabel.Text = "Invalid email or password";
+                    _statusLabel.Text = _apiClient.LastLoginErrorCode == "EMAIL_NOT_VERIFIED"
+                        ? (_apiClient.LastLoginErrorMessage
+                            ?? "Please verify your email. Check your inbox for the verification link.")
+                        : "Invalid email or password";
                     _loginButton.Enabled = true;
                     _loginButton.Text = "Login";
                 }

--- a/mobile-app/src/screens/LoginScreen.tsx
+++ b/mobile-app/src/screens/LoginScreen.tsx
@@ -29,7 +29,11 @@ export default function LoginScreen() {
     try {
       await login(email.trim(), password);
     } catch (err: any) {
-      Alert.alert('Login Failed', err.message || 'Invalid email or password');
+      if (err.code === 'EMAIL_NOT_VERIFIED') {
+        Alert.alert('Verify your email', err.message || 'Check your inbox for the verification link.');
+      } else {
+        Alert.alert('Login Failed', err.message || 'Invalid email or password');
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Follow-up to the security audit (#109), which turned email verification ON by default. The login API returns 403 `{ code: 'EMAIL_NOT_VERIFIED' }`, but only the web UI read it — desktop, both browser extensions, and mobile showed a generic "invalid email or password", locking unverified users out with no actionable signal.

## Changes
- **Desktop** (`LoginForm.cs`) — branch the failed-login message on `ApiClient.LastLoginErrorCode` (the client already captured it; the UI just discarded it).
- **Browser extension** (chrome + firefox `popup.js`) — branch on `data.code`.
- **Mobile** (`LoginScreen.tsx`) — branch on `err.code` (`AuthError` already carries it).
- **Web** — unchanged (already handled the code correctly).

Each unverified user now sees "Please verify your email. Check your inbox…".

## Verification
- Extension: `node --check` both popups ✓
- Desktop: `dotnet build` ✓
- Mobile: `tsc --noEmit` clean ✓

## Known gap (separate follow-up)
`resend-verification` is auth-gated, so a logged-out unverified user can't trigger a resend. An unauthenticated, rate-limited, email-only resend endpoint is needed for full recovery. Not in this PR.

## Operational reminder
Existing users who predate enforcement have `emailVerified = null` and are now blocked. Count + decide backfill:
```sql
select count(*) from users where "emailVerified" is null;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)