### PR TITLE
feat(auth): complete token revocation across all clients

### DIFF
--- a/browser-extension/chrome/background.js
+++ b/browser-extension/chrome/background.js
@@ -15,6 +15,24 @@ let pendingLogs    = [];    // buffered before next sync
 let activeSession  = null;  // { id, plannedDuration, startTime, sessionType }
 let distractions   = [];    // from user preferences
 
+// ─── Persistence helpers ──────────────────────────────────────────────────────
+
+const MAX_PENDING_LOGS = 500; // matches desktop's offline-queue bound
+
+async function persistPendingLogs() {
+  if (pendingLogs.length > MAX_PENDING_LOGS) {
+    pendingLogs = pendingLogs.slice(-MAX_PENDING_LOGS); // keep newest
+  }
+  await chrome.storage.local.set({ pendingLogs });
+}
+
+async function restorePendingLogs() {
+  const { pendingLogs: stored } = await chrome.storage.local.get('pendingLogs');
+  if (Array.isArray(stored) && stored.length) {
+    pendingLogs = [...stored, ...pendingLogs];
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 async function getToken() {
@@ -114,9 +132,10 @@ async function syncActivities() {
       body:    JSON.stringify({ source: 'browser', activities: logsToSend }),
     });
     if (res.status === 401) {
-      // Stale token — clear it so popup shows login screen
+      // Token expired/revoked — clear it so popup shows login, but KEEP the
+      // logs: they sync after re-login (TOKEN_UPDATED triggers a replay).
       await chrome.storage.local.remove('token');
-      pendingLogs = []; // discard; user must re-auth
+      pendingLogs = [...logsToSend, ...pendingLogs];
     } else if (!res.ok) {
       // Transient error — put logs back for next sync
       pendingLogs = [...logsToSend, ...pendingLogs];
@@ -124,6 +143,9 @@ async function syncActivities() {
   } catch {
     pendingLogs = [...logsToSend, ...pendingLogs];
   }
+
+  // Persist survivors so an MV3 worker restart doesn't lose them.
+  await persistPendingLogs();
 }
 
 async function fetchActiveSession() {
@@ -233,9 +255,10 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     (msg.token
       ? chrome.storage.local.set({ token: msg.token })
       : Promise.resolve()
-    ).then(() => {
-      fetchActiveSession();
-      fetchUserPreferences();
+    ).then(async () => {
+      await fetchActiveSession();
+      await fetchUserPreferences();
+      await syncActivities(); // replay logs preserved across the logged-out period
     });
     sendResponse({ ok: true });
     return true;
@@ -246,6 +269,20 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       updateBadge();
     });
     sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.type === 'LOGOUT') {
+    (async () => {
+      // Explicit logout: last-chance sync while the token still works,
+      // then clear all auth + buffered state.
+      flushCurrentTab();
+      await syncActivities();
+      pendingLogs = [];
+      await chrome.storage.local.remove(['token', 'user', 'pendingLogs']);
+      activeSession = null;
+      updateBadge();
+      sendResponse({ ok: true });
+    })();
     return true;
   }
   if (msg.type === 'FORCE_SYNC') {
@@ -268,6 +305,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
 (async () => {
+  await restorePendingLogs();
   const stored = await chrome.storage.local.get(['distractions']);
   distractions = stored.distractions || [];
   await fetchActiveSession();

--- a/browser-extension/chrome/popup/popup.js
+++ b/browser-extension/chrome/popup/popup.js
@@ -114,7 +114,9 @@ formLogin.addEventListener('submit', async (e) => {
 });
 
 btnLogout.addEventListener('click', async () => {
-  await chrome.storage.local.remove(['token', 'user']);
+  await new Promise(resolve =>
+    chrome.runtime.sendMessage({ type: 'LOGOUT' }, resolve)
+  );
   showScreen('auth');
 });
 

--- a/browser-extension/firefox/background.js
+++ b/browser-extension/firefox/background.js
@@ -15,6 +15,24 @@ let pendingLogs   = [];
 let activeSession = null;
 let distractions  = [];
 
+// ─── Persistence helpers ──────────────────────────────────────────────────────
+
+const MAX_PENDING_LOGS = 500; // matches desktop's offline-queue bound
+
+async function persistPendingLogs() {
+  if (pendingLogs.length > MAX_PENDING_LOGS) {
+    pendingLogs = pendingLogs.slice(-MAX_PENDING_LOGS); // keep newest
+  }
+  await browser.storage.local.set({ pendingLogs });
+}
+
+async function restorePendingLogs() {
+  const { pendingLogs: stored } = await browser.storage.local.get('pendingLogs');
+  if (Array.isArray(stored) && stored.length) {
+    pendingLogs = [...stored, ...pendingLogs];
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 async function getToken() {
@@ -106,13 +124,20 @@ async function syncActivities() {
       body:    JSON.stringify({ source: 'browser', activities: logsToSend }),
     });
     if (res.status === 401) {
+      // Token expired/revoked — clear it so popup shows login, but KEEP the
+      // logs: they sync after re-login (TOKEN_UPDATED triggers a replay).
       await browser.storage.local.remove('token');
+      pendingLogs = [...logsToSend, ...pendingLogs];
     } else if (!res.ok) {
+      // Transient error — put logs back for next sync
       pendingLogs = [...logsToSend, ...pendingLogs];
     }
   } catch {
     pendingLogs = [...logsToSend, ...pendingLogs];
   }
+
+  // Persist survivors so an event-page restart doesn't lose them.
+  await persistPendingLogs();
 }
 
 async function fetchActiveSession() {
@@ -197,14 +222,30 @@ browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
   if (msg.type === 'TOKEN_UPDATED') {
-    fetchActiveSession();
-    fetchUserPreferences();
-    sendResponse({ ok: true });
+    (async () => {
+      await fetchActiveSession();
+      await fetchUserPreferences();
+      await syncActivities(); // replay logs preserved across the logged-out period
+    })().then(() => sendResponse({ ok: true }));
     return true;
   }
   if (msg.type === 'TOKEN_CLEARED') {
     browser.storage.local.remove('token').then(() => { activeSession = null; updateBadge(); });
     sendResponse({ ok: true });
+    return true;
+  }
+  if (msg.type === 'LOGOUT') {
+    (async () => {
+      // Explicit logout: last-chance sync while the token still works,
+      // then clear all auth + buffered state.
+      flushCurrentTab();
+      await syncActivities();
+      pendingLogs = [];
+      await browser.storage.local.remove(['token', 'user', 'pendingLogs']);
+      activeSession = null;
+      updateBadge();
+      sendResponse({ ok: true });
+    })();
     return true;
   }
   if (msg.type === 'FORCE_SYNC') {
@@ -225,6 +266,7 @@ browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
 (async () => {
+  await restorePendingLogs();
   const stored = await browser.storage.local.get(['distractions']);
   distractions = stored.distractions || [];
   await fetchActiveSession();

--- a/browser-extension/firefox/popup/popup.js
+++ b/browser-extension/firefox/popup/popup.js
@@ -145,7 +145,9 @@ formLogin.addEventListener('submit', async e => {
 });
 
 btnLogout.addEventListener('click', async () => {
-  await browser.storage.local.remove(['token', 'user']);
+  await new Promise(resolve =>
+    browser.runtime.sendMessage({ type: 'LOGOUT' }, resolve)
+  );
   showScreen('auth');
 });
 

--- a/desktop-app/FlowShield.Desktop.Tests/ApiClientTests.cs
+++ b/desktop-app/FlowShield.Desktop.Tests/ApiClientTests.cs
@@ -992,6 +992,54 @@ public class ApiClientTests
         Assert.True(eventFired);
         db.Verify(d => d.SaveSetting("AuthToken", string.Empty), Times.Once);
     }
+
+    // ---------- Logout idempotency ----------
+
+    [Fact]
+    public void Logout_CalledTwice_RaisesSessionExpiredOnce()
+    {
+        var client = BuildClient(AuthenticatedDb(), new FakeHttpHandler());
+        var fired = 0;
+        client.SessionExpired += (_, _) => fired++;
+
+        client.Logout();
+        client.Logout();
+
+        Assert.Equal(1, fired);
+        Assert.False(client.IsAuthenticated());
+    }
+
+    // ---------- 401 → clear token + fire SessionExpired ----------
+
+    [Fact]
+    public async Task GetActiveSession_On401_ClearsTokenAndRaisesSessionExpired()
+    {
+        var handler = new FakeHttpHandler(HttpStatusCode.Unauthorized, "");
+        var client = BuildClient(AuthenticatedDb(), handler);
+        var fired = 0;
+        client.SessionExpired += (_, _) => fired++;
+
+        var result = await client.GetActiveSessionAsync();
+
+        Assert.Null(result);
+        Assert.False(client.IsAuthenticated());
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public async Task GetUserPreferences_On401_ClearsTokenAndRaisesSessionExpired()
+    {
+        var handler = new FakeHttpHandler(HttpStatusCode.Unauthorized, "");
+        var client = BuildClient(AuthenticatedDb(), handler);
+        var fired = 0;
+        client.SessionExpired += (_, _) => fired++;
+
+        var result = await client.GetUserPreferencesAsync();
+
+        Assert.Null(result);
+        Assert.False(client.IsAuthenticated());
+        Assert.Equal(1, fired);
+    }
 }
 
 // ---------- FakeHttpHandler ----------

--- a/desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs
+++ b/desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs
@@ -699,4 +699,16 @@ public class SessionManagerTests
             Assert.Null(sm.CurrentSession);
         });
     }
+
+    [Fact]
+    public async Task TriggerResync_WhenUnauthenticated_DoesNotCallApiOrTouchSession()
+    {
+        var (sm, api, _, _, _, _) = Build();
+        api.Setup(a => a.IsAuthenticated()).Returns(false);
+
+        await sm.TriggerResyncAsync();
+
+        // A revoked/missing token must never be misread as a remote session stop.
+        api.Verify(a => a.GetActiveSessionAsync(), Times.Never);
+    }
 }

--- a/desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs
+++ b/desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs
@@ -96,7 +96,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
 
             var result = await sm.StartSessionAsync(25);
 
@@ -110,7 +110,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
 
@@ -125,7 +125,7 @@ public class SessionManagerTests
         {
             var (sm, api, _, _, _, _) = Build();
             var session = MakeSession();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(session);
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(session);
 
             await sm.StartSessionAsync(25);
 
@@ -140,7 +140,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, tracker, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
 
@@ -154,7 +154,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync((SessionInfo?)null);
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync((SessionInfo?)null);
 
             var result = await sm.StartSessionAsync(25);
 
@@ -169,7 +169,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(It.IsAny<int>(), It.IsAny<string>()))
+            api.Setup(a => a.StartSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>()))
                .ThrowsAsync(new Exception("network error"));
 
             var result = await sm.StartSessionAsync(25);
@@ -185,7 +185,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             sm.BlockingEnabled = true;
 
             await sm.StartSessionAsync(25);
@@ -201,7 +201,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             // BlockingEnabled is false by default
 
             await sm.StartSessionAsync(25);
@@ -218,7 +218,7 @@ public class SessionManagerTests
         {
             var (sm, api, _, _, _, _) = Build();
             var session = MakeSession();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(session);
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(session);
 
             SessionInfo? fired = null;
             sm.SessionStarted += (_, s) => fired = s;
@@ -238,7 +238,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
 
             await sm.StartSessionAsync(25);
@@ -254,7 +254,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
 
             await sm.StartSessionAsync(25);
@@ -270,7 +270,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync("sess-1")).ReturnsAsync(true);
 
             await sm.StartSessionAsync(25);
@@ -286,7 +286,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, tracker, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
 
             await sm.StartSessionAsync(25);
@@ -302,7 +302,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
             sm.BlockingEnabled = true;
 
@@ -320,7 +320,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
 
             var fired = false;
@@ -341,7 +341,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
             sm.BlockingEnabled = true;
@@ -357,7 +357,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             sm.BlockingEnabled = true;
 
             await sm.StartSessionAsync(25);
@@ -454,7 +454,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
@@ -471,7 +471,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, tracker, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
@@ -487,7 +487,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
 
             var fired = false;
@@ -520,7 +520,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
@@ -537,7 +537,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, web, appB) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             sm.BlockingEnabled = true;
 
@@ -562,7 +562,7 @@ public class SessionManagerTests
                 Id = "sess-1", PlannedDuration = 25,
                 StartTime = DateTime.UtcNow.AddMinutes(-3), Completed = false, IsPaused = false,
             };
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "resume")).ReturnsAsync(resumedSession);
 
@@ -586,7 +586,7 @@ public class SessionManagerTests
                 Id = "sess-1", PlannedDuration = 25,
                 StartTime = DateTime.UtcNow.AddMinutes(-3), Completed = false, IsPaused = false,
             };
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "resume")).ReturnsAsync(resumedSession);
 
@@ -610,7 +610,7 @@ public class SessionManagerTests
                 Id = "sess-1", PlannedDuration = 25,
                 StartTime = DateTime.UtcNow.AddMinutes(-3), Completed = false, IsPaused = false,
             };
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "resume")).ReturnsAsync(resumedSession);
 
@@ -631,7 +631,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
 
             await sm.StartSessionAsync(25);
             var result = await sm.ResumeSessionAsync();
@@ -664,7 +664,7 @@ public class SessionManagerTests
                 Id = "sess-1", PlannedDuration = 25,
                 StartTime = DateTime.UtcNow.AddMinutes(-3), Completed = false, IsPaused = false,
             };
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "resume")).ReturnsAsync(resumedSession);
             sm.BlockingEnabled = true;
@@ -686,7 +686,7 @@ public class SessionManagerTests
         RunOnSTA(async () =>
         {
             var (sm, api, _, _, _, _) = Build();
-            api.Setup(a => a.StartSessionAsync(25, "WORK")).ReturnsAsync(MakeSession());
+            api.Setup(a => a.StartSessionAsync(25, "WORK", null)).ReturnsAsync(MakeSession());
             api.Setup(a => a.TogglePauseAsync("sess-1", "pause")).ReturnsAsync(MakeSession());
             api.Setup(a => a.EndSessionAsync(It.IsAny<string>())).ReturnsAsync(true);
 

--- a/desktop-app/Services/ApiClient.cs
+++ b/desktop-app/Services/ApiClient.cs
@@ -183,6 +183,7 @@ namespace FlowShield.Desktop.Services
                 // Fallback used: Fetch latest session and check if it's active
                 // This works even if /api/sessions/active endpoint is missing on server
                 var response = await _httpClient.GetAsync("/api/sessions?limit=1");
+                if (HandleUnauthorized(response)) return null;
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -288,6 +289,7 @@ namespace FlowShield.Desktop.Services
                 };
 
                 var response = await _httpClient.SendAsync(request);
+                if (HandleUnauthorized(response)) return false;
                 return response.IsSuccessStatusCode;
             }
             catch
@@ -358,6 +360,7 @@ namespace FlowShield.Desktop.Services
                     return null;
 
                 var response = await _httpClient.GetAsync("/api/user/preferences");
