### PR TITLE
Unauthenticated request-verification endpoint + login resend button

### DIFF
--- a/web-app/src/app/api/auth/request-verification/route.test.ts
+++ b/web-app/src/app/api/auth/request-verification/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  update: vi.fn(async () => ({})),
+  sendEmail: vi.fn(async () => true),
+  rateLimit: vi.fn(async () => ({ allowed: true, resetInMs: 0 })),
+  getSettings: vi.fn(async () => ({
+    email: { verification: { enabled: true, subject: 'Verify your email' } },
+  })),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { findUnique: mocks.findUnique, update: mocks.update } },
+}));
+vi.mock('@/lib/email', () => ({ sendEmail: mocks.sendEmail }));
+vi.mock('@/lib/settings', () => ({ getSettings: mocks.getSettings }));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: mocks.rateLimit,
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/auth/request-verification', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/auth/request-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rateLimit.mockResolvedValue({ allowed: true, resetInMs: 0 });
+  });
+
+  it('returns 200 generic message and sends nothing when the email is unknown', async () => {
+    mocks.findUnique.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ email: 'nobody@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('generates a token and sends the verification email for an unverified user', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ id: 'u-1', email: 'user@example.com', emailVerified: null });
+    const res = await POST(makeRequest({ email: 'user@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u-1' },
+        data: expect.objectContaining({
+          verificationToken: expect.any(String),
+          verificationTokenExpires: expect.any(Date),
+        }),
+      })
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'user@example.com' })
+    );
+  });
+
+  it('sends nothing for an already-verified user (still returns 200)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      id: 'u-2',
+      email: 'done@example.com',
+      emailVerified: new Date(),
+    });
+    const res = await POST(makeRequest({ email: 'done@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed email with 400', async () => {
+    const res = await POST(makeRequest({ email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 when the IP rate limit is exceeded (before touching the DB)', async () => {
+    mocks.rateLimit.mockResolvedValueOnce({ allowed: false, resetInMs: 5000 });
+    const res = await POST(makeRequest({ email: 'user@example.com' }));
+    expect(res.status).toBe(429);
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('does not send when the per-email cap is hit, but still returns a generic 200', async () => {
+    // 1st call = IP limit (allowed), 2nd call = per-email limit (blocked)
+    mocks.rateLimit
+      .mockResolvedValueOnce({ allowed: true, resetInMs: 0 })
+      .mockResolvedValueOnce({ allowed: false, resetInMs: 5000 });
+    mocks.findUnique.mockResolvedValueOnce({ id: 'u-3', email: 'spammed@example.com', emailVerified: null });
+    const res = await POST(makeRequest({ email: 'spammed@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/web-app/src/app/api/auth/request-verification/route.ts
+++ b/web-app/src/app/api/auth/request-verification/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { rateLimit, getClientIp } from '@/lib/rate-limit';
+import { sendEmail } from '@/lib/email';
+import { getSettings } from '@/lib/settings';
+
+const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const RequestVerificationSchema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+/**
+ * POST /api/auth/request-verification
+ *
+ * Unauthenticated companion to /api/auth/resend-verification (which needs a
+ * token). A user locked out at login because their email isn't verified has no
+ * token, so this lets them request a fresh link by email address alone.
+ *
+ * Always returns 200 with a generic message — never reveal whether the email
+ * is registered or already verified (account enumeration). A link is only
+ * actually sent for accounts that exist and are not yet verified.
+ *
+ * Rate limited by BOTH IP and email: the IP limit stops one host from probing
+ * many addresses; the per-email limit stops an attacker from bombing one
+ * victim's inbox from rotating IPs.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const ip = getClientIp(request);
+    const ipRl = await rateLimit(`request-verify-ip:${ip}`, 5, 60 * 60 * 1000);
+    if (!ipRl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(ipRl.resetInMs / 1000)) } }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parsed = RequestVerificationSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    }
+    const { email } = parsed.data;
+
+    // Per-email limit (anti inbox-bombing). Keyed by the normalized address.
+    const emailRl = await rateLimit(`request-verify-email:${email.toLowerCase()}`, 3, 60 * 60 * 1000);
+
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, emailVerified: true },
+    });
+
+    // Only send for a real, still-unverified account that hasn't hit the
+    // per-email cap. All branches return the same generic response below.
+    if (user && !user.emailVerified && emailRl.allowed) {
+      const verificationToken = crypto.randomBytes(32).toString('hex');
+      const verificationTokenExpires = new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS);
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { verificationToken, verificationTokenExpires },
+      });
+
+      const emailSettings = await getSettings();
+      if (emailSettings.email.verification.enabled) {
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+        const verificationUrl = `${appUrl}/api/auth/verify?token=${verificationToken}`;
+        await sendEmail({
+          to: user.email,
+          subject: emailSettings.email.verification.subject,
+          html: `<p>Please click the link below to verify your email address:</p>
+        <a href="${verificationUrl}">${verificationUrl}</a>
+        <p>This link will expire in 24 hours.</p>`,
+        });
+      }
+    }
+
+    // Identical response regardless of existence / verified state / email cap.
+    return NextResponse.json({
+      message: 'If that email is registered and not yet verified, a new verification link has been sent.',
+    });
+  } catch (error) {
+    logger.error('Request-verification error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web-app/src/app/auth/login/page.tsx
+++ b/web-app/src/app/auth/login/page.tsx
@@ -18,6 +18,7 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showResend, setShowResend] = useState(false);
 
   useEffect(() => {
     if (searchParams.get('registered') === 'true') {
@@ -30,10 +31,35 @@ export default function LoginPage() {
     }
   }, [searchParams]);
 
+  const handleResend = async () => {
+    setError('');
+    setSuccess('');
+    setLoading(true);
+    try {
+      const response = await fetch('/api/auth/request-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: formData.email }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setShowResend(false);
+        setSuccess(data.message || 'Verification email sent. Check your inbox.');
+      } else {
+        setError(data.error || 'Could not resend verification email.');
+      }
+    } catch {
+      setError('An error occurred. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     setSuccess('');
+    setShowResend(false);
     setLoading(true);
 
     try {
@@ -48,8 +74,10 @@ export default function LoginPage() {
       if (!response.ok) {
         if (data.code === 'EMAIL_NOT_VERIFIED') {
           setError('Please verify your email before signing in. Check your inbox for the verification link.');
+          setShowResend(true);
         } else {
           setError(data.error || 'Login failed');
+          setShowResend(false);
         }
         return;
       }
@@ -89,6 +117,16 @@ export default function LoginPage() {
           {error && (
             <div className="bg-danger-50 dark:bg-danger-500/10 border border-danger-200 dark:border-danger-500/20 text-danger-600 dark:text-danger-400 px-4 py-3 rounded-xl text-sm">
               {error}
+              {showResend && (
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  disabled={loading || !formData.email}
+                  className="mt-2 block font-medium text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-50"
+                >
+                  Resend verification email
+                </button>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
Follow-up to email-verification enforcement (#109/#110). `/api/auth/resend-verification` is auth-gated, so a user locked out at login (unverified, no token) had no way to get a fresh link. This adds an unauthenticated companion.

## Changes
- **`POST /api/auth/request-verification`** — request a verification link by email alone.
  - Zod-validated email.
  - **Enumeration-safe:** always returns a generic 200; a link is only actually sent for a real, still-unverified account.
  - **Rate limited two ways:** by IP (5/hr — stops one host probing many addresses) and by email (3/hr — stops inbox-bombing a victim from rotating IPs).
  - Honors `email.verification.enabled`; reuses the existing token/email flow.
- **Web login page** — on `EMAIL_NOT_VERIFIED`, shows a "Resend verification email" button wired to the endpoint.
- **6 unit tests** — unknown email, unverified (sends), already-verified (no send), malformed (400), IP 429, per-email cap (generic 200, no send).

## Verification
- New test 6/6 ✓ · full suite 257/257 ✓ · lint clean · build ✓ (route registered).

## Notes
- Desktop / extension / mobile can call this endpoint to add their own resend buttons later; web is wired now.
- Still open: existing pre-enforcement users with `emailVerified = null` (backfill decision) and the L1 token-revocation branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)