+                if (HandleUnauthorized(response)) return null;
                 if (response.IsSuccessStatusCode)
                 {
                     var responseData = await response.Content.ReadAsStringAsync();
@@ -401,6 +404,7 @@ namespace FlowShield.Desktop.Services
                 var content = new StringContent(json, Encoding.UTF8, "application/json");
 
                 var response = await _httpClient.PostAsync("/api/devices", content);
+                if (HandleUnauthorized(response)) return false;
                 if (response.IsSuccessStatusCode)
                 {
                     _dbService.SaveSetting("DeviceId", deviceId);
@@ -457,6 +461,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync($"/api/analytics?period={period}");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 return JsonConvert.DeserializeObject<AnalyticsData>(data);
@@ -470,6 +475,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync($"/api/sessions?limit={limit}");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<SessionListResponse>(data);
@@ -484,6 +490,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync("/api/goals");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<GoalListResponse>(data);
@@ -523,6 +530,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync("/api/projects");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 // Projects API returns a direct array, not a wrapped object
@@ -572,7 +580,7 @@ namespace FlowShield.Desktop.Services
                     Content = content
                 };
                 var response = await _httpClient.SendAsync(request);
-
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<PreferencesResponse>(data);
@@ -587,6 +595,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync($"/api/leaderboard?period={period}");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 return JsonConvert.DeserializeObject<LeaderboardData>(data);
@@ -640,6 +649,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync("/api/teams");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<TeamsResponse>(data);
@@ -712,6 +722,7 @@ namespace FlowShield.Desktop.Services
             {
                 if (string.IsNullOrEmpty(_authToken)) return null;
                 var response = await _httpClient.GetAsync("/api/categories");
+                if (HandleUnauthorized(response)) return null;
                 if (!response.IsSuccessStatusCode) return null;
                 var data = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<CategoryRulesResponse>(data);
@@ -728,12 +739,28 @@ namespace FlowShield.Desktop.Services
 
         public void Logout()
         {
+            // Idempotent: concurrent 401s from parallel requests must not re-fire
+            // SessionExpired or thrash the DB settings.
+            if (string.IsNullOrEmpty(_authToken)) return;
+
             _authToken = null;
             _httpClient.DefaultRequestHeaders.Remove("Authorization");
             _dbService.SaveSetting("AuthToken", string.Empty);
             _dbService.SaveSetting("UserId", string.Empty);
 
             SessionExpired?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Detects a 401 response, clears auth state, and raises SessionExpired
+        /// (once, via the idempotent Logout). Returns true when the response was
+        /// a 401 and has been handled.
+        /// </summary>
+        private bool HandleUnauthorized(HttpResponseMessage response)
+        {
+            if (response.StatusCode != HttpStatusCode.Unauthorized) return false;
+            Logout();
+            return true;
         }
     }
 

--- a/desktop-app/Services/SessionManager.cs
+++ b/desktop-app/Services/SessionManager.cs
@@ -204,6 +204,12 @@ namespace FlowShield.Desktop.Services
         /// </summary>
         public async Task TriggerResyncAsync()
         {
+            // A missing/revoked token makes GetActiveSessionAsync return null, which
+            // the logic below would misread as "session stopped on another device"
+            // and kill the local session + disengage blocking. Never resync while
+            // unauthenticated — the local session must survive token revocation.
+            if (!_apiClient.IsAuthenticated()) return;
+
             try
             {
                 var session = await _apiClient.GetActiveSessionAsync();

--- a/desktop-app/UI/TrayApplication.cs
+++ b/desktop-app/UI/TrayApplication.cs
@@ -438,10 +438,11 @@ namespace FlowShield.Desktop.UI
                 // one, leaking a timer. Rely on LoginForm's Start() call instead.
                 _ = _sessionManager.InitializeAsync();
 
-                // Recover from an expired-session period: resync session state and
-                // reconnect Pusher so real-time events resume with the fresh UserId.
+                // Recover from an expired-session period: resync session state so a
+                // session that changed while logged out is picked up. Pusher is
+                // reconnected by RegisterDeviceAndLoadPreferencesAsync above (it calls
+                // ConnectPusherAsync after prefs load), so no direct call is needed here.
                 _ = _sessionManager.TriggerResyncAsync();
-                ConnectPusherAsync();
             }
         }
 

--- a/desktop-app/UI/TrayApplication.cs
+++ b/desktop-app/UI/TrayApplication.cs
@@ -431,8 +431,17 @@ namespace FlowShield.Desktop.UI
                 // Register device and load preferences after successful login
                 RegisterDeviceAndLoadPreferencesAsync();
 
-                // Start background session polling and pick up any active session
+                // Start background session polling and pick up any active session.
+                // NOTE: _syncService.Start() is intentionally omitted here — LoginForm
+                // already calls it on successful login (LoginForm.cs LoginButton_Click).
+                // Calling it again would overwrite _syncTimer without disposing the old
+                // one, leaking a timer. Rely on LoginForm's Start() call instead.
                 _ = _sessionManager.InitializeAsync();
+
+                // Recover from an expired-session period: resync session state and
+                // reconnect Pusher so real-time events resume with the fresh UserId.
+                _ = _sessionManager.TriggerResyncAsync();
+                ConnectPusherAsync();
             }
         }
 
@@ -642,9 +651,21 @@ namespace FlowShield.Desktop.UI
         private void OnSessionExpired(object? sender, EventArgs e)
         {
             _syncService.Stop();
-            _notificationService.NotifyLogout(); // Or a specific session expired notification
+            _notificationService.NotifyLogout();
             BuildContextMenu();
             _trayIcon.ContextMenuStrip = _contextMenu;
+
+            // Prompt re-login via balloon. Handler is detached on fire so a later
+            // unrelated balloon (e.g. sync notification) does not open the login dialog.
+            _trayIcon.BalloonTipClicked += OnSessionExpiredBalloonClicked;
+            _trayIcon.ShowBalloonTip(10000, "FlowShield",
+                "Session expired — click here to log in again.", ToolTipIcon.Warning);
+        }
+
+        private void OnSessionExpiredBalloonClicked(object? sender, EventArgs e)
+        {
+            _trayIcon.BalloonTipClicked -= OnSessionExpiredBalloonClicked;
+            ShowLoginDialog();
         }
 
         private async void ConnectPusherAsync()

--- a/dev-docs/APP_ANALYSIS_2026-08-11.md
+++ b/dev-docs/APP_ANALYSIS_2026-08-11.md
@@ -1,0 +1,185 @@
+# FlowShield — Full App Analysis (2026-08-11)
+
+Branch: `feat/token-revocation` · Analysis by 4 parallel code explorers (web, desktop, mobile+extension, cross-surface).
+
+---
+
+## 1. Feature Matrix
+
+| Feature | Web | Desktop | Mobile | Extension |
+|---------|-----|---------|--------|-----------|
+| Sessions: start/stop | ✅ | ✅ | ✅ | ❌ (read-only) |
+| Sessions: pause/resume | ✅ | ⚠️ partial (blocking not restored) | ❌ | ❌ |
+| Active session fetch | ✅ | ✅ | ✅ | ✅ |
+| Activity sync | ✅ | ✅ | ✅ | ✅ |
+| Category normalization | ✅ `resolveCategory` | ✅ `NormalizeCategory` | ❌ raw pass-through | ✅ `categoryForDomain` |
+| Analytics | ✅ | ❌ stub | ✅ | ❌ |
+| Goals | ✅ | ❌ stub | unclear | ❌ |
+| Projects | ✅ | ❌ stub | unclear | ❌ |
+| Teams | ✅ | ❌ stub | ❌ | ❌ |
+| AI Coach | ✅ | ⚠️ partial (SSE works, no context) | ❌ | ❌ |
+| Token revocation (tokenVersion) | ✅ | ❌ | ❌ | ❌ |
+| 401 handling UX | ✅ | ⚠️ throws, no re-login UI | ⚠️ generic error | ✅ clears token |
+| EMAIL_NOT_VERIFIED surfaced | ✅ | ✅ | ✅ | ❌ |
+| Timer: server-anchored | ✅ | ✅ | ❌ local countdown | ❌ |
+| Signup | ✅ | ❌ | ❌ (redirects to web) | ❌ |
+| Google OAuth | ✅ | ❌ | ❌ | ❌ |
+
+---
+
+## 2. Web App
+
+### Capabilities
+- **Auth:** signup + email verification, login (rate-limited 10/15min), password reset (token-based, tokenVersion bump), forgot password, resend verification, Google OAuth, token revocation via tokenVersion
+- **Sessions:** CRUD, pause/toggle, auto-end with 5min grace, 409 on concurrent active session, duration capping vs clock-skew abuse
+- **Analytics:** weekly/monthly/yearly, Redis-cached, distraction + peak-time detection
+- **Teams:** CRUD, role-based member removal, self-leave, cascade delete
+- **Goals:** create/list/upsert, 4 types (DAILY_TIME, WEEKLY_TIME, STREAK, PRODUCTIVITY_SCORE), one active per type
+- **Projects:** CRUD with cost tracking (hourlyRate, budget, plannedHours), session linking
+- **AI Coach:** Gemini SSE, tier-quota (FREE 1/month, PRO/TEAM unlimited), tiered caching
+- **Admin:** user management, announcement/digest emails, settings, stats
+- **Misc:** push notifications, weekly digest cron, data export, leaderboard, health check
+
+### Missing Logic (with evidence)
+| # | Finding | Evidence | Severity |
+|---|---------|----------|----------|
+| 1 | No `/api/auth/logout` endpoint — client-side only; can't revoke mid-session | 9 auth routes, no logout | HIGH |
+| 2 | No token refresh/rotation | `login/route.ts` issues single JWT | MED |
+| 3 | No email-change endpoint | `user/profile/route.ts` only updates name/timezone/prefs | MED |
+| 4 | No `/api/goals/[id]` — can't delete individual goal | `goals/route.ts` POST/GET only | MED |
+| 5 | Subscription tier not enforced anywhere except coach | `coach/advice/route.ts:93-120` only gate; 61 refs mostly logging | HIGH |
+| 6 | Rate limiting only on auth routes — analytics/export/leaderboard/activity unprotected | `rate-limit.ts` used in auth only | HIGH |
+| 7 | Pagination missing/inconsistent — goals no limit, analytics unbounded date-fill | `goals/route.ts`, `leaderboard/route.ts:57` | MED |
+| 8 | Password reset token stored **plaintext** in DB | `reset-password/route.ts:36` `findUnique({passwordResetToken})` | HIGH (security) |
+| 9 | `emailVerified` not enforced in protected routes — unverified accounts fully functional | `getAuthUserId()` no check | MED |
+| 10 | Leaderboard exposes all users platform-wide (names + minutes) to any authed user | `leaderboard/route.ts:45-58` | MED (privacy) |
+| 11 | No `subscriptionExpires` field — expire-subscriptions cron likely no-op; PRO never expires | schema + `cron/expire-subscriptions` | MED |
+| 12 | No MFA/2FA | no TOTP schema/routes | LOW |
+| 13 | No email unsubscribe endpoint — GDPR risk | admin sends emails, no opt-out handler | MED |
+| 14 | No account recovery beyond password reset (email loss = permanent lock) | — | LOW |
+
+### Incapabilities
+- No payment integration (Stripe/Lemon Squeezy) — subs tracked, never billed or enforced
+- No org/workspace hierarchy, no team goals/shared projects, no team invitations (code-join only)
+- No recurring goals/habits, no calendar integration, no time-blocking
+- No SSO/SAML, no audit logging, no data-retention policies
+- No circuit breakers for Gemini/Pusher/Redis; no retry for failed notifications
+
+---
+
+## 3. Desktop App
+
+### Capabilities
+- Session start/stop with server-anchored timer; state persistence
+- Activity tracking (keyboard/mouse hooks, categorization, per-session attribution)
+- Website blocking (hosts file + admin check + DNS flush + stale-block recovery)
+- App blocking (process kill enforcement)
+- Cross-device sync (30s poll + Pusher, 4-case conflict handling)
+- Offline queue (synced flag, exponential backoff, network-reconnect resync)
+- Auth (bearer token, DB storage, 401 → SessionExpired event)
+- Auto-update check, DPAPI key protection, autostart
+
+### Missing Logic
+| # | Finding | Evidence | Severity |
+|---|---------|----------|----------|
+| 1 | Pause/resume: **blocking NOT restored on resume** — acknowledged bug comment | `SessionManager.cs:99-100` | HIGH |
+| 2 | 401 → Logout + event but no re-login UI; token has no stored expiry (reactive only) | `ApiClient.cs:702`, `ApiClient.cs:45-89` | HIGH |
+| 3 | **8+ empty catch blocks** — silent state corruption | `DatabaseService.cs:455,486`, `SessionManager.cs:105,188,262`, `WebsiteBlocker.cs:108`, `ApiClient.cs` ×9 | HIGH |
+| 4 | Multi-device race: simultaneous start on two devices → conflicting events; no mutex on `CurrentSession`/`IsPaused`/`IsRunning` triplet | `SessionManager.cs:210-235, 27-30` | MED |
+| 5 | Admin check at EnableBlocking() call, not startup — no graceful degrade | `WebsiteBlocker.cs:191-193` | MED |
+| 6 | Offline queue: no dedup — retried sync can double-count activities → inflated stats | `SyncService.cs`, `ApiClient.cs` | MED |
+| 7 | DispatcherTimer (UI) + _reSyncTimer (system thread) uncoordinated — state flip-flop | `SessionManager.cs:60-62` | MED |
+| 8 | Update: no rollback/atomic install — failed update can corrupt binary | `UpdateService.cs:80-180` | LOW |
+| 9 | No tokenVersion awareness — revoked tokens work until server 401s | `ApiClient.cs` | HIGH |
+
+### Incapabilities (roadmap sprints 14–18 undone)
+| Feature | State |
+|---------|-------|
+| Pause/resume | PARTIAL/BROKEN (blocking loss) |
+| Analytics dashboard | STUB — API method wired, UI doesn't load data |
+| Goals | STUB — hardcoded test data in GoalsWindow |
+| AI Coach | PARTIAL — SSE streams, no session context/personalization |
+| Teams/Leaderboards | STUB — fetch works, no invite/join/sync, no data loading |
+| Projects | STUB — window exists, no CRUD calls |
+
+---
+
+## 4. Mobile App
+
+### Capabilities
+- Login (email/password), auth persistence (SecureStore)
+- Dashboard analytics (week/month), Focus Timer (15/25/45/60min, WORK/STUDY/CREATIVE)
+- Timer pause/resume/cancel **local controls** (but no server pause endpoint call)
+- Session history with scores/badges
+- Offline activity queue with retry, push notifications (Expo)
+
+### Missing Logic
+| # | Finding | Evidence | Severity |
+|---|---------|----------|----------|
+| 1 | No in-app signup — redirects to flowshield.app | `LoginScreen.tsx:38` | MED |
+| 2 | No Google OAuth | `auth.tsx` | LOW |
+| 3 | **Timer local countdown — no server startTime anchor** — violates project timer rule; drift/sleep breaks it | `TimerScreen.tsx:55-80` | HIGH |
+| 4 | No pause endpoint call — `toggle-pause` never invoked; can't see paused state from other devices | `api.ts` zero pause refs | HIGH |
+| 5 | No token refresh; clears on failure only; generic errors lose codes | `api.ts:40-55` | MED |
+| 6 | Offline queue unbounded — no max length/TTL (desktop has 500-cap/7d TTL; mobile doesn't) | `offlineQueue.ts:1-20` | MED |
+| 7 | No iOS push config (Android channel only) | `notifications.ts:30-35` | MED |
+| 8 | Settings toggles not persisted to API | `SettingsScreen.tsx:15-50` | LOW |
+| 9 | No category normalization — raw pass-through to sync | `api.ts` | MED |
+| 10 | No tokenVersion awareness | `api.ts` | HIGH |
+
+### Incapabilities
+- No signup, no OAuth, no server-anchored timing, no pause sync, no teams/coach/goals/projects
+
+---
+
+## 5. Browser Extension
+
+### Capabilities
+- Badge timer (remaining minutes), tab tracking + domain categorization
+- 1-min activity sync alarm, 30s session poll, FORCE_POLL_SESSION
+- Distraction detection vs user prefs
+- Login/logout popup; 401 clears stale token
+- Chrome MV3 + Firefox MV2 near-parity
+
+### Missing Logic
+| # | Finding | Evidence | Severity |
+|---|---------|----------|----------|
+| 1 | **Chrome popup calls MV2-only `browser.tabs.executeScript()`** — doesn't exist in MV3; should be `chrome.scripting.executeScript()` | `chrome/popup/popup.js:15-25` | HIGH (bug) |
+| 2 | On 401: `pendingLogs = []` — **unsynced activity discarded** | `chrome/background.js` | MED |
+| 3 | `pendingLogs` unbounded — no TTL/max size | `chrome/background.js:180-195` | MED |
+| 4 | Sync retry: no backoff, no retry cap | `chrome/background.js:215-235` | MED |
+| 5 | MV3 service worker suspension — no keepalive strategy for long idle | `chrome/manifest.json` | LOW |
+| 6 | EMAIL_NOT_VERIFIED not surfaced (other clients fixed in #110) | popup.js | MED |
+| 7 | No signup flow | popup.js:60-90 | LOW |
+
+### Incapabilities
+- Cannot start/stop/pause sessions from popup (read-only)
+- Cannot edit blocklist/distractions from popup
+- No token refresh, no offline backoff queue
+
+---
+
+## 6. Cross-Surface Gaps (highest-value fixes)
+
+| Risk | Severity | Root cause |
+|------|----------|-----------|
+| Token revocation invisible to desktop/mobile/extension — revoked tokens keep working until next 401; desktop has no re-login UX at all | **CRITICAL** | tokenVersion only enforced server-side; clients don't handle revocation UX (relevant to current branch `feat/token-revocation`) |
+| Mobile timer drift | HIGH | Local countdown, violates server-anchor rule all other surfaces follow |
+| Pause state fragmentation | HIGH | Web ✅, desktop ⚠️ (blocking lost), mobile ❌, extension ❌ — pausing from web leaves mobile timer running blind |
+| Desktop silent 401s | HIGH | Throws without SessionExpired invoke on several call paths (`ApiClient.cs:166,250,315`) |
+| Category normalization ×3 implementations | MED | Desktop NormalizeCategory / web resolveCategory / mobile none → analytics fragmentation |
+| Activity sync payload drift | MED | Zod optional-heavy schema silently drops fields; 3 clients send different shapes |
+| Extension discards pending logs on 401 | MED | Data loss on token expiry |
+
+---
+
+## 7. Recommended Priority Order
+
+1. **Finish token revocation across clients** (current branch): 401/revocation → clear token + re-login prompt on desktop/mobile/extension; add `/api/auth/logout`. Desktop: fire `SessionExpired` on all 401 paths.
+2. **Fix Chrome popup MV2 API bug** (`browser.tabs.executeScript` → broken in MV3).
+3. **Mobile timer server-anchoring** (known project gotcha, mobile violates it).
+4. **Hash password reset tokens** in DB.
+5. **Rate-limit non-auth routes** (analytics, export, leaderboard, activity sync).
+6. **Desktop pause/resume blocking restore** (SessionManager.cs:99-100).
+7. **Subscription enforcement or drop the tiers** — currently decorative outside coach.
+8. Bound mobile + extension offline queues (mirror desktop's 500/7d).

--- a/docs/superpowers/plans/2026-08-11-token-revocation-clients.md
+++ b/docs/superpowers/plans/2026-08-11-token-revocation-clients.md
@@ -1,0 +1,1090 @@
+# Token Revocation Client Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a revoked JWT unusable on every surface within ~30s, with re-login UX and zero data loss; add a "log out of all devices" endpoint + UI.
+
+**Architecture:** Reactive 401 handling only — the server already rejects revoked tokens (`web-app/src/lib/jwt.ts` checks the `tv` claim against `User.tokenVersion`, Redis-cached). Clients detect the resulting 401s on their existing ≤30s polls. New `POST /api/auth/logout-all` bumps `tokenVersion`. Active focus sessions are never killed by auth loss; unsynced activity is preserved and replayed after re-login.
+
+**Tech Stack:** Next.js 16 App Router + Prisma + Upstash Redis (web) · .NET 8 WinForms/WPF + xUnit/Moq (desktop) · Expo/React Native (mobile) · Chrome MV3 + Firefox MV2 vanilla JS (extension)
+
+**Spec:** `docs/superpowers/specs/2026-08-11-token-revocation-clients-design.md`
+
+## Reality Corrections (verified against code; supersede the spec where they conflict)
+
+1. Extension EMAIL_NOT_VERIFIED is ALREADY implemented in both popups (`chrome/popup/popup.js:97`, `firefox/popup/popup.js:128`) — no task for it.
+2. Extension badge ALREADY clears when session is null (`formatBadge(null)` → `''`) — no task for it.
+3. Desktop mutation paths (sync, start session, toggle-pause, goals, projects, teams) ALREADY call `Logout()` which fires `SessionExpired`. The real gaps: (a) silent GET methods — including `GetActiveSessionAsync`, polled every 30s — swallow 401s and never fire the event; (b) `Logout()` is not idempotent so concurrent 401s fire the event repeatedly; (c) **`SessionManager.TriggerResyncAsync()` interprets the null returned by an unauthenticated `GetActiveSessionAsync()` as "session stopped on another device" and kills the local session + disengages blocking (`SessionManager.cs:221-236`)** — revocation currently destroys an active focus session, the exact opposite of the spec guarantee.
+
+## Global Constraints
+
+- `npm run lint` must return **zero errors** (warnings OK) before any push — CI hard-fails on errors.
+- `npm run build` must pass locally before push.
+- All 3 suites stay green: 115 Vitest (`cd web-app && npm test`), 94 xUnit (`cd desktop-app && dotnet test`), 12 Playwright specs.
+- Never use `<a href>` for internal Next.js navigation — `<Link>` only.
+- Timer rule: never `prev - 1` countdowns; anchor to server `startTime` (not changed by this plan, don't regress it).
+- Chrome and Firefox extension directories are fully independent copies — every extension change is made in BOTH `browser-extension/chrome/` and `browser-extension/firefox/` (Firefox uses `browser.*` namespace, Chrome uses `chrome.*`).
+- Desktop nullable is enabled; match existing Serilog `Log.Warning/Error` style.
+- Commit messages: conventional commits, no Co-Authored-By lines.
+
+---
+
+### Task 1: `POST /api/auth/logout-all` endpoint (web)
+
+**Files:**
+- Create: `web-app/src/app/api/auth/logout-all/route.ts`
+- Create: `web-app/src/app/api/auth/logout-all/route.test.ts`
+- Modify: `web-app/openapi.yaml` (add endpoint entry under the Auth tag, matching existing entry style)
+
+**Interfaces:**
+- Consumes: `getAuthUserId(request)`, `revokeUserTokens(userId)` from `@/lib/jwt`; `rateLimit(key, limit, windowMs)` from `@/lib/rate-limit`; `prisma` from `@/lib/prisma`.
+- Produces: `POST /api/auth/logout-all` — bearer-auth'd, no body, returns `204` on success, `401` unauthenticated, `429` rate-limited. Tasks 2, 7, 8 call this endpoint.
+
+- [ ] **Step 1: Write the failing test**
+
+Check `web-app/vitest.config.ts` (or `vite.config.ts`) resolves the `@/` alias; if not, add `resolve: { alias: { '@': path.resolve(__dirname, 'src') } }`.
+
+```ts
+// web-app/src/app/api/auth/logout-all/route.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { update: vi.fn() } },
+}));
+vi.mock('@/lib/jwt', () => ({
+  getAuthUserId: vi.fn(),
+  revokeUserTokens: vi.fn(),
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn(),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST } from './route';
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
+import { rateLimit } from '@/lib/rate-limit';
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/auth/logout-all', { method: 'POST' });
+}
+
+describe('POST /api/auth/logout-all', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 4, resetInMs: 0 });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue(null);
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when rate limited', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    vi.mocked(rateLimit).mockResolvedValue({ allowed: false, remaining: 0, resetInMs: 60000 });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(429);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('bumps tokenVersion, busts the cache, and returns 204', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(204);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { tokenVersion: { increment: 1 } },
+    });
+    expect(revokeUserTokens).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns 500 when the DB update throws', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    vi.mocked(prisma.user.update).mockRejectedValue(new Error('db down'));
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web-app && npx vitest run src/app/api/auth/logout-all/route.test.ts`
+Expected: FAIL — cannot resolve `./route`
+
+- [ ] **Step 3: Write the route**
+
+```ts
+// web-app/src/app/api/auth/logout-all/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
+import { rateLimit } from '@/lib/rate-limit';
+import { logger } from '@/lib/logger';
+
+/**
+ * Log out of all devices: bump the user's tokenVersion so every token minted
+ * before now fails the `tv` check in getAuthUserId, then bust the Redis cache
+ * so the new version takes effect immediately. The caller clears its own
+ * stored token after a 204.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUserId(request);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Rate limit: 5 per hour per user
+    const rl = await rateLimit(`logout-all:${userId}`, 5, 60 * 60 * 1000);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(rl.resetInMs / 1000)) } }
+      );
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { tokenVersion: { increment: 1 } },
+    });
+    await revokeUserTokens(userId);
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    logger.error('Logout-all error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web-app && npx vitest run src/app/api/auth/logout-all/route.test.ts`
+Expected: 4 PASS
+
+- [ ] **Step 5: Add OpenAPI entry**
+
+In `web-app/openapi.yaml`, add under paths (match the file's existing style for auth endpoints):
+
+```yaml
+  /api/auth/logout-all:
+    post:
+      tags: [Auth]
+      summary: Log out of all devices
+      description: Increments the user's tokenVersion, revoking every previously issued JWT.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: All tokens revoked
+        "401":
+          description: Missing or invalid token
+        "429":
+          description: Rate limited (5/hour per user)
+```
+
+- [ ] **Step 6: Full web suite + lint**
+
+Run: `cd web-app && npm test && npm run lint`
+Expected: 119 tests pass (115 + 4 new), zero lint errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web-app/src/app/api/auth/logout-all/ web-app/openapi.yaml web-app/vitest.config.ts
+git commit -m "feat(auth): add POST /api/auth/logout-all endpoint bumping tokenVersion"
+```
+
+---
+
+### Task 2: "Log out of all devices" button on web profile page
+
+**Files:**
+- Modify: `web-app/src/app/(app)/profile/page.tsx` (~line 920, next to the existing "Danger zone — Delete account" section)
+
+**Interfaces:**
+- Consumes: `POST /api/auth/logout-all` (Task 1); `getToken`, `removeToken`, `removeUserData` from `@/lib/auth-token`; the page's existing `router` and `onMessage({ type, text })` feedback pattern (see the delete-account handler at ~line 849-863).
+
+- [ ] **Step 1: Read the existing danger-zone section**
+
+Read `web-app/src/app/(app)/profile/page.tsx:840-956` to match the exact card/button component structure and the `onMessage` prop plumbing of the delete-account block.
+
+- [ ] **Step 2: Add handler + UI**
+
+Add a handler following the delete-account handler's shape:
+
+```tsx
+const handleLogoutAll = async () => {
+  setLogoutAllBusy(true);
+  try {
+    const res = await fetch('/api/auth/logout-all', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${getToken()}` },
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      onMessage({ type: 'error', text: data.error || 'Failed to log out of all devices.' });
+      return;
+    }
+    removeToken();
+    removeUserData();
+    router.push('/auth/login');
+  } finally {
+    setLogoutAllBusy(false);
+  }
+};
+```
+
+with `const [logoutAllBusy, setLogoutAllBusy] = useState(false);` and a section above the Danger zone:
+
+```tsx
+<h2 className="...">Security</h2>
+<p className="...">Signed in on another device you don't recognize? This signs you out everywhere, including this browser.</p>
+<button onClick={handleLogoutAll} disabled={logoutAllBusy} className="...">
+  {logoutAllBusy ? 'Logging out…' : 'Log out of all devices'}
+</button>
+```
+
+Copy the Tailwind classes from the surrounding sections (heading, description, and a non-red variant of the danger button). Add `removeUserData` to the existing `@/lib/auth-token` import on line 5.
+
+- [ ] **Step 3: Verify build + lint**
+
+Run: `cd web-app && npm run lint && npm run build`
+Expected: zero lint errors, build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "web-app/src/app/(app)/profile/page.tsx"
+git commit -m "feat(web): log-out-of-all-devices button on profile page"
+```
+
+---
+
+### Task 3: Playwright E2E — revocation kills the other session
+
+**Files:**
+- Create: `web-app/e2e/logout-all.spec.ts`
+
+**Interfaces:**
+- Consumes: `POST /api/auth/login`, `POST /api/auth/logout-all`, `GET /api/sessions` (any auth'd route works as the probe).
+
+- [ ] **Step 1: Read an existing auth-using spec**
+
+Read `web-app/e2e/auth.spec.ts` to learn how existing specs obtain test credentials / base URL (env vars, fixtures, or helpers). Reuse that mechanism verbatim.
+
+- [ ] **Step 2: Write the spec**
+
+API-level test (no browser UI needed — matches `api-health.spec.ts` style). Adapt the credential source to what Step 1 found; skip when credentials are absent, same as existing specs handle it:
+
+```ts
+// web-app/e2e/logout-all.spec.ts
+import { test, expect } from '@playwright/test';
+
+const EMAIL = process.env.E2E_EMAIL;      // adapt to the repo's actual convention
+const PASSWORD = process.env.E2E_PASSWORD;
+
+test.describe('logout-all revocation', () => {
+  test.skip(!EMAIL || !PASSWORD, 'E2E credentials not configured');
+
+  test('revokes a second token within one request', async ({ request }) => {
+    const loginA = await request.post('/api/auth/login', {
+      data: { email: EMAIL, password: PASSWORD },
+    });
+    expect(loginA.ok()).toBeTruthy();
+    const { token: tokenA } = await loginA.json();
+
+    const loginB = await request.post('/api/auth/login', {
+      data: { email: EMAIL, password: PASSWORD },
+    });
+    const { token: tokenB } = await loginB.json();
+
+    // Both tokens work
+    const probeB = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenB}` },
+    });
+    expect(probeB.status()).toBe(200);
+
+    // Logout-all with token A
+    const revoke = await request.post('/api/auth/logout-all', {
+      headers: { Authorization: `Bearer ${tokenA}` },
+    });
+    expect(revoke.status()).toBe(204);
+
+    // Token B is now dead
+    const probeBAfter = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenB}` },
+    });
+    expect(probeBAfter.status()).toBe(401);
+
+    // Token A is dead too (it was minted before the bump)
+    const probeAAfter = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenA}` },
+    });
+    expect(probeAAfter.status()).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 3: Run the spec**
+
+Run: `cd web-app && npx playwright test e2e/logout-all.spec.ts`
+Expected: PASS (or SKIP if credentials unavailable locally — in that case run the full existing suite to confirm nothing broke: `npx playwright test`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web-app/e2e/logout-all.spec.ts
+git commit -m "test(e2e): logout-all revokes concurrent tokens"
+```
+
+---
+
+### Task 4: Desktop — idempotent Logout + 401 detection in silent methods
+
+**Files:**
+- Modify: `desktop-app/Services/ApiClient.cs`
+- Test: `desktop-app/FlowShield.Desktop.Tests/ApiClientTests.cs`
+
+**Interfaces:**
+- Consumes: existing test helpers in `ApiClientTests.cs` — `BuildClient(Mock<IDatabaseService>, FakeHttpHandler)`, `AuthenticatedDb()`, `FakeHttpHandler(HttpStatusCode, string)`.
+- Produces: `ApiClient.Logout()` becomes idempotent (fires `SessionExpired` at most once per authenticated period); every API method that receives a 401 clears auth state and fires the event. Task 5 and 6 depend on the single-fire guarantee.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `ApiClientTests.cs`, following its existing patterns:
+
+```csharp
+[Fact]
+public void Logout_CalledTwice_RaisesSessionExpiredOnce()
+{
+    var client = BuildClient(AuthenticatedDb(), new FakeHttpHandler());
+    var fired = 0;
+    client.SessionExpired += (_, _) => fired++;
+
+    client.Logout();
+    client.Logout();
+
+    Assert.Equal(1, fired);
+    Assert.False(client.IsAuthenticated());
+}
+
+[Fact]
+public async Task GetActiveSession_On401_ClearsTokenAndRaisesSessionExpired()
+{
+    var handler = new FakeHttpHandler(HttpStatusCode.Unauthorized, "");
+    var client = BuildClient(AuthenticatedDb(), handler);
+    var fired = 0;
+    client.SessionExpired += (_, _) => fired++;
+
+    var result = await client.GetActiveSessionAsync();
+
+    Assert.Null(result);
+    Assert.False(client.IsAuthenticated());
+    Assert.Equal(1, fired);
+}
+
+[Fact]
+public async Task GetUserPreferences_On401_ClearsTokenAndRaisesSessionExpired()
+{
+    var handler = new FakeHttpHandler(HttpStatusCode.Unauthorized, "");
+    var client = BuildClient(AuthenticatedDb(), handler);
+    var fired = 0;
+    client.SessionExpired += (_, _) => fired++;
+
+    var result = await client.GetUserPreferencesAsync();
+
+    Assert.Null(result);
+    Assert.False(client.IsAuthenticated());
+    Assert.Equal(1, fired);
+}
+```
+
+NOTE: if an existing test asserts `GetActiveSessionAsync` returns null on 401 WITHOUT the event (there is a 401 test near line 128), keep its return-value assertion and update its expectations to the new behavior rather than deleting it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd desktop-app && dotnet test --filter "FullyQualifiedName~ApiClientTests"`
+Expected: the 3 new tests FAIL (event count 0 or 2, token not cleared)
+
+- [ ] **Step 3: Implement**
+
+In `ApiClient.cs`:
+
+(a) Make `Logout()` (line 729) idempotent:
+
+```csharp
+public void Logout()
+{
+    // Idempotent: concurrent 401s from parallel requests must not re-fire
+    // SessionExpired or thrash the DB settings.
+    if (string.IsNullOrEmpty(_authToken)) return;
+
+    _authToken = null;
+    _httpClient.DefaultRequestHeaders.Remove("Authorization");
+    _dbService.SaveSetting("AuthToken", string.Empty);
+    _dbService.SaveSetting("UserId", string.Empty);
+
+    SessionExpired?.Invoke(this, EventArgs.Empty);
+}
+```
+
+(b) Add a helper near `Logout()`:
+
+```csharp
+/// <summary>
+/// Detects a 401 response, clears auth state, and raises SessionExpired
+/// (once, via the idempotent Logout). Returns true when the response was
+/// a 401 and has been handled.
+/// </summary>
+private bool HandleUnauthorized(HttpResponseMessage response)
+{
+    if (response.StatusCode != HttpStatusCode.Unauthorized) return false;
+    Logout();
+    return true;
+}
+```
+
+(c) In every silent-null method, insert the check between receiving the response and the `IsSuccessStatusCode` check. Pattern:
+
+```csharp
+var response = await _httpClient.GetAsync("...");
+if (HandleUnauthorized(response)) return null;
+if (!response.IsSuccessStatusCode) return null;
+```
+
+Apply to: `GetActiveSessionAsync` (:185), `GetUserPreferencesAsync` (:360), `GetAnalyticsAsync` (:459), `GetSessionHistoryAsync` (:472), `GetGoalsAsync` (:486), `GetProjectsAsync` (:525), `UpdatePreferencesAsync` (:574), `GetLeaderboardAsync` (:589), `GetTeamsAsync` (:642), `GetCategoryRulesAsync` (:714), and `EndSessionAsync` (:290 — returns `false` instead of `null`), `RegisterDeviceAsync` (:403 — returns `false`).
+
+Leave the mutation paths (`SyncActivitiesAsync`, `StartSessionAsync`, `TogglePauseAsync`, `SetGoalAsync`, `CreateProjectAsync`, `CreateTeamAsync`, `JoinTeamAsync`) as they are — they already `Logout()` + throw, and the idempotent `Logout()` now de-duplicates the event.
+
+- [ ] **Step 4: Run the full desktop suite**
+
+Run: `cd desktop-app && dotnet test`
+Expected: all pass (94 existing + 3 new = 97; adjust count if Step 1's NOTE modified a test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop-app/Services/ApiClient.cs desktop-app/FlowShield.Desktop.Tests/ApiClientTests.cs
+git commit -m "fix(desktop): detect 401 in all API calls; make Logout idempotent"
+```
+
+---
+
+### Task 5: Desktop — revocation must not kill the local session
+
+**Files:**
+- Modify: `desktop-app/Services/SessionManager.cs:205-263` (`TriggerResyncAsync`)
+- Test: `desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs`
+
+**Interfaces:**
+- Consumes: `IApiClient.IsAuthenticated()` — confirm the interface in `desktop-app/Interfaces/` declares it (the concrete `ApiClient` has it at :376); add to the interface if missing.
+- Produces: `TriggerResyncAsync()` is a no-op while unauthenticated. This is what keeps the 30s poll from reading an auth-less `GetActiveSessionAsync() == null` as "session stopped remotely" (`SessionManager.cs:221-236`).
+
+- [ ] **Step 1: Write the failing test**
+
+Read `SessionManagerTests.cs` first to reuse its existing mock setup (it mocks `IApiClient`, `IActivityTracker`, `INotificationService`, `IWebsiteBlocker`, `IApplicationBlocker`). Then add:
+
+```csharp
+[Fact]
+public async Task TriggerResync_WhenUnauthenticated_DoesNotCallApiOrTouchSession()
+{
+    // Arrange: manager with a mocked IApiClient that reports unauthenticated.
+    // Reuse the test class's existing helper/builder for SessionManager.
+    _apiClientMock.Setup(a => a.IsAuthenticated()).Returns(false);
+
+    // Act
+    await _sessionManager.TriggerResyncAsync();
+
+    // Assert: the resync never even asks the server — a null active-session
+    // response while logged out must not be mistaken for a remote stop.
+    _apiClientMock.Verify(a => a.GetActiveSessionAsync(), Times.Never);
+}
+```
+
+(Adapt field/builder names to the test class's existing conventions.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd desktop-app && dotnet test --filter "FullyQualifiedName~SessionManagerTests"`
+Expected: new test FAILS (`GetActiveSessionAsync` was called once)
+
+- [ ] **Step 3: Implement the guard**
+
+At the top of `TriggerResyncAsync()` (`SessionManager.cs:205`):
+
+```csharp
+public async Task TriggerResyncAsync()
+{
+    // A missing/revoked token makes GetActiveSessionAsync return null, which
+    // the logic below would misread as "session stopped on another device"
+    // and kill the local session + disengage blocking. Never resync while
+    // unauthenticated — the local session must survive token revocation.
+    if (!_apiClient.IsAuthenticated()) return;
+
+    try
+    {
+        ...existing body unchanged...
+```
+
+If `IApiClient` lacks `IsAuthenticated()`, add `bool IsAuthenticated();` to the interface — the concrete implementation already exists.
+
+- [ ] **Step 4: Run the full desktop suite**
+
+Run: `cd desktop-app && dotnet test`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop-app/Services/SessionManager.cs desktop-app/FlowShield.Desktop.Tests/SessionManagerTests.cs desktop-app/Interfaces/
+git commit -m "fix(desktop): keep local session alive when token is revoked mid-session"
+```
+
+---
+
+### Task 6: Desktop — re-login prompt and post-login recovery
+
+**Files:**
+- Modify: `desktop-app/UI/TrayApplication.cs:642-648` (`OnSessionExpired`) and the login-success block at ~:422-435 (`ShowLoginDialog`)
+
+**Interfaces:**
+- Consumes: `SessionExpired` single-fire event (Task 4); existing `ShowLoginDialog()` at :422; `_syncService.Start()` / `SyncNowAsync()`; `_sessionManager.TriggerResyncAsync()`; `ConnectPusherAsync()`.
+- Produces: user-visible re-login path — tray balloon on expiry, click opens login; successful re-login restarts sync (replays offline queue), resyncs session state, reconnects Pusher.
+
+- [ ] **Step 1: Balloon prompt on expiry**
+
+Replace `OnSessionExpired` (:642):
+
+```csharp
+private void OnSessionExpired(object? sender, EventArgs e)
+{
+    _syncService.Stop();
+    _notificationService.NotifyLogout();
+    BuildContextMenu();
+    _trayIcon.ContextMenuStrip = _contextMenu;
+
+    // Prompt re-login: balloon click opens the login dialog. Handler is
+    // detached on fire so a later unrelated balloon doesn't open login.
+    _trayIcon.BalloonTipClicked += OnSessionExpiredBalloonClicked;
+    _trayIcon.ShowBalloonTip(10000, "FlowShield",
+        "Session expired — click here to log in again.", ToolTipIcon.Warning);
+}
+
+private void OnSessionExpiredBalloonClicked(object? sender, EventArgs e)
+{
+    _trayIcon.BalloonTipClicked -= OnSessionExpiredBalloonClicked;
+    ShowLoginDialog();
+}
+```
+
+- [ ] **Step 2: Post-login recovery**
+
+Read the `ShowLoginDialog` success block (~:424-435). After the existing register-device call, ensure ALL of the following happen (add whichever are missing):
+
+```csharp
+private void ShowLoginDialog()
+{
+    var loginForm = new LoginForm(_apiClient, _syncService, _dbService);
+    if (loginForm.ShowDialog() == DialogResult.OK)
+    {
+        BuildContextMenu();
+        _trayIcon.ContextMenuStrip = _contextMenu;
+
+        RegisterDeviceAndLoadPreferencesAsync();
+
+        // Recover from an expired-session period:
+        _syncService.Start();                        // resume periodic sync; replays PendingOperations + unsynced logs
+        _ = _sessionManager.TriggerResyncAsync();    // pick up session state changed while logged out
+        ConnectPusherAsync();                        // real-time events need the fresh UserId setting
+    }
+}
+```
+
+Check `LoginForm` internals first — if it already restarts `_syncService`, don't double-start (a second `Start()` replaces the timer; verify `SyncService.Start` at `SyncService.cs:67-76` is safe to call twice or guard accordingly — it overwrites `_syncTimer` without disposing the old one, so if both call it, remove the duplicate from `LoginForm` or dispose before re-creating).
+
+- [ ] **Step 3: Build + full suite**
+
+Run: `cd desktop-app && dotnet build && dotnet test`
+Expected: build clean, all tests pass
+
+- [ ] **Step 4: Manual smoke (needs Windows)**
+
+If on Windows: run the app, log in, revoke via web profile "Log out of all devices" (Task 2), wait ≤30s → balloon appears, session/blocking (if active) keep running, click balloon → login → sync resumes. If not on Windows, note this in the commit body as pending manual verification.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop-app/UI/TrayApplication.cs
+git commit -m "feat(desktop): re-login balloon on session expiry; restart sync+pusher after re-login"
+```
+
+---
+
+### Task 7: Mobile — 401 interceptor, error codes, logoutAll
+
+**Files:**
+- Modify: `mobile-app/src/lib/api.ts`
+
+**Interfaces:**
+- Consumes: existing `apiFetch`, `removeToken`, `removeStoredUser`; `POST /api/auth/logout-all` (Task 1).
+- Produces (Task 8 depends on these exact names):
+  - `class ApiError extends Error { code?: string; status: number }` (exported; `AuthError` stays for login)
+  - `export function setOnUnauthorized(handler: () => void): void` — module-level callback fired on 401
+  - `api.logoutAll(): Promise<void>`
+
+- [ ] **Step 1: Add ApiError + interceptor**
+
+In `api.ts`, after the `AuthError` class (:19-26):
+
+```ts
+/** Non-auth API error that preserves HTTP status and the API's error code. */
+export class ApiError extends Error {
+  code?: string;
+  status: number;
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// Fired when any authenticated call gets a 401 (token expired or revoked).
+// AuthProvider registers a handler that flags the session as expired.
+let onUnauthorized: (() => void) | null = null;
+export function setOnUnauthorized(handler: () => void): void {
+  onUnauthorized = handler;
+}
+```
+
+Modify `apiFetch` (:80-94) to intercept:
+
+```ts
+async function apiFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const token = await getToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string>),
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_URL}${path}`, { ...options, headers });
+
+  // 401 on an authenticated call = token expired or revoked. Login itself
+  // returns 401 for bad credentials — that's not a session expiry.
+  if (res.status === 401 && token && !path.startsWith('/api/auth/login')) {
+    await removeToken();
+    onUnauthorized?.();
+  }
+
+  return res;
+}
+```
+
+- [ ] **Step 2: Preserve error codes on all methods**
+
+Replace every generic `throw new Error('Failed to ...')` in `api.ts` with the ApiError pattern. Example for `getAnalytics` (:132) — apply the same shape to `getSessions` (:138), `startSession` (:152-155, currently half-done), `endSession` (:168), `cancelSession` (:180), `syncActivity` (:197):
+
+```ts
+if (!res.ok) {
+  const data = await res.json().catch(() => ({}));
+  throw new ApiError(data.error || 'Failed to fetch analytics', res.status, data.code);
+}
+```
+
+(Keep `AuthError` in `login` — screens already match on it.)
+
+- [ ] **Step 3: Add logoutAll**
+
+In the `api` object, after `logout` (:124):
+
+```ts
+async logoutAll(): Promise<void> {
+  const res = await apiFetch('/api/auth/logout-all', { method: 'POST' });
+  // 401 means the token was already dead — that's still "logged out everywhere".
+  if (!res.ok && res.status !== 401) {
+    const data = await res.json().catch(() => ({}));
+    throw new ApiError(data.error || 'Failed to log out of all devices', res.status, data.code);
+  }
+  await removeToken();
+  await removeStoredUser();
+},
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd mobile-app && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile-app/src/lib/api.ts
+git commit -m "feat(mobile): 401 interceptor, ApiError codes, logoutAll"
+```
+
+---
+
+### Task 8: Mobile — session-expired banner + logout-all in Settings
+
+**Files:**
+- Modify: `mobile-app/src/lib/auth.tsx`
+- Modify: `mobile-app/App.tsx` (or wherever the navigator is rendered under `AuthProvider` — read it first)
+- Modify: `mobile-app/src/screens/SettingsScreen.tsx`
+
+**Interfaces:**
+- Consumes: `setOnUnauthorized`, `api.logoutAll`, `ApiError` (Task 7).
+- Produces: `useAuth()` additionally returns `sessionExpired: boolean` and `logoutAll: () => Promise<void>`.
+
+- [ ] **Step 1: Extend the auth context**
+
+In `auth.tsx`:
+
+```tsx
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { api, User, setOnUnauthorized } from './api';
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+  sessionExpired: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  logoutAll: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  loading: true,
+  sessionExpired: false,
+  login: async () => {},
+  logout: async () => {},
+  logoutAll: async () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  useEffect(() => {
+    // Flag expiry instead of hard-logout: a running focus timer must keep
+    // running; the user re-authenticates via the banner when they choose.
+    setOnUnauthorized(() => setSessionExpired(true));
+    (async () => {
+      try {
+        const token = await api.getToken();
+        if (token) {
+          const stored = await api.getStoredUser();
+          if (stored) {
+            setUser(stored);
+          }
+        }
+      } catch {
+        // Token invalid or storage error
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const { user: u } = await api.login(email, password);
+    setUser(u);
+    setSessionExpired(false);
+  };
+
+  const logout = async () => {
+    await api.logout();
+    setUser(null);
+    setSessionExpired(false);
+  };
+
+  const logoutAll = async () => {
+    await api.logoutAll();
+    setUser(null);
+    setSessionExpired(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, sessionExpired, login, logout, logoutAll }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+```
+
+- [ ] **Step 2: Global expired banner**
+
+Read `App.tsx` / `AppNavigator.tsx` to find the component INSIDE `AuthProvider` that renders the navigator. Add there (colors from `src/lib/theme.ts`):
+
+```tsx
+const { sessionExpired, user, logout } = useAuth();
+...
+{sessionExpired && user && (
+  <TouchableOpacity
+    style={{ backgroundColor: '#f59e0b', paddingVertical: 10, paddingHorizontal: 16 }}
+    onPress={() => { logout(); }}
+  >
+    <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600' }}>
+      Session expired — tap to log in again
+    </Text>
+  </TouchableOpacity>
+)}
+```
+
+Rendered above the navigator so it shows on every screen, including a running timer. Tapping calls `logout()` → `user` null → navigator lands on LoginScreen. Match the file's existing style conventions (StyleSheet vs inline).
+
+- [ ] **Step 3: Settings row**
+
+In `SettingsScreen.tsx`, add a row (match existing row styling) with confirm dialog:
+
+```tsx
+const { logoutAll } = useAuth();
+
+const handleLogoutAll = () => {
+  Alert.alert(
+    'Log out of all devices?',
+    'This signs you out everywhere, including this phone.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Log out everywhere',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await logoutAll();
+          } catch {
+            Alert.alert('Error', 'Could not log out of all devices. Check your connection.');
+          }
+        },
+      },
+    ]
+  );
+};
+```
+
+- [ ] **Step 4: Typecheck + manual verify**
+
+Run: `cd mobile-app && npx tsc --noEmit`
+Expected: no errors.
+Manual (Expo Go): log in on phone → revoke from web profile → next API call (open Dashboard) shows banner; if a timer is running it keeps counting; tap banner → login screen; log back in → banner gone. Settings → "Log out of all devices" → lands on login.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile-app/src/lib/auth.tsx mobile-app/App.tsx mobile-app/src/navigation/ mobile-app/src/screens/SettingsScreen.tsx
+git commit -m "feat(mobile): session-expired banner and log-out-of-all-devices"
+```
+
+---
+
+### Task 9: Extension (Chrome) — preserve pending logs across 401, replay after re-login
+
+**Files:**
+- Modify: `browser-extension/chrome/background.js`
+- Modify: `browser-extension/chrome/popup/popup.js:116-119` (logout button)
+
+**Interfaces:**
+- Consumes: existing `pendingLogs` array, `syncActivities()` (:103-127), `flushCurrentTab()` (:74-90), message handlers (:221-266).
+- Produces: `pendingLogs` persisted to `chrome.storage.local` (key `pendingLogs`, max 500 newest), restored on worker start; new `LOGOUT` message that syncs-then-clears; `TOKEN_UPDATED` replays preserved logs.
+
+- [ ] **Step 1: Persistence helpers**
+
+In `background.js` after the state block (:16):
+
+```js
+const MAX_PENDING_LOGS = 500; // matches desktop's offline-queue bound
+
+async function persistPendingLogs() {
+  if (pendingLogs.length > MAX_PENDING_LOGS) {
+    pendingLogs = pendingLogs.slice(-MAX_PENDING_LOGS); // keep newest
+  }
+  await chrome.storage.local.set({ pendingLogs });
+}
+
+async function restorePendingLogs() {
+  const { pendingLogs: stored } = await chrome.storage.local.get('pendingLogs');
+  if (Array.isArray(stored) && stored.length) {
+    pendingLogs = [...stored, ...pendingLogs];
+  }
+}
+```
+
+- [ ] **Step 2: Stop discarding on 401; persist on every outcome**
+
+Replace the body of `syncActivities()` (:103-127):
+
+```js
+async function syncActivities() {
+  const token = await getToken();
+  if (!token || !pendingLogs.length) return;
+
+  const logsToSend = [...pendingLogs];
+  pendingLogs = [];
+
+  try {
+    const res = await fetch(`${API_BASE}/api/activity/sync`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body:    JSON.stringify({ source: 'browser', activities: logsToSend }),
+    });
+    if (res.status === 401) {
+      // Token expired/revoked — clear it so popup shows login, but KEEP the
+      // logs: they sync after re-login (TOKEN_UPDATED triggers a replay).
+      await chrome.storage.local.remove('token');
+      pendingLogs = [...logsToSend, ...pendingLogs];
+    } else if (!res.ok) {
+      // Transient error — put logs back for next sync
+      pendingLogs = [...logsToSend, ...pendingLogs];
+    }
+  } catch {
+    pendingLogs = [...logsToSend, ...pendingLogs];
+  }
+
+  // Persist survivors so an MV3 worker restart doesn't lose them.
+  await persistPendingLogs();
+}
+```
+
+- [ ] **Step 3: Replay after re-login + restore on startup**
+
+In the `TOKEN_UPDATED` handler (:231-242), add a sync after the session fetch:
+
+```js
+  if (msg.type === 'TOKEN_UPDATED') {
+    (msg.token
+      ? chrome.storage.local.set({ token: msg.token })
+      : Promise.resolve()
+    ).then(async () => {
+      await fetchActiveSession();
+      await fetchUserPreferences();
+      await syncActivities(); // replay logs preserved across the logged-out period
+    });
+    sendResponse({ ok: true });
+    return true;
+  }
+```
+
+In the init IIFE (:270-281), add `await restorePendingLogs();` as the first statement inside.
+
+- [ ] **Step 4: Voluntary logout = final sync, then clear everything**
+
+Add a `LOGOUT` message handler in `background.js` (next to `TOKEN_CLEARED`, which stays for backward compat):
+
+```js
+  if (msg.type === 'LOGOUT') {
+    (async () => {
+      // Explicit logout: last-chance sync while the token still works,
+      // then clear all auth + buffered state.
+      flushCurrentTab();
+      await syncActivities();
+      pendingLogs = [];
+      await chrome.storage.local.remove(['token', 'user', 'pendingLogs']);
+      activeSession = null;
+      updateBadge();
+      sendResponse({ ok: true });
+    })();
+    return true;
+  }
+```
+
+In `popup/popup.js` replace the logout handler (:116-119):
+
+```js
+btnLogout.addEventListener('click', async () => {
+  await new Promise(resolve =>
+    chrome.runtime.sendMessage({ type: 'LOGOUT' }, resolve)
+  );
+  showScreen('auth');
+});
+```
+
+- [ ] **Step 5: Manual verification (Chrome)**
+
+Load unpacked `browser-extension/chrome/`. Log in, browse a few sites, then revoke from web profile. Within ~1min: badge clears, popup shows login, and `chrome.storage.local.get('pendingLogs')` (inspect service worker console) shows preserved entries. Log back in via popup → entries sync (storage empties). Explicit logout → storage token+pendingLogs both empty.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add browser-extension/chrome/
+git commit -m "fix(extension/chrome): preserve unsynced logs across 401, replay after re-login"
+```
+
+---
+
+### Task 10: Extension (Firefox) — same changes as Task 9
+
+**Files:**
+- Modify: `browser-extension/firefox/background.js`
+- Modify: `browser-extension/firefox/popup/popup.js` (logout button)
+
+**Interfaces:**
+- Same as Task 9. Firefox uses the `browser.*` namespace and MV2 event-page background; the logic is identical.
+
+- [ ] **Step 1: Port all four Task 9 changes**
+
+Apply the exact Task 9 diffs to the Firefox copies, substituting `chrome.` → `browser.` throughout (the Firefox files already use `browser.*` — match the file's existing namespace usage, not Task 9's literal text). The Firefox popup's logout button and `TOKEN_UPDATED`/init flows mirror Chrome's; the Firefox-only `loadTokenFromPage()` (`firefox/popup/popup.js:60-93`) is untouched.
+
+- [ ] **Step 2: Manual verification (Firefox)**
+
+`about:debugging` → Load Temporary Add-on → `browser-extension/firefox/manifest.json`. Repeat the Task 9 Step 5 checklist.
+
+- [ ] **Step 3: Build both zips**
+
+Run: `cd browser-extension && npm run build`
+Expected: `dist/flowshield-chrome-*.zip` and `dist/flowshield-firefox-*.zip` build cleanly
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add browser-extension/firefox/
+git commit -m "fix(extension/firefox): preserve unsynced logs across 401, replay after re-login"
+```
+
+---
+
+### Task 11: Final verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Web**
+
+Run: `cd web-app && npm run lint && npm run build && npm test && npx playwright test`
+Expected: zero lint errors; build passes; 119 unit tests; 13 E2E specs (12 + logout-all)
+
+- [ ] **Step 2: Desktop**
+
+Run: `cd desktop-app && dotnet test`
+Expected: all tests pass (97+)
+
+- [ ] **Step 3: Mobile**
+
+Run: `cd mobile-app && npx tsc --noEmit`
+Expected: clean
+
+- [ ] **Step 4: Cross-device manual checklist (spec success criteria)**
+
+- [ ] Web profile → "Log out of all devices" → own browser lands on login
+- [ ] Second web session's next request 401s → redirected to login
+- [ ] Desktop (Windows): balloon ≤30s after revocation; active session + blocking untouched; balloon click → login → queued activities sync
+- [ ] Mobile: banner appears; running timer keeps counting; re-login replays offline queue
+- [ ] Extension (both): popup shows login ≤30s; pendingLogs preserved; re-login syncs them
+
+- [ ] **Step 5: Record any deviations**
+
+If any check fails, fix before proceeding; do not mark the plan complete with failing checks. Then update `RELEASE_NOTES.md` if the repo's convention includes unreleased entries (check first).

--- a/docs/superpowers/specs/2026-08-11-token-revocation-clients-design.md
+++ b/docs/superpowers/specs/2026-08-11-token-revocation-clients-design.md
@@ -1,0 +1,97 @@
+# Token Revocation — Client Completion Design
+
+**Date:** 2026-08-11
+**Branch:** `feat/token-revocation`
+**Status:** Approved
+**Context:** Server-side revocation via `User.tokenVersion` shipped in c9cba15 (`web-app/src/lib/jwt.ts` validates `tv` claim, Redis-cached). No client handles revocation; desktop 401s throw silently on several paths; extension discards unsynced logs on 401; no logout endpoint exists. Full findings: `dev-docs/APP_ANALYSIS_2026-08-11.md`.
+
+## Goal
+
+Revoked token becomes unusable on every surface within ~30 seconds, with correct re-login UX and zero data loss. Active focus sessions are never killed by revocation.
+
+## Decisions
+
+- **Detection: reactive 401 only.** Server already rejects revoked tokens. Every surface polls ≤30s (desktop `_reSyncTimer` 30s, extension session poll 30s, web SWR 30s), so a 401 lands within ~30s with no new protocol. Proactive validation endpoints and Pusher revocation events rejected as redundant complexity.
+- **Logout semantics: local + logout-everywhere.** Normal logout stays client-side (delete stored token, no server call). New `POST /api/auth/logout-all` bumps `tokenVersion` to kill all devices.
+- **Mid-session behavior: preserve focus.** Auth loss never stops a running session or disables blocking. Syncs queue offline and replay after re-login.
+- **Voluntary vs involuntary logout (extension):** explicit user logout flushes pending logs (final sync attempt, then clear); involuntary 401 preserves them for post-re-login replay.
+
+## 1. Server (web-app)
+
+`POST /api/auth/logout-all`:
+- Auth via existing `getAuthUserId()` bearer flow
+- `User.tokenVersion += 1` AND delete the Redis tokenVersion cache key in the same request (stale cache would delay revocation)
+- Rate limit via existing `src/lib/rate-limit.ts`: 5/hour per user
+- Response `204`; caller clears its own token afterward
+- No request body; no Zod schema needed
+
+No changes to token issuance. No refresh tokens (backlog).
+
+**Web UI:** settings/profile page adds "Log out of all devices" button → call endpoint → clear own stored token → redirect to login.
+
+## 2. Desktop (.NET)
+
+**Unify 401 handling** in `Services/ApiClient.cs`:
+- Today: `:702` fires Logout + `SessionExpired`; `:166, :250, :315` just throw; ~9 catch blocks return null silently.
+- Add one private helper (e.g. `HandleUnauthorizedAsync(HttpResponseMessage)`) invoked on every API response. On 401: clear stored token, raise `SessionExpired` exactly once (guard flag against concurrent calls triple-firing), log via Serilog.
+
+**`UI/TrayApplication.cs`:** subscribe `SessionExpired` → tray balloon "Session expired — log in again"; click opens existing login dialog. Non-blocking.
+
+**Mid-session:**
+- `SessionManager` and `BlockingService` unaffected by auth loss — session and blocking continue.
+- `SyncService` treats 401 like offline: activities queue to `PendingOperations` (existing 500-cap / 7-day TTL), replay after re-login.
+- `_reSyncTimer` pauses while unauthenticated instead of hammering 401s; resumes on re-auth.
+
+**Re-login:** existing dialog; success → store token → `SyncService` replays queue → resync timer resumes.
+
+**Out of scope:** full empty-catch cleanup (only paths the 401 helper touches gain logging).
+
+## 3. Mobile (Expo)
+
+**`src/lib/api.ts`:** central 401 interceptor in the fetch wrapper — delete SecureStore token, flag auth context. Preserve error codes everywhere: throw `{ code, message }` from all endpoints (extend the #110 login pattern to the whole client), not generic `Error(data.error)`.
+
+**`src/lib/auth.tsx`:** 401 flag → context sets `user = null` → auth-gated navigator lands on LoginScreen.
+
+**Mid-session:** running focus timer continues locally; on-screen banner "Session expired — log in". `offlineQueue.ts` keeps holding sync payloads, replays after re-login. (Queue bounding is backlog item 8 — untouched here.)
+
+**Settings screen:** "Log out of all devices" button → `POST /api/auth/logout-all` → clear SecureStore → login screen.
+
+## 4. Extension (chrome/ MV3 + firefox/ MV2 — both copies)
+
+**`background.js`:**
+- Today 401 → remove token AND `pendingLogs = []` (data loss). Fix: keep `pendingLogs` and mirror to `chrome.storage.local` (survives MV3 worker restarts); replay after re-login.
+- Cap mirrored logs at 500 entries, drop oldest (matches desktop bound).
+- Logged-out state clears the timer badge (neutral/grey), so the user notices.
+
+**`popup/popup.js`:** surface `EMAIL_NOT_VERIFIED` on login with proper message + verify-email hint (parity with #110), both browsers.
+
+**Logout button:** explicit logout = final sync attempt for pending logs, then clear everything.
+
+**Out of scope:** Chrome popup MV2 `browser.tabs.executeScript` bug (backlog item 2, next PR); session controls in popup.
+
+## 5. Testing & Verification
+
+| Layer | Tests |
+|-------|-------|
+| Web (Vitest) | logout-all: bumps tokenVersion, deletes Redis key, rate-limited, 401 without token. jwt.ts: old `tv` claim rejected immediately after bump. |
+| Desktop (xUnit) | 401 helper: token cleared, `SessionExpired` raised exactly once under concurrent 401s. SyncService: 401 → queue (not dropped), replay after re-auth. Session/blocking state untouched by auth loss. |
+| E2E (Playwright) | Two contexts logged in; logout-all from one; other's next API call 401s → redirected to login. |
+| Extension (manual) | Revoke from web → ≤30s popup shows login, badge cleared, pendingLogs preserved in storage; re-login → logs sync. |
+| Mobile (manual) | Revoke while timer running → banner, timer continues, queue replays after login. |
+| Cross-device smoke | Web logout-all → desktop tray prompt ≤30s, session/blocking intact, re-login replays queue. |
+
+**Success criteria:**
+- Revoked token unusable on every surface ≤30s
+- Zero data loss: queued activities survive revocation and replay
+- Active focus sessions never killed by revocation
+- `npm run lint` zero errors; all suites green (115 Vitest, 94 xUnit, 12 Playwright specs)
+
+## Backlog (follow-up sub-projects, report §7 order)
+
+1. Chrome MV3 popup `browser.tabs.executeScript` bug (shipped + broken)
+2. Mobile timer server-anchoring
+3. Hash password reset tokens in DB
+4. Rate-limit non-auth routes
+5. Desktop pause/resume blocking restore (`SessionManager.cs:99-100`)
+6. Subscription enforcement decision
+7. Bound mobile offline queue (extension slice done in this project)

--- a/mobile-app/src/lib/api.ts
+++ b/mobile-app/src/lib/api.ts
@@ -25,6 +25,25 @@ export class AuthError extends Error {
   }
 }
 
+/** Non-auth API error that preserves HTTP status and the API's error code. */
+export class ApiError extends Error {
+  code?: string;
+  status: number;
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// Fired when any authenticated call gets a 401 (token expired or revoked).
+// AuthProvider registers a handler that flags the session as expired.
+let onUnauthorized: (() => void) | null = null;
+export function setOnUnauthorized(handler: () => void): void {
+  onUnauthorized = handler;
+}
+
 export interface Session {
   id: string;
   startTime: string;
@@ -87,10 +106,16 @@ async function apiFetch(path: string, options: RequestInit = {}): Promise<Respon
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  return fetch(`${API_URL}${path}`, {
-    ...options,
-    headers,
-  });
+  const res = await fetch(`${API_URL}${path}`, { ...options, headers });
+
+  // 401 on an authenticated call = token expired or revoked. Login itself
+  // returns 401 for bad credentials — that's not a session expiry.
+  if (res.status === 401 && token && !path.startsWith('/api/auth/login')) {
+    await removeToken();
+    onUnauthorized?.();
+  }
+
+  return res;
 }
 
 export const api = {
@@ -123,19 +148,36 @@ export const api = {
     await removeStoredUser();
   },
 
+  async logoutAll(): Promise<void> {
+    const res = await apiFetch('/api/auth/logout-all', { method: 'POST' });
+    // 401 means the token was already dead — that's still "logged out everywhere".
+    if (!res.ok && res.status !== 401) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to log out of all devices', res.status, data.code);
+    }
+    await removeToken();
+    await removeStoredUser();
+  },
+
   async getAnalytics(period: 'week' | 'month' = 'week'): Promise<{
     summary: AnalyticsSummary;
     dailyStats: DailyStat[];
     peakTimes: { peakPeriod: string };
   }> {
     const res = await apiFetch(`/api/analytics?period=${period}`);
-    if (!res.ok) throw new Error('Failed to fetch analytics');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to fetch analytics', res.status, data.code);
+    }
     return res.json();
   },
 
   async getSessions(limit = 20): Promise<Session[]> {
     const res = await apiFetch(`/api/sessions?limit=${limit}`);
-    if (!res.ok) throw new Error('Failed to fetch sessions');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to fetch sessions', res.status, data.code);
+    }
     const data = await res.json();
     return data.sessions || data;
   },
@@ -151,7 +193,7 @@ export const api = {
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || 'Failed to start session');
+      throw new ApiError(data.error || 'Failed to start session', res.status, data.code);
     }
     return res.json();
   },
@@ -165,7 +207,10 @@ export const api = {
         completed: true,
       }),
     });
-    if (!res.ok) throw new Error('Failed to end session');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to end session', res.status, data.code);
+    }
     return res.json();
   },
 
@@ -177,7 +222,10 @@ export const api = {
         completed: false,
       }),
     });
-    if (!res.ok) throw new Error('Failed to cancel session');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to cancel session', res.status, data.code);
+    }
     return res.json();
   },
 
@@ -194,7 +242,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ activities, source: 'mobile' }),
     });
-    if (!res.ok) throw new Error('Failed to sync activity');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new ApiError(data.error || 'Failed to sync activity', res.status, data.code);
+    }
   },
 
   async registerPushToken(pushToken: string): Promise<void> {

--- a/mobile-app/src/lib/auth.tsx
+++ b/mobile-app/src/lib/auth.tsx
@@ -1,25 +1,33 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { api, User } from './api';
+import { api, User, setOnUnauthorized } from './api';
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  sessionExpired: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
+  logoutAll: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
+  sessionExpired: false,
   login: async () => {},
   logout: async () => {},
+  logoutAll: async () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   useEffect(() => {
+    // Flag expiry instead of hard-logout: a running focus timer must keep
+    // running; the user re-authenticates via the banner when they choose.
+    setOnUnauthorized(() => setSessionExpired(true));
     (async () => {
       try {
         const token = await api.getToken();
@@ -40,15 +48,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = async (email: string, password: string) => {
     const { user: u } = await api.login(email, password);
     setUser(u);
+    setSessionExpired(false);
   };
 
   const logout = async () => {
     await api.logout();
     setUser(null);
+    setSessionExpired(false);
+  };
+
+  const logoutAll = async () => {
+    await api.logoutAll();
+    setUser(null);
+    setSessionExpired(false);
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, sessionExpired, login, logout, logoutAll }}>
       {children}
     </AuthContext.Provider>
   );

--- a/mobile-app/src/lib/auth.tsx
+++ b/mobile-app/src/lib/auth.tsx
@@ -59,8 +59,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logoutAll = async () => {
     await api.logoutAll();
-    setUser(null);
     setSessionExpired(false);
+    setUser(null);
   };
 
   return (

--- a/mobile-app/src/navigation/AppNavigator.tsx
+++ b/mobile-app/src/navigation/AppNavigator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActivityIndicator, View, Text } from 'react-native';
+import { ActivityIndicator, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -90,7 +90,7 @@ function TabIcon({ label }: { label: string; color: string }) {
 }
 
 export default function AppNavigator() {
-  const { user, loading } = useAuth();
+  const { user, loading, sessionExpired, logout } = useAuth();
 
   if (loading) {
     return (
@@ -101,26 +101,49 @@ export default function AppNavigator() {
   }
 
   return (
-    <NavigationContainer>
-      {user ? (
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="Main" component={MainTabs} />
-          <Stack.Screen
-            name="Settings"
-            component={SettingsScreen}
-            options={{
-              headerShown: true,
-              headerTitle: 'Settings',
-              headerStyle: { backgroundColor: colors.card },
-              headerTintColor: colors.text,
-            }}
-          />
-        </Stack.Navigator>
-      ) : (
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="Login" component={LoginScreen} />
-        </Stack.Navigator>
+    <View style={styles.root}>
+      {sessionExpired && user && (
+        <TouchableOpacity style={styles.expiredBanner} onPress={() => { logout(); }}>
+          <Text style={styles.expiredBannerText}>
+            Session expired — tap to log in again
+          </Text>
+        </TouchableOpacity>
       )}
-    </NavigationContainer>
+      <NavigationContainer>
+        {user ? (
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="Main" component={MainTabs} />
+            <Stack.Screen
+              name="Settings"
+              component={SettingsScreen}
+              options={{
+                headerShown: true,
+                headerTitle: 'Settings',
+                headerStyle: { backgroundColor: colors.card },
+                headerTintColor: colors.text,
+              }}
+            />
+          </Stack.Navigator>
+        ) : (
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="Login" component={LoginScreen} />
+          </Stack.Navigator>
+        )}
+      </NavigationContainer>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  expiredBanner: {
+    backgroundColor: colors.warning,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  expiredBannerText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+});

--- a/mobile-app/src/screens/SettingsScreen.tsx
+++ b/mobile-app/src/screens/SettingsScreen.tsx
@@ -27,7 +27,16 @@ export default function SettingsScreen() {
         {
           text: 'Log out everywhere',
           style: 'destructive',
-          onPress: () => { logoutAll(); },
+          onPress: async () => {
+            try {
+              await logoutAll();
+            } catch {
+              Alert.alert(
+                'Error',
+                'Could not log out of all devices. Check your connection and try again.'
+              );
+            }
+          },
         },
       ]
     );

--- a/mobile-app/src/screens/SettingsScreen.tsx
+++ b/mobile-app/src/screens/SettingsScreen.tsx
@@ -11,10 +11,27 @@ import {
 } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { colors, spacing, fontSize } from '../lib/theme';
+import { useAuth } from '../lib/auth';
 
 export default function SettingsScreen() {
   const [sessionReminders, setSessionReminders] = useState(true);
   const [completionAlerts, setCompletionAlerts] = useState(true);
+  const { logoutAll } = useAuth();
+
+  const handleLogoutAll = () => {
+    Alert.alert(
+      'Log out of all devices',
+      'This will revoke all active sessions, including this device. You will need to log in again.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Log out everywhere',
+          style: 'destructive',
+          onPress: () => { logoutAll(); },
+        },
+      ]
+    );
+  };
 
   const handleNotificationToggle = async (
     key: 'reminders' | 'completion',
@@ -122,6 +139,20 @@ export default function SettingsScreen() {
           onPress={() => Linking.openURL('https://flowshield.app')}
         >
           <Text style={styles.settingTitle}>FlowShield Website</Text>
+          <Text style={styles.chevron}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Account */}
+      <Text style={styles.sectionHeader}>Account</Text>
+      <View style={styles.card}>
+        <TouchableOpacity
+          style={[styles.settingRow, { borderBottomWidth: 0 }]}
+          onPress={handleLogoutAll}
+        >
+          <Text style={[styles.settingTitle, { color: colors.danger }]}>
+            Log out of all devices
+          </Text>
           <Text style={styles.chevron}>›</Text>
         </TouchableOpacity>
       </View>

--- a/web-app/e2e/logout-all.spec.ts
+++ b/web-app/e2e/logout-all.spec.ts
@@ -1,0 +1,47 @@
+// web-app/e2e/logout-all.spec.ts
+import { test, expect } from '@playwright/test';
+
+const EMAIL = process.env.E2E_EMAIL;
+const PASSWORD = process.env.E2E_PASSWORD;
+
+test.describe('logout-all revocation', () => {
+  test.skip(!EMAIL || !PASSWORD, 'E2E credentials not configured');
+
+  test('revokes a second token within one request', async ({ request }) => {
+    const loginA = await request.post('/api/auth/login', {
+      data: { email: EMAIL, password: PASSWORD },
+    });
+    expect(loginA.ok()).toBeTruthy();
+    const { token: tokenA } = await loginA.json();
+
+    const loginB = await request.post('/api/auth/login', {
+      data: { email: EMAIL, password: PASSWORD },
+    });
+    expect(loginB.ok()).toBeTruthy();
+    const { token: tokenB } = await loginB.json();
+
+    // Both tokens work
+    const probeB = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenB}` },
+    });
+    expect(probeB.status()).toBe(200);
+
+    // Logout-all with token A
+    const revoke = await request.post('/api/auth/logout-all', {
+      headers: { Authorization: `Bearer ${tokenA}` },
+    });
+    expect(revoke.status()).toBe(204);
+
+    // Token B is now dead
+    const probeBAfter = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenB}` },
+    });
+    expect(probeBAfter.status()).toBe(401);
+
+    // Token A is dead too (it was minted before the bump)
+    const probeAAfter = await request.get('/api/sessions?limit=1', {
+      headers: { Authorization: `Bearer ${tokenA}` },
+    });
+    expect(probeAAfter.status()).toBe(401);
+  });
+});

--- a/web-app/openapi.yaml
+++ b/web-app/openapi.yaml
@@ -148,6 +148,21 @@ paths:
       responses:
         302: {description: Redirect after verification}
 
+  /api/auth/logout-all:
+    post:
+      tags: [Auth]
+      summary: Log out of all devices
+      description: Increments the user's tokenVersion, revoking every previously issued JWT.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: All tokens revoked
+        "401":
+          description: Missing or invalid token
+        "429":
+          description: Rate limited (5/hour per user)
+
   /api/sessions:
     get:
       tags: [Sessions]

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   role              UserRole         @default(USER)
   subscriptionTier  SubscriptionTier @default(FREE)
   lastCoachCallAt   DateTime?
+  tokenVersion      Int              @default(0)
   subscriptions     Subscription[]
   categoryRules     CategoryRule[]
 

--- a/web-app/src/app/(app)/profile/page.tsx
+++ b/web-app/src/app/(app)/profile/page.tsx
@@ -3,10 +3,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import NotificationManager from '@/components/common/NotificationManager';
 import { getToken, removeToken, removeUserData, setUserData } from '@/lib/auth-token';
-
-// ... (inside the component's JSX, likely in a "Settings" or "Preferences" section)
-// I need to see the file content first to know where to insert it.
-// Wait, I am viewing it in parallel. I'll do a separate tool call to edit after viewing.
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -838,11 +834,13 @@ function AccountAndPrivacyCard({
   };
 
   const handleLogoutAll = async () => {
+    const token = getToken();
+    if (!token) return;
     setLogoutAllBusy(true);
     try {
       const res = await fetch('/api/auth/logout-all', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));

--- a/web-app/src/app/(app)/profile/page.tsx
+++ b/web-app/src/app/(app)/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import NotificationManager from '@/components/common/NotificationManager';
-import { getToken, removeToken, setUserData } from '@/lib/auth-token';
+import { getToken, removeToken, removeUserData, setUserData } from '@/lib/auth-token';
 
 // ... (inside the component's JSX, likely in a "Settings" or "Preferences" section)
 // I need to see the file content first to know where to insert it.
@@ -775,6 +775,8 @@ function AccountAndPrivacyCard({
   const [delConfirm, setDelConfirm] = useState(false);
   const [delSaving, setDelSaving] = useState(false);
 
+  const [logoutAllBusy, setLogoutAllBusy] = useState(false);
+
   const handleChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
     onMessage(null);
@@ -832,6 +834,26 @@ function AccountAndPrivacyCard({
       onMessage({ type: 'success', text: 'Your data has been downloaded.' });
     } catch {
       onMessage({ type: 'error', text: 'Failed to export your data.' });
+    }
+  };
+
+  const handleLogoutAll = async () => {
+    setLogoutAllBusy(true);
+    try {
+      const res = await fetch('/api/auth/logout-all', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        onMessage({ type: 'error', text: data.error || 'Failed to log out of all devices.' });
+        return;
+      }
+      removeToken();
+      removeUserData();
+      router.push('/auth/login');
+    } finally {
+      setLogoutAllBusy(false);
     }
   };
 
@@ -912,6 +934,24 @@ function AccountAndPrivacyCard({
         </p>
         <Button type="button" variant="secondary" size="sm" onClick={handleExport}>
           Download my data
+        </Button>
+      </Card>
+
+      <Card>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">
+          Security
+        </h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Signed in on another device you don&apos;t recognize? This signs you out everywhere, including this browser.
+        </p>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleLogoutAll}
+          disabled={logoutAllBusy}
+        >
+          {logoutAllBusy ? 'Logging out…' : 'Log out of all devices'}
         </Button>
       </Card>
 

--- a/web-app/src/app/api/activity/analysis/route.ts
+++ b/web-app/src/app/api/activity/analysis/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { PRODUCTIVE_CATEGORIES } from '@/app/api/categories/route';
 import { getLocalHour, getLocalDate } from '@/lib/timezone';
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/app/api/activity/recategorize/route.ts
+++ b/web-app/src/app/api/activity/recategorize/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { normalizeCategory, CATEGORIES } from '@/app/api/categories/route';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
@@ -18,7 +18,7 @@ import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
  */
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/activity/sync/route.ts
+++ b/web-app/src/app/api/activity/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { resolveCategory } from '@/lib/activity-sync';
@@ -38,7 +38,7 @@ const syncBodySchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -120,7 +120,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/app/api/admin/email/announce/route.ts
+++ b/web-app/src/app/api/admin/email/announce/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import sanitizeHtml from 'sanitize-html';
 import { prisma } from '@/lib/prisma';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 import { sendEmail } from '@/lib/email';
 
 const AnnounceSchema = z.object({
@@ -28,7 +28,7 @@ const EMAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
 };
 
 export async function POST(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/admin/email/digest/route.ts
+++ b/web-app/src/app/api/admin/email/digest/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 import { sendEmail } from '@/lib/email';
 
 export async function POST(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/admin/settings/route.ts
+++ b/web-app/src/app/api/admin/settings/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 import { getSettings, saveSettings } from '@/lib/settings';
 
 export async function GET(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/admin/stats/route.ts
+++ b/web-app/src/app/api/admin/stats/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 
 export async function GET(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/admin/users/[id]/route.ts
+++ b/web-app/src/app/api/admin/users/[id]/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 import { invalidateUserTierCache } from '@/lib/subscription';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
@@ -68,7 +68,7 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
@@ -124,7 +124,7 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/admin/users/route.ts
+++ b/web-app/src/app/api/admin/users/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getAdminFromToken } from '@/lib/jwt';
+import { getAuthAdminId } from '@/lib/jwt';
 
 export async function GET(request: NextRequest) {
-  const adminId = getAdminFromToken(request);
+  const adminId = await getAuthAdminId(request);
   if (!adminId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/web-app/src/app/api/analytics/distractions/route.ts
+++ b/web-app/src/app/api/analytics/distractions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { PRODUCTIVE_CATEGORIES } from '@/app/api/categories/route';
 
@@ -14,7 +14,7 @@ import { PRODUCTIVE_CATEGORIES } from '@/app/api/categories/route';
  */
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/analytics/insights/route.ts
+++ b/web-app/src/app/api/analytics/insights/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { generateInsights } from '@/lib/insights';
 
@@ -43,7 +43,7 @@ function computeStreak(dailyStats: { date: Date | string; totalFocusMinutes: num
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/analytics/route.ts
+++ b/web-app/src/app/api/analytics/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { calculateProductivityScore, detectPeakTimes } from '@/lib/productivity';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { redis, CACHE_TTL } from '@/lib/redis';
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/analytics/yearly/route.ts
+++ b/web-app/src/app/api/analytics/yearly/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 /**
@@ -24,7 +24,7 @@ function formatDateInTz(date: Date, timezone: string): string {
 
 export async function GET(request: NextRequest) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
 
         if (!userId) {
             return NextResponse.json(

--- a/web-app/src/app/api/auth/google/callback/route.ts
+++ b/web-app/src/app/api/auth/google/callback/route.ts
@@ -109,9 +109,13 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Issue our standard JWT
+    // Issue our standard JWT.
+    // user.tokenVersion is present because every find/create/update path above
+    // uses `include` (not `select`), which returns all scalar fields. If any of
+    // those is changed to `select`, you MUST add tokenVersion or tv becomes
+    // undefined and revocation breaks for OAuth users.
     const jwtToken = sign(
-      { userId: user.id, email: user.email, role: user.role },
+      { userId: user.id, email: user.email, role: user.role, tv: user.tokenVersion },
       getJwtSecret(),
       { expiresIn: '7d', algorithm: 'HS256' }
     );

--- a/web-app/src/app/api/auth/login/route.ts
+++ b/web-app/src/app/api/auth/login/route.ts
@@ -42,6 +42,7 @@ export async function POST(request: NextRequest) {
         createdAt: true,
         emailVerified: true,
         subscriptionTier: true,
+        tokenVersion: true,
         preferences: true,
       },
     });
@@ -76,7 +77,7 @@ export async function POST(request: NextRequest) {
 
     // Create JWT token
     const token = sign(
-      { userId: user.id, email: user.email, role: user.role },
+      { userId: user.id, email: user.email, role: user.role, tv: user.tokenVersion },
       getJwtSecret(),
       { expiresIn: rememberMe ? '30d' : '7d', algorithm: 'HS256' } // 30 days if rememberMe is true, else 7 days
     );

--- a/web-app/src/app/api/auth/logout-all/route.test.ts
+++ b/web-app/src/app/api/auth/logout-all/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { user: { update: vi.fn() } },
+}));
+vi.mock('@/lib/jwt', () => ({
+  getAuthUserId: vi.fn(),
+  revokeUserTokens: vi.fn(),
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn(),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST } from './route';
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
+import { rateLimit } from '@/lib/rate-limit';
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/auth/logout-all', { method: 'POST' });
+}
+
+describe('POST /api/auth/logout-all', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 4, resetInMs: 0 });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue(null);
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when rate limited', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    vi.mocked(rateLimit).mockResolvedValue({ allowed: false, remaining: 0, resetInMs: 60000 });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(429);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('bumps tokenVersion, busts the cache, and returns 204', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(204);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { tokenVersion: { increment: 1 } },
+    });
+    expect(revokeUserTokens).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns 500 when the DB update throws', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue('user-1');
+    vi.mocked(prisma.user.update).mockRejectedValue(new Error('db down'));
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/web-app/src/app/api/auth/logout-all/route.ts
+++ b/web-app/src/app/api/auth/logout-all/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
+import { rateLimit } from '@/lib/rate-limit';
+import { logger } from '@/lib/logger';
+
+/**
+ * Log out of all devices: bump the user's tokenVersion so every token minted
+ * before now fails the `tv` check in getAuthUserId, then bust the Redis cache
+ * so the new version takes effect immediately. The caller clears its own
+ * stored token after a 204.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUserId(request);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Rate limit: 5 per hour per user
+    const rl = await rateLimit(`logout-all:${userId}`, 5, 60 * 60 * 1000);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(rl.resetInMs / 1000)) } }
+      );
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { tokenVersion: { increment: 1 } },
+    });
+    await revokeUserTokens(userId);
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    logger.error('Logout-all error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web-app/src/app/api/auth/resend-verification/route.ts
+++ b/web-app/src/app/api/auth/resend-verification/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import crypto from 'crypto';
 import { sendEmail } from '@/lib/email';
@@ -9,7 +9,7 @@ import { getSettings } from '@/lib/settings';
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/auth/reset-password/route.ts
+++ b/web-app/src/app/api/auth/reset-password/route.ts
@@ -4,6 +4,7 @@ import { hashPassword } from '@/lib/auth';
 import { logger } from '@/lib/logger';
 import { rateLimit, getClientIp } from '@/lib/rate-limit';
 import { ResetPasswordSchema } from '@/lib/schemas';
+import { revokeUserTokens } from '@/lib/jwt';
 
 /**
  * POST /api/auth/reset-password
@@ -64,8 +65,10 @@ export async function POST(request: NextRequest) {
         hashedPassword: hashed,
         passwordResetToken: null,
         passwordResetExpires: null,
+        tokenVersion: { increment: 1 }, // revoke all existing tokens
       },
     });
+    await revokeUserTokens(user.id); // bust the token-version cache
 
     return NextResponse.json({
       message: 'Password reset successfully. You can now sign in with your new password.',

--- a/web-app/src/app/api/categories/[id]/route.ts
+++ b/web-app/src/app/api/categories/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { CATEGORIES, PRODUCTIVE_CATEGORIES } from '@/app/api/categories/route';
 
@@ -26,7 +26,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -109,7 +109,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/categories/route.ts
+++ b/web-app/src/app/api/categories/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 // Canonical category list — used by all clients
@@ -34,7 +34,7 @@ export function normalizeCategory(category: string): string {
  */
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -79,7 +79,7 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/coach/advice/route.test.ts
+++ b/web-app/src/app/api/coach/advice/route.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/lib/redis', () => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: vi.fn(() => 'user-1'),
+  getAuthUserId: vi.fn(async () => 'user-1'),
 }));
 
 vi.mock('@/lib/prisma', () => ({

--- a/web-app/src/app/api/coach/advice/route.ts
+++ b/web-app/src/app/api/coach/advice/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { redis } from '@/lib/redis';
 import { rateLimit } from '@/lib/rate-limit';
@@ -61,7 +61,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {

--- a/web-app/src/app/api/devices/route.ts
+++ b/web-app/src/app/api/devices/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 // GET - List all connected devices for the user
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
 // POST - Register or update a device connection
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest) {
 // PATCH - Update device (rename, deactivate)
 export async function PATCH(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -157,7 +157,7 @@ export async function PATCH(request: NextRequest) {
 // DELETE - Disconnect/remove a device
 export async function DELETE(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/app/api/export/route.ts
+++ b/web-app/src/app/api/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 /**
@@ -17,7 +17,7 @@ function csvCell(value: unknown): string {
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/goals/route.ts
+++ b/web-app/src/app/api/goals/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { CreateGoalSchema } from '@/lib/schemas';
 
 export async function GET(req: NextRequest) {
   try {
-    const userId = getUserIdFromToken(req);
+    const userId = await getAuthUserId(req);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const userId = getUserIdFromToken(req);
+    const userId = await getAuthUserId(req);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/leaderboard/route.ts
+++ b/web-app/src/app/api/leaderboard/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { redis, CACHE_TTL } from '@/lib/redis';
 
@@ -13,7 +13,7 @@ type RawLeaderboardEntry = {
 
 export async function GET(request: NextRequest) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
 
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/migrate-distractions/route.ts
+++ b/web-app/src/app/api/migrate-distractions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 // Mapping of old distraction values to new ones
@@ -23,7 +23,7 @@ const distractionMapping: Record<string, string> = {
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/app/api/projects/[id]/route.test.ts
+++ b/web-app/src/app/api/projects/[id]/route.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 process.env.JWT_SECRET = 'test-secret-at-least-32-chars-long-xyz';
 
 const mocks = vi.hoisted(() => ({
-  getUserIdFromToken: vi.fn(),
+  getAuthUserId: vi.fn(),
   projectFindFirst: vi.fn(),
   projectDelete: vi.fn(),
   projectUpdate: vi.fn(),
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: mocks.getUserIdFromToken,
+  getAuthUserId: mocks.getAuthUserId,
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -53,14 +53,14 @@ describe('DELETE /api/projects/[id]', () => {
   });
 
   it('returns 401 when unauthenticated', async () => {
-    mocks.getUserIdFromToken.mockReturnValue(null);
+    mocks.getAuthUserId.mockResolvedValue(null);
     const res = await DELETE(makeRequest(), makeParams('p1'));
     expect(res.status).toBe(401);
     expect(mocks.projectDelete).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the project does not exist', async () => {
-    mocks.getUserIdFromToken.mockReturnValue('user-1');
+    mocks.getAuthUserId.mockResolvedValue('user-1');
     mocks.projectFindFirst.mockResolvedValueOnce(null);
     const res = await DELETE(makeRequest(), makeParams('does-not-exist'));
     expect(res.status).toBe(404);
@@ -68,7 +68,7 @@ describe('DELETE /api/projects/[id]', () => {
   });
 
   it('returns 404 when the project belongs to another user', async () => {
-    mocks.getUserIdFromToken.mockReturnValue('user-1');
+    mocks.getAuthUserId.mockResolvedValue('user-1');
     // findFirst is scoped by { id, userId } — another user's project returns null
     mocks.projectFindFirst.mockResolvedValueOnce(null);
     const res = await DELETE(makeRequest(), makeParams('someone-elses-project'));
@@ -80,7 +80,7 @@ describe('DELETE /api/projects/[id]', () => {
   });
 
   it('deletes the project and returns ok on success', async () => {
-    mocks.getUserIdFromToken.mockReturnValue('user-1');
+    mocks.getAuthUserId.mockResolvedValue('user-1');
     mocks.projectFindFirst.mockResolvedValueOnce({
       id: 'p1',
       userId: 'user-1',

--- a/web-app/src/app/api/projects/[id]/route.ts
+++ b/web-app/src/app/api/projects/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { UpdateProjectCostSchema } from '@/lib/schemas';
@@ -11,7 +11,7 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params;
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -48,7 +48,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/projects/cost/route.ts
+++ b/web-app/src/app/api/projects/cost/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 
@@ -25,7 +25,7 @@ function getPeriodRange(period: Period): { start: Date; end: Date } {
 }
 
 export async function GET(request: NextRequest) {
-  const userId = getUserIdFromToken(request);
+  const userId = await getAuthUserId(request);
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/web-app/src/app/api/projects/route.ts
+++ b/web-app/src/app/api/projects/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { CreateProjectSchema } from '@/lib/schemas';
 
 export async function GET(request: NextRequest) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
 
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
 
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/push/send/route.ts
+++ b/web-app/src/app/api/push/send/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import webpush from 'web-push';
 import { logger } from '@/lib/logger';
 import { PushSendSchema } from '@/lib/schemas';
@@ -9,7 +9,7 @@ import { PushSendSchema } from '@/lib/schemas';
 
 export async function POST(req: NextRequest) {
     try {
-        const userId = getUserIdFromToken(req);
+        const userId = await getAuthUserId(req);
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }

--- a/web-app/src/app/api/push/subscribe/route.ts
+++ b/web-app/src/app/api/push/subscribe/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { rateLimit } from '@/lib/rate-limit';
 
@@ -43,7 +43,7 @@ function isAllowedPushEndpoint(url: string): boolean {
 
 export async function POST(req: NextRequest) {
     try {
-        const userId = getUserIdFromToken(req);
+        const userId = await getAuthUserId(req);
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }

--- a/web-app/src/app/api/reports/weekly/route.ts
+++ b/web-app/src/app/api/reports/weekly/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { getWeeklyStats } from '@/lib/reports';
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/lib/prisma', () => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: vi.fn(() => 'user-1'),
+  getAuthUserId: vi.fn(async () => 'user-1'),
 }));
 
 vi.mock('@/lib/pusher', () => ({

--- a/web-app/src/app/api/sessions/[id]/auto-end/route.ts
+++ b/web-app/src/app/api/sessions/[id]/auto-end/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
@@ -23,7 +23,7 @@ const GRACE_MINUTES = 5;
  */
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/sessions/[id]/route.ts
+++ b/web-app/src/app/api/sessions/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
@@ -17,7 +17,7 @@ export async function PATCH(
   context: RouteContext
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -153,7 +153,7 @@ export async function DELETE(
   context: RouteContext
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/sessions/[id]/toggle-pause/route.ts
+++ b/web-app/src/app/api/sessions/[id]/toggle-pause/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 export async function POST(
@@ -8,7 +8,7 @@ export async function POST(
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }

--- a/web-app/src/app/api/sessions/active/route.ts
+++ b/web-app/src/app/api/sessions/active/route.ts
@@ -1,14 +1,14 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
     try {
-        const userId = getUserIdFromToken(request);
+        const userId = await getAuthUserId(request);
 
         if (!userId) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/sessions/route.test.ts
+++ b/web-app/src/app/api/sessions/route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/prisma', () => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: vi.fn(() => 'user-1'),
+  getAuthUserId: vi.fn(async () => 'user-1'),
 }));
 
 vi.mock('@/lib/pusher', () => ({

--- a/web-app/src/app/api/sessions/route.ts
+++ b/web-app/src/app/api/sessions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { triggerUserEvent } from '@/lib/pusher';
 import { invalidateAnalyticsCache } from '@/lib/analytics-cache';
@@ -9,7 +9,7 @@ import { CreateSessionSchema } from '@/lib/schemas';
 // Create a new session
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
 // Get user's sessions
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/web-app/src/app/api/teams/[id]/members/[userId]/route.ts
+++ b/web-app/src/app/api/teams/[id]/members/[userId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 /**
@@ -16,7 +16,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; userId: string }> }
 ) {
   try {
-    const actingUserId = getUserIdFromToken(request);
+    const actingUserId = await getAuthUserId(request);
     if (!actingUserId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/web-app/src/app/api/teams/[id]/route.ts
+++ b/web-app/src/app/api/teams/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 /**
@@ -11,7 +11,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { id } = await params;
@@ -92,7 +92,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { id } = await params;
@@ -128,7 +128,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { id } = await params;

--- a/web-app/src/app/api/teams/join/route.ts
+++ b/web-app/src/app/api/teams/join/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { rateLimit, getClientIp } from '@/lib/rate-limit';
 
@@ -14,7 +14,7 @@ import { rateLimit, getClientIp } from '@/lib/rate-limit';
  */
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const ip = getClientIp(request);

--- a/web-app/src/app/api/teams/route.ts
+++ b/web-app/src/app/api/teams/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 
 /**
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
  */
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const memberships = await prisma.teamMembership.findMany({
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { name } = await request.json();

--- a/web-app/src/app/api/user/delete/route.test.ts
+++ b/web-app/src/app/api/user/delete/route.test.ts
@@ -17,7 +17,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: vi.fn(() => 'user-1'),
+  getAuthUserId: vi.fn(async () => 'user-1'),
+  revokeUserTokens: vi.fn(async () => {}),
 }));
 
 import { DELETE } from './route';

--- a/web-app/src/app/api/user/delete/route.ts
+++ b/web-app/src/app/api/user/delete/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { verifyPassword } from '@/lib/auth';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { DeleteAccountSchema } from '@/lib/schemas';
 
@@ -15,7 +15,7 @@ import { DeleteAccountSchema } from '@/lib/schemas';
  */
 export async function DELETE(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -63,6 +63,7 @@ export async function DELETE(request: NextRequest) {
     // sessions, activityLogs, goals, dailyStats, devices,
     // pushSubscriptions, projects, preferences
     await prisma.user.delete({ where: { id: userId } });
+    await revokeUserTokens(userId); // clear the tv cache — user row is already gone
 
     logger.info(`User account deleted: ${userId}`);
 

--- a/web-app/src/app/api/user/password/route.test.ts
+++ b/web-app/src/app/api/user/password/route.test.ts
@@ -20,7 +20,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@/lib/jwt', () => ({
-  getUserIdFromToken: vi.fn(() => 'user-1'),
+  getAuthUserId: vi.fn(async () => 'user-1'),
+  revokeUserTokens: vi.fn(async () => {}),
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
@@ -76,7 +77,7 @@ describe('POST /api/user/password', () => {
     expect(mocks.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'user-1' },
-        data: { hashedPassword: `hashed:${VALID_NEW}` },
+        data: { hashedPassword: `hashed:${VALID_NEW}`, tokenVersion: { increment: 1 } },
       })
     );
   });

--- a/web-app/src/app/api/user/password/route.ts
+++ b/web-app/src/app/api/user/password/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { hashPassword, verifyPassword } from '@/lib/auth';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId, revokeUserTokens } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { rateLimit } from '@/lib/rate-limit';
 import { ChangePasswordSchema } from '@/lib/schemas';
@@ -15,7 +15,7 @@ import { ChangePasswordSchema } from '@/lib/schemas';
  */
 export async function POST(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -69,8 +69,9 @@ export async function POST(request: NextRequest) {
     const hashed = await hashPassword(newPassword);
     await prisma.user.update({
       where: { id: userId },
-      data: { hashedPassword: hashed },
+      data: { hashedPassword: hashed, tokenVersion: { increment: 1 } }, // revoke existing tokens
     });
+    await revokeUserTokens(userId); // bust the token-version cache
 
     return NextResponse.json({ message: 'Password updated successfully' });
   } catch (error) {

--- a/web-app/src/app/api/user/preferences/route.ts
+++ b/web-app/src/app/api/user/preferences/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { UpdatePreferencesSchema } from '@/lib/schemas';
 import { bustCoachCacheIfPaid } from '@/lib/coach-quota';
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
 
 export async function PATCH(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/app/api/user/profile/route.ts
+++ b/web-app/src/app/api/user/profile/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getUserIdFromToken } from '@/lib/jwt';
+import { getAuthUserId } from '@/lib/jwt';
 import { logger } from '@/lib/logger';
 import { UpdateProfileSchema } from '@/lib/schemas';
 
 export async function GET(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const userId = getUserIdFromToken(request);
+    const userId = await getAuthUserId(request);
 
     if (!userId) {
       return NextResponse.json(

--- a/web-app/src/lib/jwt.test.ts
+++ b/web-app/src/lib/jwt.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sign } from 'jsonwebtoken';
+
+const SECRET = 'test-secret-at-least-32-characters-long!!';
+process.env.JWT_SECRET = SECRET;
+
+const mocks = vi.hoisted(() => ({
+  redisGet: vi.fn(),
+  redisSet: vi.fn(async () => 'OK'),
+  redisDel: vi.fn(async () => 1),
+  findUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  redis: { get: mocks.redisGet, set: mocks.redisSet, del: mocks.redisDel },
+  CACHE_TTL: 300,
+}));
+vi.mock('@/lib/prisma', () => ({ prisma: { user: { findUnique: mocks.findUnique } } }));
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+import { getAuthUserId, getAuthAdminId, revokeUserTokens } from './jwt';
+
+function reqWith(token: string) {
+  return new Request('http://localhost/api', {
+    headers: { Authorization: `Bearer ${token}` },
+  }) as unknown as import('next/server').NextRequest;
+}
+const mint = (payload: object) => sign(payload, SECRET, { algorithm: 'HS256' });
+
+describe('getAuthUserId — signature + revocation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.redisGet.mockResolvedValue(null); // cache miss → seed from DB
+    mocks.findUnique.mockResolvedValue({ tokenVersion: 0 });
+  });
+
+  it('returns null without a Bearer token', async () => {
+    const req = new Request('http://localhost/api') as unknown as import('next/server').NextRequest;
+    expect(await getAuthUserId(req)).toBeNull();
+  });
+
+  it('returns null for a token signed with the wrong secret', async () => {
+    const bad = sign({ userId: 'u-1', tv: 0 }, 'some-other-secret-32-characters-long!!', { algorithm: 'HS256' });
+    expect(await getAuthUserId(reqWith(bad))).toBeNull();
+  });
+
+  it('accepts a token whose tv matches the current version', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ tokenVersion: 3 });
+    const token = mint({ userId: 'u-1', tv: 3 });
+    expect(await getAuthUserId(reqWith(token))).toBe('u-1');
+  });
+
+  it('rejects a token whose tv is older than the current version (revoked)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ tokenVersion: 2 });
+    const token = mint({ userId: 'u-1', tv: 1 });
+    expect(await getAuthUserId(reqWith(token))).toBeNull();
+  });
+
+  it('treats a legacy token with no tv claim as version 0 (still valid at v0)', async () => {
+    mocks.findUnique.mockResolvedValueOnce({ tokenVersion: 0 });
+    const token = mint({ userId: 'u-1' }); // no tv
+    expect(await getAuthUserId(reqWith(token))).toBe('u-1');
+  });
+
+  it('uses the cached version on a cache hit (no DB read)', async () => {
+    mocks.redisGet.mockResolvedValueOnce(5);
+    const token = mint({ userId: 'u-1', tv: 5 });
+    expect(await getAuthUserId(reqWith(token))).toBe('u-1');
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('fails OPEN (token accepted) when the version lookup throws', async () => {
+    mocks.redisGet.mockRejectedValueOnce(new Error('redis down'));
+    mocks.findUnique.mockRejectedValueOnce(new Error('db down'));
+    const token = mint({ userId: 'u-1', tv: 0 });
+    expect(await getAuthUserId(reqWith(token))).toBe('u-1');
+  });
+});
+
+describe('getAuthAdminId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.redisGet.mockResolvedValue(0);
+  });
+
+  it('resolves for an ADMIN token', async () => {
+    expect(await getAuthAdminId(reqWith(mint({ userId: 'a-1', role: 'ADMIN', tv: 0 })))).toBe('a-1');
+  });
+
+  it('returns null for a non-admin token', async () => {
+    expect(await getAuthAdminId(reqWith(mint({ userId: 'u-1', role: 'USER', tv: 0 })))).toBeNull();
+  });
+});
+
+describe('revokeUserTokens', () => {
+  it('busts the token-version cache key', async () => {
+    mocks.redisDel.mockClear();
+    await revokeUserTokens('u-1');
+    expect(mocks.redisDel).toHaveBeenCalledWith('tv:u-1');
+  });
+});

--- a/web-app/src/lib/jwt.ts
+++ b/web-app/src/lib/jwt.ts
@@ -1,10 +1,24 @@
 /**
- * JWT Configuration
- * Ensures JWT_SECRET is properly configured and fails fast if not set
+ * JWT configuration + authentication helpers.
+ *
+ * Tokens carry a `tv` (token version) claim. A user's authoritative version
+ * lives in `User.tokenVersion`; bumping it (on password change/reset) revokes
+ * every token minted before the bump. `getAuthUserId` / `getAuthAdminId` verify
+ * the signature AND check `tv` against the current version, so they are async.
+ *
+ * These intentionally replace the old synchronous `getUserIdFromToken` /
+ * `getAdminFromToken` — the rename forces every call site to `await`, turning a
+ * missed conversion into a compile error rather than a silent auth bypass (an
+ * un-awaited Promise is always truthy).
  */
 
 import { verify } from 'jsonwebtoken';
 import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { redis } from '@/lib/redis';
+import { logger } from '@/lib/logger';
+
+const TV_CACHE_TTL_SECONDS = 3600; // self-heals a missed cache bust within 1h
 
 export function getJwtSecret(): string {
   const secret = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET;
@@ -17,55 +31,99 @@ export function getJwtSecret(): string {
 
   // In production, enforce minimum secret length
   if (process.env.NODE_ENV === 'production' && secret.length < 32) {
-    throw new Error(
-      'JWT_SECRET must be at least 32 characters long in production'
-    );
+    throw new Error('JWT_SECRET must be at least 32 characters long in production');
   }
 
   return secret;
 }
 
+interface AuthClaims {
+  userId: string;
+  role?: string;
+  tv?: number;
+}
+
 /**
- * Extract and verify JWT token from Authorization header
- * @param request NextRequest object
- * @returns userId from token or null if invalid
+ * Verify the Bearer token's signature (algorithm pinned) and return its claims,
+ * or null if missing/invalid. Synchronous — no revocation check here.
  */
-export function getUserIdFromToken(request: NextRequest): string | null {
+function verifyAuthHeader(request: NextRequest): AuthClaims | null {
   try {
     const authHeader = request.headers.get('Authorization');
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return null;
     }
-
     const token = authHeader.substring(7);
-    // Pin the algorithm — without this, jsonwebtoken accepts whatever `alg` the
-    // token header declares (alg-confusion / alg:none risk on any lib change).
-    const decoded = verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as { userId: string };
-    return decoded.userId;
-  } catch (error) {
+    return verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as AuthClaims;
+  } catch {
     return null;
   }
 }
 
 /**
- * Extract and verify JWT token, returning userId only if the user is an ADMIN.
- * @param request NextRequest object
- * @returns userId if role === 'ADMIN', otherwise null
+ * Current authoritative token version for a user. Cached in Redis (short TTL so
+ * a missed cache-bust self-heals); seeded from the DB on a miss.
  */
-export function getAdminFromToken(request: NextRequest): string | null {
-  try {
-    const authHeader = request.headers.get('Authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return null;
-    }
+async function currentTokenVersion(userId: string): Promise<number> {
+  const key = `tv:${userId}`;
+  const cached = await redis.get<number>(key);
+  if (typeof cached === 'number') return cached;
 
-    const token = authHeader.substring(7);
-    const decoded = verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as { userId: string; role?: string };
-    if (decoded.role !== 'ADMIN') {
-      return null;
-    }
-    return decoded.userId;
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { tokenVersion: true },
+  });
+  const version = user?.tokenVersion ?? 0;
+  await redis.set(key, version, { ex: TV_CACHE_TTL_SECONDS });
+  return version;
+}
+
+/**
+ * True if the token's version is older than the user's current version.
+ * Fails OPEN (not revoked) on infra errors so a Redis/DB blip doesn't log every
+ * user out — the signature was already verified by the caller.
+ */
+async function isRevoked(userId: string, tokenVersion: number): Promise<boolean> {
+  try {
+    const current = await currentTokenVersion(userId);
+    return tokenVersion < current;
   } catch (error) {
-    return null;
+    logger.error('Token-version check failed (failing open)', error);
+    return false;
+  }
+}
+
+/**
+ * Verify the Bearer token and return its userId, or null if invalid/revoked.
+ * Tokens minted before the `tv` claim existed are treated as version 0.
+ */
+export async function getAuthUserId(request: NextRequest): Promise<string | null> {
+  const claims = verifyAuthHeader(request);
+  if (!claims?.userId) return null;
+  if (await isRevoked(claims.userId, claims.tv ?? 0)) return null;
+  return claims.userId;
+}
+
+/**
+ * Like `getAuthUserId` but only resolves for ADMIN-role tokens.
+ */
+export async function getAuthAdminId(request: NextRequest): Promise<string | null> {
+  const claims = verifyAuthHeader(request);
+  if (!claims?.userId || claims.role !== 'ADMIN') return null;
+  if (await isRevoked(claims.userId, claims.tv ?? 0)) return null;
+  return claims.userId;
+}
+
+/**
+ * Revoke all of a user's existing tokens. The caller must have already bumped
+ * `User.tokenVersion` (typically inside the same Prisma update). This busts the
+ * Redis cache so the new version takes effect immediately. Best-effort — the
+ * cache TTL is the backstop.
+ */
+export async function revokeUserTokens(userId: string): Promise<void> {
+  try {
+    await redis.del(`tv:${userId}`);
+  } catch (error) {
+    logger.error('Failed to bust token-version cache', error);
   }
 }


### PR DESCRIPTION
Completes JWT token revocation end-to-end. Server-side `tokenVersion` enforcement (jwt.ts, c9cba15) already rejected revoked tokens; this branch makes every client detect the resulting 401, prompt re-login, and preserve unsynced data — plus adds a "log out of all devices" endpoint + UI.

## What's included
- **Web** — `POST /api/auth/logout-all` (bumps `tokenVersion`, busts Redis cache, rate-limited 5/hr); "Log out of all devices" button on profile; Playwright E2E proving concurrent-token revocation.
- **Desktop (.NET)** — idempotent `Logout()`; 401 detection across all API methods → single `SessionExpired`; **resync guard so revocation no longer kills an active focus session** (the worst bug found); tray re-login balloon + post-login recovery (sync replay, resync, Pusher reconnect).
- **Mobile (Expo)** — central 401 interceptor, `ApiError` code preservation, session-expired banner (running timer keeps counting), `logoutAll` in Settings.
- **Extension (Chrome MV3 + Firefox MV2)** — unsynced logs preserved across 401 (were discarded), persisted to storage, replayed after re-login; voluntary logout flushes-then-clears.

## Guarantees verified (final whole-branch review)
- Revoked token unusable ≤30s on every surface (under healthy infra).
- Zero data loss: active focus sessions never killed by revocation; queued activity preserved + replayed.
- No 401→refetch→401 loop on any client.

## Verification
- Web: lint 0 errors, 265 Vitest pass, build ✓
- Desktop: compiles clean (0 errors, 0 CS0854 — pre-existing Moq breakage fixed). **xUnit executes only on Windows CI** (net8.0-windows/WPF runtime unavailable on Linux).
- Mobile: `tsc --noEmit` clean
- Extension: `node --check` clean, both zips build

## Before release (post-merge, on Windows)
- Run desktop xUnit suite on Windows CI
- Manual cross-device checklist: revoke from web → confirm balloon/banner/login-prompt ≤30s on desktop/mobile/extension, active session + blocking survive, queued logs replay after re-login

Spec: `docs/superpowers/specs/2026-08-11-token-revocation-clients-design.md`
Plan: `docs/superpowers/plans/2026-08-11-token-revocation-clients.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)